### PR TITLE
feat: negative caching + IDN TLD & oversized-response fixes from PR #8 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,35 +37,42 @@ go build
 ```bash
 vim config.yaml
 ```
+> ⚠️ 配置文件的 YAML 键名**区分大小写**，请全部使用小写（如 `cacheexpiration`、`requireredis`、`proxyserver`），否则该项不会被解析、回退到默认值。
+
 ```yaml
 redis:
   addr: "redis:6379"          # Redis服务器地址
   password: ""                 # Redis密码，如无密码则留空
   db: 0                        # Redis数据库编号
-cacheExpiration: 3600          # 缓存过期时间，单位：秒
+cacheexpiration: 3600          # 缓存过期时间，单位：秒
 
 # 高级缓存配置（可选，新版本功能）
 cache:
-  requireRedis: false          # false=允许Redis失败时降级到内存缓存，true=Redis必须可用否则程序退出
-  memoryMaxSize: 10000         # 内存缓存最大条目数，超过此数量将不再缓存新数据（默认: 10000）
-  memoryCleanInterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
+  requireredis: false          # false=允许Redis失败时降级到内存缓存，true=Redis必须可用否则程序退出
+  memorymaxsize: 10000         # 内存缓存最大条目数，超过此数量按 LRU 淘汰最久未使用条目（默认: 10000）
+  memorycleaninterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
+  negativecacheexpiration: 60  # “未找到/被拒”结果的缓存时间，单位：秒（默认: 60；设为负数则禁用）
 
 port: 8043                     # 服务监听端口
-rateLimit: 50                  # 并发限制，即程序向上游whois服务器发起的最大并发请求数
+ratelimit: 50                  # 并发限制，即程序向上游whois服务器发起的最大并发请求数
 
 # 代理配置（可选）
-ProxyServer: "http://127.0.0.1:8080"  # 代理服务器地址
-ProxySuffixes:                         # 需要使用代理的TLD后缀列表，留空表示不使用代理
-ProxyUsername: ""                      # 代理服务器用户名（如需认证）
-ProxyPassword: ""                      # 代理服务器密码（如需认证）
+proxyserver: "http://127.0.0.1:8080"  # 代理服务器地址
+proxysuffixes: []                      # 需要使用代理的TLD后缀列表，留空表示不使用代理；填 ["all"] 表示全部走代理
+proxyusername: ""                      # 代理服务器用户名（如需认证）
+proxypassword: ""                      # 代理服务器密码（如需认证）
 
-logLevel: "info"                       # 日志级别：debug、info、warn、error（默认：info）
-bootstrapInterval: 86400               # RDAP 服务器列表从 IANA 刷新间隔，单位：秒；0 或不填则禁用（推荐：86400）
+loglevel: "info"                       # 日志级别：debug、info、warn、error（默认：info）
+bootstrapinterval: 86400               # RDAP 服务器列表从 IANA 刷新间隔，单位：秒；0 或不填则禁用（推荐：86400）
 ```
+
+部分配置项可通过环境变量覆盖（优先级高于配置文件），如 `WHOIS_REDIS_ADDR`、`WHOIS_PORT`、`WHOIS_RATE_LIMIT`、`WHOIS_CACHE_EXPIRATION`、`WHOIS_NEGATIVE_CACHE_EXPIRATION`、`WHOIS_LOG_LEVEL` 等。
 
 **配置说明：**
 - **Redis配置**：建议使用Redis以获得更好的性能和多实例缓存共享能力
 - **缓存过期时间**：根据查询频率调整，建议3600秒
+- **内存缓存**：Redis 不可用时的兜底，达到上限后按 LRU（最近最少使用）淘汰
+- **负向缓存**：将“未找到/被拒”的查询结果短时间缓存，避免对不存在的资源反复请求上游；默认 60 秒
 - **并发限制**：控制向上游服务器的请求频率，避免被限流。
 - **代理配置**：某些TLD可能需要代理访问，可配置特定后缀使用代理
 - **日志级别**：`debug` 会输出每次缓存命中和上游查询，流量大时噪声较高；生产环境建议保持 `info`
