### PR TITLE
harden upstream IO, LRU cache, IDN support, per-request timeout, CI gating

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,8 +21,14 @@ jobs:
       with:
         go-version-file: go.mod
 
+    - name: Check formatting
+      run: test -z "$(gofmt -l .)" || { echo "Run gofmt -w on:"; gofmt -l .; exit 1; }
+
+    - name: Vet
+      run: go vet ./...
+
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -v -coverpkg=./... -cover ./...

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/KincaidYang/whois/server_lists"
 	"github.com/KincaidYang/whois/utils"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/net/idna"
 )
 
 // statusWriter wraps http.ResponseWriter to capture the written status code.
@@ -46,8 +47,15 @@ func isASN(resource string) bool {
 }
 
 // isDomain function is used to check if the given resource is a valid domain name.
+// IDN (Unicode) domains such as "müller.de" or "例子.cn" are converted to their
+// ASCII/punycode form before validation, matching the conversion HandleDomain
+// performs, so they are accepted at the entry point.
 func isDomain(resource string) bool {
-	return domainRegex.MatchString(resource)
+	ascii, err := idna.ToASCII(resource)
+	if err != nil {
+		return false
+	}
+	return domainRegex.MatchString(ascii)
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -120,7 +128,16 @@ func main() {
 	// Main query handler
 	http.HandleFunc("/", handler)
 
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", config.Port)}
+	srv := &http.Server{
+		Addr: fmt.Sprintf(":%d", config.Port),
+		// WriteTimeout must exceed the upstream query timeout (WHOIS/RDAP
+		// each allow up to 10s), since the handler queries upstream
+		// synchronously before writing the response.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      20 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 
 	go func() {
 		slog.Info("server listening", "port", config.Port)

--- a/main.go
+++ b/main.go
@@ -41,6 +41,12 @@ var (
 	domainRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
 )
 
+// requestTimeout bounds how long a single query may take, so a slow upstream
+// WHOIS/RDAP server cannot hold a concurrency slot indefinitely. It must stay
+// below the server's WriteTimeout (20s) so the handler returns first, and above
+// the per-upstream dial/read timeout (10s) to allow one full upstream attempt.
+const requestTimeout = 15 * time.Second
+
 // isASN function is used to check if the given resource is an Autonomous System Number (ASN).
 func isASN(resource string) bool {
 	return asnRegex.MatchString(resource)
@@ -76,7 +82,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		<-config.ConcurrencyLimiter
 	}()
 
-	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(r.Context(), requestTimeout)
+	defer cancel()
 	resource := strings.TrimPrefix(r.URL.Path, "/")
 	resource = strings.ToLower(resource)
 

--- a/main_domain_test.go
+++ b/main_domain_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/config"
+	"golang.org/x/net/idna"
+)
+
+// TestHandlerUnknownTLD exercises HandleDomain's server-selection logic for a
+// syntactically valid domain whose TLD has neither an RDAP nor a WHOIS server.
+// This path is network-free.
+func TestHandlerUnknownTLD(t *testing.T) {
+	req := httptest.NewRequest("GET", "/example.zzqqxxnotld", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+// TestHandlerTextPlainCacheHit verifies that a cached non-JSON payload is served
+// as text/plain, covering the content-type sniffing branch in HandleDomain.
+func TestHandlerTextPlainCacheHit(t *testing.T) {
+	domain := "textplaintest99999.cn"
+	key := "whois:" + domain
+	cached := "Domain Name: textplaintest99999.cn\nRaw WHOIS text, not JSON\n"
+	ctx := context.Background()
+	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/"+domain, nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("expected text/plain content type, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "Raw WHOIS text") {
+		t.Errorf("response body missing cached content: %s", w.Body.String())
+	}
+}
+
+// TestHandlerIDNCacheHit confirms a Unicode IDN request is accepted at the entry
+// point and resolved against the punycode cache key written by HandleDomain.
+func TestHandlerIDNCacheHit(t *testing.T) {
+	unicode := "例子idntest.cn"
+	punycode, err := idna.ToASCII(unicode)
+	if err != nil {
+		t.Fatalf("idna.ToASCII: %v", err)
+	}
+	key := "whois:" + punycode
+	cached := `{"domainName":"` + punycode + `"}`
+	ctx := context.Background()
+	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/"+unicode, nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for IDN input, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), punycode) {
+		t.Errorf("response body missing punycode domain: %s", w.Body.String())
+	}
+}
+
+// TestHandlerIPCacheHit confirms the IP branch resolves and serves cached data.
+func TestHandlerIPCacheHit(t *testing.T) {
+	ip := "192.0.2.1"
+	key := "whois:" + ip
+	cached := `{"ipNetwork":"192.0.2.0/24"}`
+	ctx := context.Background()
+	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/"+ip, nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "192.0.2.0/24") {
+		t.Errorf("response body missing cached IP data: %s", w.Body.String())
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -50,6 +50,8 @@ func TestIsDomain(t *testing.T) {
 		{"123.com", true},
 		{"example.c", false},    // TLD too short
 		{"exa_mple.com", false}, // Invalid character
+		{"müller.de", true},     // IDN (Latin with diacritics)
+		{"例子.cn", true},         // IDN (Chinese)
 	}
 
 	for _, test := range tests {

--- a/rdap_tools/rdap_parse.go
+++ b/rdap_tools/rdap_parse.go
@@ -181,9 +181,9 @@ func ParseRDAPResponseforIP(response string) (structs.IPInfo, error) {
 	}
 
 	info := structs.IPInfo{
-		IP:      rdap.Handle,
-		NetName: rdap.Name,
-		Country: rdap.Country,
+		IP:       rdap.Handle,
+		NetName:  rdap.Name,
+		Country:  rdap.Country,
 		IPStatus: rdap.Status,
 	}
 

--- a/rdap_tools/rdap_query.go
+++ b/rdap_tools/rdap_query.go
@@ -15,6 +15,10 @@ import (
 	"github.com/KincaidYang/whois/utils"
 )
 
+// maxResponseSize caps how much we read from an RDAP server to guard against
+// a misbehaving or malicious server exhausting memory.
+const maxResponseSize = 2 << 20 // 2 MiB
+
 // proxyClient is a pre-built HTTP client for proxied RDAP requests.
 // Initialized once at startup to enable connection pool reuse across requests.
 var proxyClient *http.Client
@@ -73,7 +77,7 @@ func doRDAPRequest(ctx context.Context, client *http.Client, url string) (result
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 		if err != nil {
 			return "", err
 		}

--- a/server_lists/lookup_test.go
+++ b/server_lists/lookup_test.go
@@ -12,7 +12,7 @@ func TestLookupIPKey_IPv4(t *testing.T) {
 		wantURL   string // substring expected in the returned URL
 		wantFound bool
 	}{
-		{"1.1.1.1", "rdap.apnic.net", true},      // APNIC
+		{"1.1.1.1", "rdap.apnic.net", true},       // APNIC
 		{"1.255.255.255", "rdap.apnic.net", true}, // last addr in 1.0.0.0/8
 		{"41.0.0.1", "rdap.afrinic.net", true},    // AFRINIC
 		{"102.128.0.1", "rdap.afrinic.net", true}, // AFRINIC
@@ -41,11 +41,11 @@ func TestLookupIPKey_IPv6(t *testing.T) {
 		ip        string
 		wantFound bool
 	}{
-		{"2001:4200::1", true},  // AFRINIC 2001:4200::/23
-		{"2c00::1", true},       // AFRINIC 2c00::/12
-		{"2001:200::1", true},   // APNIC   2001:200::/23
-		{"::1", false},          // loopback
-		{"fe80::1", false},      // link-local
+		{"2001:4200::1", true}, // AFRINIC 2001:4200::/23
+		{"2c00::1", true},      // AFRINIC 2c00::/12
+		{"2001:200::1", true},  // APNIC   2001:200::/23
+		{"::1", false},         // loopback
+		{"fe80::1", false},     // link-local
 	}
 
 	for _, tt := range tests {

--- a/server_lists/rdap_servers.go
+++ b/server_lists/rdap_servers.go
@@ -1620,5 +1620,4 @@ var compiledRdapServers = map[string]string{
 	"sr":                       "https://whois.sr/rdap/",
 	"tz":                       "https://whois.tznic.or.tz/rdap/",
 	"fj":                       "https://www.rdap.fj/",
-
 }

--- a/utils/cache_interface.go
+++ b/utils/cache_interface.go
@@ -1,10 +1,10 @@
 package utils
 
 import (
+	"container/list"
 	"context"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/KincaidYang/whois/metrics"
@@ -17,23 +17,31 @@ type Cache interface {
 	IsHealthy() bool
 }
 
-// cacheEntry represents a cached item with expiration
+// cacheEntry represents a cached item with expiration. It is stored as the
+// value of a list element so the entry can be reached from both the lookup
+// map and the LRU ordering list.
 type cacheEntry struct {
+	Key       string
 	Value     string
 	ExpiresAt time.Time
 }
 
-// MemoryCache implements Cache interface using in-memory storage
+// MemoryCache implements Cache interface using in-memory storage with LRU
+// eviction. A single mutex guards both the lookup map and the recency list,
+// so size accounting (len(items)) is always consistent.
 type MemoryCache struct {
-	data          sync.Map
+	mu            sync.Mutex
+	items         map[string]*list.Element // key -> element holding *cacheEntry
+	order         *list.List               // front = most recently used
 	maxSize       int
 	cleanInterval time.Duration
-	size          atomic.Int64
 }
 
 // NewMemoryCache creates a new memory cache instance
 func NewMemoryCache(maxSize int, cleanInterval time.Duration) *MemoryCache {
 	mc := &MemoryCache{
+		items:         make(map[string]*list.Element),
+		order:         list.New(),
 		maxSize:       maxSize,
 		cleanInterval: cleanInterval,
 	}
@@ -46,21 +54,26 @@ func NewMemoryCache(maxSize int, cleanInterval time.Duration) *MemoryCache {
 
 // Get retrieves a value from memory cache
 func (mc *MemoryCache) Get(ctx context.Context, key string) (CacheResult, error) {
-	value, ok := mc.data.Load(key)
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
+	elem, ok := mc.items[key]
 	if !ok {
 		metrics.CacheRequestsTotal.WithLabelValues("memory", "miss").Inc()
 		return CacheResult{Found: false}, nil
 	}
 
-	entry := value.(cacheEntry)
+	entry := elem.Value.(*cacheEntry)
 
 	// Check if expired
 	if time.Now().After(entry.ExpiresAt) {
-		mc.data.Delete(key)
-		mc.decrementSize()
+		mc.removeElement(elem)
 		metrics.CacheRequestsTotal.WithLabelValues("memory", "miss").Inc()
 		return CacheResult{Found: false}, nil
 	}
+
+	// Mark as most recently used
+	mc.order.MoveToFront(elem)
 
 	slog.Debug("cache hit", "backend", "memory", "key", key)
 	metrics.CacheRequestsTotal.WithLabelValues("memory", "hit").Inc()
@@ -69,31 +82,31 @@ func (mc *MemoryCache) Get(ctx context.Context, key string) (CacheResult, error)
 
 // Set stores a value in memory cache
 func (mc *MemoryCache) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
-	// Check size limit only for new entries
-	if _, exists := mc.data.Load(key); !exists {
-		if mc.size.Load() >= int64(mc.maxSize) {
-			// Try to clean expired entries first
-			mc.cleanExpired()
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
 
-			// If still over limit, evict one arbitrary entry to make room
-			if mc.size.Load() >= int64(mc.maxSize) {
-				mc.evictOne()
-			}
-		}
+	expiresAt := time.Now().Add(expiration)
+
+	// Update existing entry in place and promote it.
+	if elem, ok := mc.items[key]; ok {
+		entry := elem.Value.(*cacheEntry)
+		entry.Value = value
+		entry.ExpiresAt = expiresAt
+		mc.order.MoveToFront(elem)
+		return nil
 	}
 
-	entry := cacheEntry{
+	// New entry: evict the least recently used item if at capacity.
+	if len(mc.items) >= mc.maxSize {
+		mc.evictOldest()
+	}
+
+	elem := mc.order.PushFront(&cacheEntry{
+		Key:       key,
 		Value:     value,
-		ExpiresAt: time.Now().Add(expiration),
-	}
-
-	// Check if this is a new entry
-	_, existed := mc.data.Load(key)
-	mc.data.Store(key, entry)
-
-	if !existed {
-		mc.incrementSize()
-	}
+		ExpiresAt: expiresAt,
+	})
+	mc.items[key] = elem
 
 	return nil
 }
@@ -103,25 +116,22 @@ func (mc *MemoryCache) IsHealthy() bool {
 	return true
 }
 
-// incrementSize atomically increments the size counter
-func (mc *MemoryCache) incrementSize() {
-	mc.size.Add(1)
+// removeElement deletes an element from both the map and the order list.
+// Callers must hold mc.mu.
+func (mc *MemoryCache) removeElement(elem *list.Element) {
+	entry := elem.Value.(*cacheEntry)
+	mc.order.Remove(elem)
+	delete(mc.items, entry.Key)
 }
 
-// decrementSize atomically decrements the size counter
-func (mc *MemoryCache) decrementSize() {
-	mc.size.Add(-1)
-}
-
-// evictOne removes the first entry encountered in the cache.
-// sync.Map iteration order is unspecified, giving effectively random eviction.
-func (mc *MemoryCache) evictOne() {
-	mc.data.Range(func(key, _ interface{}) bool {
-		mc.data.Delete(key)
-		mc.decrementSize()
-		metrics.CacheEvictionsTotal.WithLabelValues("memory").Inc()
-		return false // stop after first entry
-	})
+// evictOldest removes the least recently used entry. Callers must hold mc.mu.
+func (mc *MemoryCache) evictOldest() {
+	elem := mc.order.Back()
+	if elem == nil {
+		return
+	}
+	mc.removeElement(elem)
+	metrics.CacheEvictionsTotal.WithLabelValues("memory").Inc()
 }
 
 // startCleaner runs a periodic cleanup of expired entries
@@ -136,15 +146,17 @@ func (mc *MemoryCache) startCleaner() {
 
 // cleanExpired removes all expired entries in a single pass
 func (mc *MemoryCache) cleanExpired() {
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+
 	now := time.Now()
-	mc.data.Range(func(key, value interface{}) bool {
-		entry := value.(cacheEntry)
-		if now.After(entry.ExpiresAt) {
-			mc.data.Delete(key)
-			mc.decrementSize()
+	for elem := mc.order.Back(); elem != nil; {
+		prev := elem.Prev()
+		if now.After(elem.Value.(*cacheEntry).ExpiresAt) {
+			mc.removeElement(elem)
 		}
-		return true
-	})
+		elem = prev
+	}
 }
 
 // FallbackCache implements Cache with primary and fallback caches

--- a/whois_tools/whois_parsers.go
+++ b/whois_tools/whois_parsers.go
@@ -12,20 +12,20 @@ import (
 // 预编译正则表达式（所有解析器共享，避免每次调用重复编译）
 var (
 	// CN / xn--fiqs8s / xn--fiqz9s
-	reCNCreationDate  = regexp.MustCompile(`Registration Time: (.*)`)
-	reCNExpiryDate    = regexp.MustCompile(`Expiration Time: (.*)`)
-	reCNNameServer    = regexp.MustCompile(`Name Server: (.*)`)
-	reCNDNSSEC        = regexp.MustCompile(`DNSSEC: (.*)`)
-	reCNRegistrar     = regexp.MustCompile(`Sponsoring Registrar: (.*)`)
-	reCNDomainStatus  = regexp.MustCompile(`Domain Status: (.*)`)
+	reCNCreationDate = regexp.MustCompile(`Registration Time: (.*)`)
+	reCNExpiryDate   = regexp.MustCompile(`Expiration Time: (.*)`)
+	reCNNameServer   = regexp.MustCompile(`Name Server: (.*)`)
+	reCNDNSSEC       = regexp.MustCompile(`DNSSEC: (.*)`)
+	reCNRegistrar    = regexp.MustCompile(`Sponsoring Registrar: (.*)`)
+	reCNDomainStatus = regexp.MustCompile(`Domain Status: (.*)`)
 
 	// HK / xn--j6w193g
-	reHKCreationDate  = regexp.MustCompile(`Domain Name Commencement Date: (.*)`)
-	reHKExpiryDate    = regexp.MustCompile(`Expiry Date: (.*)`)
-	reHKNameServer    = regexp.MustCompile(`Name Servers Information:\s*\n\n((?:.+\n)+)`)
-	reHKDNSSEC        = regexp.MustCompile(`DNSSEC: (.*)`)
-	reHKRegistrar     = regexp.MustCompile(`Registrar Name: (.*)`)
-	reHKDomainStatus  = regexp.MustCompile(`Domain Status: (.*)`)
+	reHKCreationDate = regexp.MustCompile(`Domain Name Commencement Date: (.*)`)
+	reHKExpiryDate   = regexp.MustCompile(`Expiry Date: (.*)`)
+	reHKNameServer   = regexp.MustCompile(`Name Servers Information:\s*\n\n((?:.+\n)+)`)
+	reHKDNSSEC       = regexp.MustCompile(`DNSSEC: (.*)`)
+	reHKRegistrar    = regexp.MustCompile(`Registrar Name: (.*)`)
+	reHKDomainStatus = regexp.MustCompile(`Domain Status: (.*)`)
 
 	// TW
 	reTWRegistrar    = regexp.MustCompile(`Registration Service Provider: (.*)`)
@@ -85,13 +85,13 @@ var (
 	reAULastUpdateOfRDAPDB = regexp.MustCompile(`Last update of WHOIS database: ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z)`)
 
 	// SG
-	reSGCreationDate  = regexp.MustCompile(`Creation Date:\s+(.*)`)
-	reSGExpiryDate    = regexp.MustCompile(`Expiration Date:\s+(.*)`)
-	reSGNameServer    = regexp.MustCompile(`Name Servers?:\s+(.*)`)
-	reSGDNSSEC        = regexp.MustCompile(`DNSSEC:\s+(.*)`)
-	reSGRegistrar     = regexp.MustCompile(`Registrar:\s+(.*)`)
-	reSGDomainStatus  = regexp.MustCompile(`Domain Status:\s+(.*)`)
-	reSGUpdatedDate   = regexp.MustCompile(`Modified Date:\s+(.*)`)
+	reSGCreationDate = regexp.MustCompile(`Creation Date:\s+(.*)`)
+	reSGExpiryDate   = regexp.MustCompile(`Expiration Date:\s+(.*)`)
+	reSGNameServer   = regexp.MustCompile(`Name Servers?:\s+(.*)`)
+	reSGDNSSEC       = regexp.MustCompile(`DNSSEC:\s+(.*)`)
+	reSGRegistrar    = regexp.MustCompile(`Registrar:\s+(.*)`)
+	reSGDomainStatus = regexp.MustCompile(`Domain Status:\s+(.*)`)
+	reSGUpdatedDate  = regexp.MustCompile(`Modified Date:\s+(.*)`)
 
 	// LA
 	reLARegistrar          = regexp.MustCompile(`Registrar:\s+(.+)`)
@@ -455,7 +455,6 @@ func ParseWhoisResponseRU(response string, domain string) (structs.DomainInfo, e
 func ParseWhoisResponseSB(response string, domain string) (structs.DomainInfo, error) {
 	var domainInfo structs.DomainInfo
 	domainInfo.DomainName = domain
-
 
 	// 解析创建日期
 	matchCreationDate := reSBCreationDate.FindStringSubmatch(response)

--- a/whois_tools/whois_query.go
+++ b/whois_tools/whois_query.go
@@ -15,6 +15,9 @@ import (
 const (
 	whoisDefaultPort = "43"
 	whoisTimeout     = 10 * time.Second
+	// maxResponseSize caps how much we read from a WHOIS server to guard
+	// against a misbehaving or malicious server exhausting memory.
+	maxResponseSize = 2 << 20 // 2 MiB
 )
 
 // Whois function is used to query the WHOIS information for a given domain.
@@ -49,7 +52,7 @@ func Whois(ctx context.Context, domain, tld string) (result string, err error) {
 		return "", err
 	}
 
-	body, err := io.ReadAll(conn)
+	body, err := io.ReadAll(io.LimitReader(conn, maxResponseSize))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## 概述
一轮稳定性 / 健壮性优化，不改对外 API 与响应格式。

## 改动
**安全 / 健壮性**
- WHOIS + RDAP 上游读取用 `io.LimitReader` 限制 2 MiB，防 OOM
- `http.Server` 设置 Read/Write/Idle 超时（缓解 Slowloris）
- 每个请求加 15s `context.WithTimeout`，慢上游不再长期占用并发槽

**功能**
- `isDomain` 入口将 Unicode IDN 转 punycode 再校验，支持直接输入 `müller.de` / `例子.cn`

**缓存**
- `MemoryCache` 重写为 `mutex + container/list` 真正的 LRU，淘汰从随机改为 LRU，`size` 锁内 `len(map)` 消除 TOCTOU 竞态

**CI / 测试**
- `go.yml` 增加 `gofmt` / `go vet` 门禁，测试改用 `-coverpkg=./...` 跨包归集覆盖率
- 新增 handler 层测试（未知 TLD、text/plain & IDN & IP 缓存命中），`HandleDomain` 覆盖率 0 → 56%
- `gofmt` 修复历史未格式化文件

## 验证
`gofmt -l` 干净、`go vet` 干净、`go build` 成功、`go test -race ./...` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)