@@ -133,6 +140,8 @@ GET 请求
 
 #### 浏览器访问
 部署后直接通过浏览器访问`http://ip:端口/你想查的域名或ip或asn`，默认端口`8043`，示例`http://1.2.3.4:8043/examlpe.com`,详细示例请参考下方
+
+> 支持直接查询国际化域名（IDN，含中文、带变音符号等 Unicode 域名），程序会自动转换为 Punycode 后查询，例如 `http://1.2.3.4:8043/例子.cn`。
 
 #### 查询域名 Whois 信息
 ```bash
@@ -299,9 +308,11 @@ curl http://localhost:8043/205794
 本项目还使用了以下第三方库：
 
 - [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis)：Go语言Redis客户端。
+- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang)：Prometheus 指标采集与暴露。
+- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk)：MCP（Model Context Protocol）Go SDK。
 - [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna)：实现了IDNA（国际化域名在应用程序）规范。
 - [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix)：实现了公共后缀列表规范。
-- [`gopkg.in/yaml.v2`](https://gopkg.in/yaml.v2)：YAML 解析库。
+- [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3)：YAML 解析库。
 
 WHOIS/RDAP 服务器列表来自于：
 - [IANA](https://www.iana.org/domains/root/db)

--- a/README_EN.md
+++ b/README_EN.md
@@ -47,35 +47,42 @@ This program requires Redis service support. You can refer to https://redis.io/d
 vim config.yaml
 ```
 
+> ⚠️ YAML keys in the config file are **case-sensitive** — use all lowercase (e.g. `cacheexpiration`, `requireredis`, `proxyserver`), otherwise the key is ignored and falls back to its default.
+
 ```yaml
 redis:
   addr: "redis:6379"           # Redis server address
   password: ""                 # Redis password, leave empty if none
   db: 0                        # Redis database number
-cacheExpiration: 3600          # Cache expiration time in seconds
+cacheexpiration: 3600          # Cache expiration time in seconds
 
 # Advanced cache configuration (optional, new feature)
 cache:
-  requireRedis: false          # false=allow fallback to memory cache when Redis fails, true=Redis must be available or program exits
-  memoryMaxSize: 10000         # Maximum entries in memory cache (default: 10000)
-  memoryCleanInterval: 300     # Memory cache cleanup interval in seconds (default: 300)
+  requireredis: false          # false=allow fallback to memory cache when Redis fails, true=Redis must be available or program exits
+  memorymaxsize: 10000         # Maximum entries in memory cache; least-recently-used entries are evicted past this (default: 10000)
+  memorycleaninterval: 300     # Memory cache cleanup interval in seconds (default: 300)
+  negativecacheexpiration: 60  # How long "not found / denied" results are cached, in seconds (default: 60; set negative to disable)
 
 port: 8043                     # Server listening port
-rateLimit: 50                  # Concurrency limit for upstream WHOIS server requests
+ratelimit: 50                  # Concurrency limit for upstream WHOIS server requests
 
 # Proxy configuration (optional)
-ProxyServer: "http://127.0.0.1:8080"  # Proxy server address
-ProxySuffixes:                         # TLD suffixes that need proxy, leave empty to disable
-ProxyUsername: ""                      # Proxy server username (if authentication required)
-ProxyPassword: ""                      # Proxy server password (if authentication required)
+proxyserver: "http://127.0.0.1:8080"  # Proxy server address
+proxysuffixes: []                      # TLD suffixes that use the proxy; empty to disable; ["all"] routes everything through the proxy
+proxyusername: ""                      # Proxy server username (if authentication required)
+proxypassword: ""                      # Proxy server password (if authentication required)
 
-logLevel: "info"                       # Log level: debug, info, warn, error (default: info)
-bootstrapInterval: 86400               # RDAP server list refresh interval in seconds; 0 or unset disables fetching (recommended: 86400)
+loglevel: "info"                       # Log level: debug, info, warn, error (default: info)
+bootstrapinterval: 86400               # RDAP server list refresh interval in seconds; 0 or unset disables fetching (recommended: 86400)
 ```
+
+Selected options can be overridden via environment variables (which take precedence over the config file), e.g. `WHOIS_REDIS_ADDR`, `WHOIS_PORT`, `WHOIS_RATE_LIMIT`, `WHOIS_CACHE_EXPIRATION`, `WHOIS_NEGATIVE_CACHE_EXPIRATION`, `WHOIS_LOG_LEVEL`.
 
 **Configuration Notes:**
 - **Redis Configuration**: Redis is recommended for better performance and multi-instance cache sharing
 - **Cache Expiration**: Adjust based on query frequency, 3600 seconds recommended
+- **Memory Cache**: Fallback when Redis is unavailable; evicts least-recently-used (LRU) entries once full
+- **Negative Cache**: Briefly caches "not found / denied" results to avoid repeatedly hitting upstream for missing resources; defaults to 60 seconds
 - **Concurrency Limit**: Controls request frequency to upstream servers to avoid rate limiting
 - **Proxy Configuration**: Some TLDs may require proxy access
 - **Log Level**: `debug` logs every cache hit and upstream query dispatch — noisy under load; `info` is recommended for production
@@ -135,6 +142,8 @@ GET requests
 #### Browser Access
 
 After deployment, access `http://ip:port/domain-or-ip-or-asn` via browser. Default port is `8043`, e.g., `http://1.2.3.4:8043/example.com`
+
+> Internationalized domain names (IDN, including Unicode domains with non-ASCII characters) can be queried directly; the program converts them to Punycode automatically, e.g. `http://1.2.3.4:8043/例子.cn`.
 
 #### Query Domain WHOIS Information
 
@@ -285,6 +294,8 @@ This project uses the following Go standard libraries:
 This project also uses the following third-party libraries:
 
 - [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis): Redis client for Go
+- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang): Prometheus metrics instrumentation and exposition
+- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk): MCP (Model Context Protocol) Go SDK
 - [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna): IDNA (Internationalized Domain Names in Applications) implementation
 - [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix): Public Suffix List implementation
 - [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3): YAML parsing library

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -7,6 +7,7 @@ cache:
   requireredis: false
   memorymaxsize: 10000
   memorycleaninterval: 300
+  negativecacheexpiration: 60
 port: 8043
 ratelimit: 60
 proxyserver: "http://127.0.0.1:8080"

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ cache:
   requireredis: false
   memorymaxsize: 10000
   memorycleaninterval: 300
+  negativecacheexpiration: 60
 port: 8043
 ratelimit: 60
 proxyserver: "http://127.0.0.1:8080"

--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,8 @@ var (
 	RequireRedis        bool
 	MemoryMaxSize       int
 	MemoryCleanInterval time.Duration
+	// NegativeCacheExpiration is how long not-found/denied results are cached.
+	NegativeCacheExpiration time.Duration
 	// BootstrapInterval is how often to refresh RDAP server lists from IANA.
 	BootstrapInterval time.Duration
 )
@@ -132,6 +134,7 @@ func init() {
 	RequireRedis = config.Cache.RequireRedis
 	MemoryMaxSize = config.Cache.MemoryMaxSize
 	MemoryCleanInterval = time.Duration(config.Cache.MemoryCleanInterval) * time.Second
+	NegativeCacheExpiration = time.Duration(config.Cache.NegativeCacheExpiration) * time.Second
 
 	// Initialize cache manager with fallback
 	initializeCacheManager()
@@ -165,6 +168,12 @@ func applyDefaultCacheConfig(config *Config) {
 	// Default: clean every 5 minutes (300 seconds)
 	if config.Cache.MemoryCleanInterval == 0 {
 		config.Cache.MemoryCleanInterval = 300
+	}
+
+	// Default: cache not-found/denied results for 60 seconds.
+	// A negative value disables negative caching; only 0 (unset) gets the default.
+	if config.Cache.NegativeCacheExpiration == 0 {
+		config.Cache.NegativeCacheExpiration = 60
 	}
 
 	// Default port: 8043
@@ -270,6 +279,11 @@ func overrideConfigWithEnv(config *Config) {
 	if memoryCleanInterval := os.Getenv("WHOIS_MEMORY_CLEAN_INTERVAL"); memoryCleanInterval != "" {
 		if interval, err := strconv.Atoi(memoryCleanInterval); err == nil {
 			config.Cache.MemoryCleanInterval = interval
+		}
+	}
+	if negativeCacheExpiration := os.Getenv("WHOIS_NEGATIVE_CACHE_EXPIRATION"); negativeCacheExpiration != "" {
+		if exp, err := strconv.Atoi(negativeCacheExpiration); err == nil {
+			config.Cache.NegativeCacheExpiration = exp
 		}
 	}
 

--- a/config/struct.go
+++ b/config/struct.go
@@ -16,6 +16,10 @@ type Config struct {
 		RequireRedis        bool `json:"requireRedis" yaml:"requireredis"`               // RequireRedis determines if Redis is required (default: false)
 		MemoryMaxSize       int  `json:"memoryMaxSize" yaml:"memorymaxsize"`             // MemoryMaxSize is the maximum number of entries in memory cache (default: 10000)
 		MemoryCleanInterval int  `json:"memoryCleanInterval" yaml:"memorycleaninterval"` // MemoryCleanInterval is the interval to clean expired entries in seconds (default: 300)
+		// NegativeCacheExpiration is how long (in seconds) "not found" / "denied"
+		// results are cached to avoid hammering upstream servers. Default: 60.
+		// Set to a negative value to disable negative caching.
+		NegativeCacheExpiration int `json:"negativeCacheExpiration" yaml:"negativecacheexpiration"`
 	} `json:"cache" yaml:"cache"`
 	// Port is the port number for the server.
 	Port int `json:"port" yaml:"port"`

--- a/handle_resources/asn.go
+++ b/handle_resources/asn.go
@@ -36,6 +36,9 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 		return
 	}
 	if cacheResult.Found {
+		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+			return
+		}
 		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
 		return
 	}
@@ -47,6 +50,7 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 	queryresult, err := rdap_tools.RDAPQueryASN(ctx, asn, serverURL)
 	if err != nil {
 		utils.HandleQueryError(w, err)
+		utils.CacheNegativeResult(ctx, config.CacheManager, key, err, config.NegativeCacheExpiration)
 		return
 	}
 

--- a/handle_resources/domain.go
+++ b/handle_resources/domain.go
@@ -83,6 +83,9 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	}
 
 	if cacheResult.Found {
+		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+			return
+		}
 		contentType := "application/json"
 		if len(cacheResult.Data) == 0 || cacheResult.Data[0] != '{' {
 			contentType = "text/plain; charset=utf-8"
@@ -96,17 +99,17 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	// If the RDAP server for the TLD is known, query the RDAP information for the domain
 	if _, ok := server_lists.LookupRdapServer(tld); ok {
 		queryResult, err = handleRDAPQuery(ctx, w, domain, tld, key)
-		if err != nil {
-			return // Error already handled in function
-		}
 	} else if _, ok := server_lists.TLDToWhoisServer[tld]; ok {
 		// If the WHOIS server for the TLD is known, query the WHOIS information for the domain
 		queryResult, err = handleWhoisQuery(ctx, w, domain, tld, key)
-		if err != nil {
-			return // Error already handled in function
-		}
 	} else {
 		utils.HandleHTTPError(w, utils.ErrorTypeInternalServer, "No WHOIS or RDAP server known for TLD: "+tld)
+		return
+	}
+	if err != nil {
+		// Error response already written by the query helper. Cache a
+		// short-TTL negative marker for stable not-found / denied outcomes.
+		utils.CacheNegativeResult(ctx, config.CacheManager, key, err, config.NegativeCacheExpiration)
 		return
 	}
 

--- a/handle_resources/ip.go
+++ b/handle_resources/ip.go
@@ -24,6 +24,9 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 		return
 	}
 	if cacheResult.Found {
+		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+			return
+		}
 		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
 		return
 	}
@@ -36,6 +39,7 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 	queryresult, err := rdap_tools.RDAPQueryIP(ctx, resource, serverURL)
 	if err != nil {
 		utils.HandleQueryError(w, err)
+		utils.CacheNegativeResult(ctx, config.CacheManager, key, err, config.NegativeCacheExpiration)
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -37,8 +37,11 @@ func (sw *statusWriter) WriteHeader(code int) {
 
 // Pre-compiled regular expressions for better performance
 var (
-	asnRegex    = regexp.MustCompile(`^(?i)(as|asn)?\d+$`)
-	domainRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+	asnRegex = regexp.MustCompile(`^(?i)(as|asn)?\d+$`)
+	// domainRegex is matched against the ASCII/punycode form (see isDomain), so
+	// the final label may be either an alphabetic TLD or a punycode TLD such as
+	// "xn--fiqs8s" (.中国), which contains digits and hyphens.
+	domainRegex = regexp.MustCompile(`^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+(?:[a-zA-Z]{2,}|xn--[a-zA-Z0-9-]+)$`)
 )
 
 // requestTimeout bounds how long a single query may take, so a slow upstream

--- a/main_domain_test.go
+++ b/main_domain_test.go
@@ -81,6 +81,26 @@ func TestHandlerIDNCacheHit(t *testing.T) {
 	}
 }
 
+// TestHandlerNegativeCacheHit verifies a cached negative marker is served as a
+// 404 rather than as a normal payload, exercising the read-side interception.
+func TestHandlerNegativeCacheHit(t *testing.T) {
+	domain := "negativecachetest99999.cn"
+	key := "whois:" + domain
+	ctx := context.Background()
+	// Seed a not-found negative marker (same encoding CacheNegativeResult writes).
+	if err := config.CacheManager.Set(ctx, key, "\x00neg:notfound", time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/"+domain, nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for negative cache hit, got %d", w.Code)
+	}
+}
+
 // TestHandlerIPCacheHit confirms the IP branch resolves and serves cached data.
 func TestHandlerIPCacheHit(t *testing.T) {
 	ip := "192.0.2.1"

--- a/main_test.go
+++ b/main_test.go
@@ -48,10 +48,12 @@ func TestIsDomain(t *testing.T) {
 		{"example..com", false},
 		{"example", false},
 		{"123.com", true},
-		{"example.c", false},    // TLD too short
-		{"exa_mple.com", false}, // Invalid character
-		{"müller.de", true},     // IDN (Latin with diacritics)
-		{"例子.cn", true},         // IDN (Chinese)
+		{"example.c", false},             // TLD too short
+		{"exa_mple.com", false},          // Invalid character
+		{"müller.de", true},              // IDN (Latin with diacritics)
+		{"例子.cn", true},                  // IDN (Chinese label, ASCII TLD)
+		{"例子.中国", true},                  // IDN with internationalized (punycode) TLD
+		{"xn--fsqu00a.xn--fiqs8s", true}, // already-punycode IDN + punycode TLD
 	}
 
 	for _, test := range tests {

--- a/rdap_tools/rdap_query.go
+++ b/rdap_tools/rdap_query.go
@@ -77,9 +77,14 @@ func doRDAPRequest(ctx context.Context, client *http.Client, url string) (result
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+		// Read one byte past the limit so an oversized response is detected and
+		// rejected rather than silently truncated.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize+1))
 		if err != nil {
 			return "", err
+		}
+		if len(body) > maxResponseSize {
+			return "", fmt.Errorf("RDAP response from %s exceeds %d bytes", url, maxResponseSize)
 		}
 		return string(body), nil
 	case http.StatusNotFound:

--- a/utils/negative_cache.go
+++ b/utils/negative_cache.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// negativeCachePrefix marks a cache entry as a cached negative result. The
+// leading NUL byte cannot appear at the start of a real WHOIS/RDAP payload
+// (JSON starts with '{', WHOIS text with printable characters), so it is safe
+// to distinguish negative markers from genuine cached data.
+const negativeCachePrefix = "\x00neg:"
+
+// Negative result kinds, encoded after the prefix.
+const (
+	negNotFound = "notfound"
+	negDenied   = "denied"
+)
+
+// negativeKindForError maps an error to a negative cache kind. Only stable
+// "not found" / "denied" outcomes are cacheable; transient errors (network,
+// parse failures) return ok=false so they are retried on the next request.
+func negativeKindForError(err error) (kind string, ok bool) {
+	switch {
+	case errors.Is(err, ErrResourceNotFound), errors.Is(err, ErrDomainNotFound):
+		return negNotFound, true
+	case errors.Is(err, ErrQueryDenied):
+		return negDenied, true
+	default:
+		return "", false
+	}
+}
+
+// IsNegativeCacheHit reports whether cached data is a negative marker and, if
+// so, writes the corresponding HTTP error response. Callers use it on a cache
+// hit before treating the data as a real payload.
+func IsNegativeCacheHit(w http.ResponseWriter, data string) bool {
+	if !strings.HasPrefix(data, negativeCachePrefix) {
+		return false
+	}
+	switch strings.TrimPrefix(data, negativeCachePrefix) {
+	case negDenied:
+		HandleHTTPError(w, ErrorTypeForbidden, "The registry denied the query")
+	default:
+		HandleHTTPError(w, ErrorTypeNotFound, "Resource not found")
+	}
+	return true
+}
+
+// CacheNegativeResult stores a short-TTL negative marker for a cacheable
+// not-found / denied error, so repeated lookups of a missing resource do not
+// hammer upstream servers. Transient errors and non-positive TTLs are ignored.
+// Write failures are intentionally swallowed: negative caching is best-effort.
+func CacheNegativeResult(ctx context.Context, cache Cache, key string, err error, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	kind, ok := negativeKindForError(err)
+	if !ok {
+		return
+	}
+	_ = cache.Set(ctx, key, negativeCachePrefix+kind, ttl)
+}

--- a/utils/negative_cache_test.go
+++ b/utils/negative_cache_test.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNegativeKindForError(t *testing.T) {
+	tests := []struct {
+		err      error
+		wantKind string
+		wantOK   bool
+	}{
+		{ErrResourceNotFound, negNotFound, true},
+		{ErrDomainNotFound, negNotFound, true},
+		{ErrQueryDenied, negDenied, true},
+		{context.DeadlineExceeded, "", false},
+		{nil, "", false},
+	}
+	for _, tt := range tests {
+		kind, ok := negativeKindForError(tt.err)
+		if kind != tt.wantKind || ok != tt.wantOK {
+			t.Errorf("negativeKindForError(%v) = (%q, %v); want (%q, %v)", tt.err, kind, ok, tt.wantKind, tt.wantOK)
+		}
+	}
+}
+
+func TestCacheNegativeResultAndHit(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryCache(10, time.Minute)
+
+	// Transient error must not be cached.
+	CacheNegativeResult(ctx, cache, "k-transient", context.DeadlineExceeded, time.Minute)
+	if r, _ := cache.Get(ctx, "k-transient"); r.Found {
+		t.Error("transient error should not be cached")
+	}
+
+	// Non-positive TTL disables caching.
+	CacheNegativeResult(ctx, cache, "k-disabled", ErrResourceNotFound, 0)
+	if r, _ := cache.Get(ctx, "k-disabled"); r.Found {
+		t.Error("ttl<=0 should disable negative caching")
+	}
+
+	// Not-found is cached and recognised as a 404 negative hit.
+	CacheNegativeResult(ctx, cache, "k-nf", ErrResourceNotFound, time.Minute)
+	r, _ := cache.Get(ctx, "k-nf")
+	if !r.Found {
+		t.Fatal("expected negative marker to be cached")
+	}
+	w := httptest.NewRecorder()
+	if !IsNegativeCacheHit(w, r.Data) {
+		t.Fatal("expected IsNegativeCacheHit to recognise the marker")
+	}
+	if w.Code != 404 {
+		t.Errorf("expected 404 for not-found marker, got %d", w.Code)
+	}
+
+	// Denied is cached and recognised as a 403 negative hit.
+	CacheNegativeResult(ctx, cache, "k-denied", ErrQueryDenied, time.Minute)
+	r, _ = cache.Get(ctx, "k-denied")
+	w = httptest.NewRecorder()
+	if !IsNegativeCacheHit(w, r.Data) {
+		t.Fatal("expected denied marker to be recognised")
+	}
+	if w.Code != 403 {
+		t.Errorf("expected 403 for denied marker, got %d", w.Code)
+	}
+}
+
+func TestIsNegativeCacheHit_RealData(t *testing.T) {
+	w := httptest.NewRecorder()
+	if IsNegativeCacheHit(w, `{"Domain Name":"example.com"}`) {
+		t.Error("real JSON payload must not be treated as a negative hit")
+	}
+	if IsNegativeCacheHit(w, "Domain Name: example.com\n") {
+		t.Error("real WHOIS text must not be treated as a negative hit")
+	}
+}

--- a/whois_tools/whois_query.go
+++ b/whois_tools/whois_query.go
@@ -52,9 +52,14 @@ func Whois(ctx context.Context, domain, tld string) (result string, err error) {
 		return "", err
 	}
 
-	body, err := io.ReadAll(io.LimitReader(conn, maxResponseSize))
+	// Read one byte past the limit so an oversized response is detected and
+	// rejected rather than silently truncated and cached as if complete.
+	body, err := io.ReadAll(io.LimitReader(conn, maxResponseSize+1))
 	if err != nil {
 		return "", err
+	}
+	if len(body) > maxResponseSize {
+		return "", fmt.Errorf("WHOIS response from %s exceeds %d bytes", whoisServer, maxResponseSize)
 	}
 
 	return string(body), nil

--- a/whois_tools/whois_query_test.go
+++ b/whois_tools/whois_query_test.go
@@ -3,6 +3,7 @@ package whois_tools
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/KincaidYang/whois/server_lists"
@@ -60,6 +61,23 @@ func TestWhois(t *testing.T) {
 
 	if result != mockResponse {
 		t.Errorf("Expected response %q, got %q", mockResponse, result)
+	}
+}
+
+func TestWhoisOversizeResponse(t *testing.T) {
+	// A response just over the cap must be rejected, not truncated and returned.
+	oversized := strings.Repeat("a", maxResponseSize+10)
+	mockServerAddr, cleanup := startMockWhoisServer(oversized)
+	defer cleanup()
+
+	server_lists.TLDToWhoisServer = map[string]string{"com": mockServerAddr}
+
+	_, err := Whois(context.Background(), "example.com", "com")
+	if err == nil {
+		t.Fatal("expected an error for oversized WHOIS response, got none")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected size-limit error, got %q", err.Error())
 	}
 }
 


### PR DESCRIPTION
## 概述
新增 negative caching，并修复 PR #8 上 codex review 指出的两处 P2 问题，附带 README 文档修正。

## 改动
**Negative caching**
- 将“未找到/被拒”的稳定结果用短 TTL（默认 60s）缓存，避免对不存在的资源反复打上游；瞬时错误（网络、解析）不缓存
- `utils/negative_cache.go`：NUL 前缀哨兵标记 + 错误映射（基于现有 sentinel + errors.Is）+ 读取拦截 `IsNegativeCacheHit` + 尽力写入 `CacheNegativeResult`
- domain / ip / asn 三个 handler 接入读写路径
- 配置项 `cache.negativecacheexpiration`（默认 60；负数禁用）+ 环境变量 `WHOIS_NEGATIVE_CACHE_EXPIRATION`，两个 config.yaml 同步

**修复 PR #8 review（codex P2）**
- `isDomain` 现接受 punycode TLD（`xn--...`），使 `例子.中国` 这类完全国际化域名也能识别，而不只是 ASCII 后缀下的 IDN 标签
- WHOIS / RDAP 读取改为读到上限 +1 字节并在超限时报错，避免静默截断后把残缺数据当完整结果缓存/返回

**文档**
- 修正 README 配置示例：yaml.v3 键名区分大小写，原先的混合大小写示例会静默回退默认值——改为全小写键
- 补充 negative cache / LRU / 环境变量覆盖 / IDN 输入说明，刷新依赖列表（yaml.v3、prometheus、mcp sdk）

## 测试
新增 negative cache 单测与 handler 404 命中测试、IDN-TLD 用例、超长 WHOIS 响应拒绝测试。`gofmt`/`go vet`/`go build`/`go test -race ./...` 全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)