### PR TITLE
feat!: v2 API response format (RFC 9083) + RFC 9457 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+- **API response format rewritten to align with RDAP (RFC 9083).** All field
+  names are now camelCase and follow RDAP vocabulary. Every successful
+  response carries an `objectClassName` discriminator (`domain` /
+  `ip network` / `autnum`). Field mapping:
+
+  | Old (domain) | New |
+  |---|---|
+  | `Domain Name` | `ldhName` (lowercase; `unicodeName` added for IDNs) |
+  | `Registrar` | `registrar` |
+  | `Registrar IANA ID` | `registrarIanaId` |
+  | `Domain Status` | `status` (ICANN EPP reference URLs stripped, deduped) |
+  | `Creation Date` | `registrationDate` |
+  | `Registry Expiry Date` | `expirationDate` |
+  | `Updated Date` | `lastChangedDate` |
+  | `Name Server` | `nameservers` (lowercase) |
+  | `DNSSEC` + `DNSSEC DS Data` | `secureDNS` object: `{delegationSigned, dsData: [{keyTag, algorithm, digestType, digest}]}` |
+  | `Last Update of Database` | `lastUpdateOfRdapDb` |
+
+  | Old (IP network) | New |
+  |---|---|
+  | `IP Network` | `handle` |
+  | `Address Range` | `startAddress` + `endAddress` (split) |
+  | `Network Name` | `name` |
+  | `CIDR` | `cidr` |
+  | `Network Type` | `type` (empty instead of `"Unknown"` filler) |
+  | `Country` | `country` |
+  | `Status` | `status` |
+  | `Creation Date` | `registrationDate` |
+  | `Updated Date` | `lastChangedDate` |
+  | `Remarks` | `remarks` |
+
+  | Old (ASN) | New |
+  |---|---|
+  | `AS Number` | `handle` |
+  | `Network Name` | `name` |
+  | `Status` | `status` |
+  | `Creation Date` | `registrationDate` |
+  | `Updated Date` | `lastChangedDate` |
+
+- **Dates normalized to RFC 3339 UTC** across all sources (RDAP and the
+  built-in ccTLD WHOIS parsers). Registry-local timestamps (.cn/.tw/.mo/.sg
+  UTC+8, .jp UTC+9) are converted to UTC. Date-only values stay `YYYY-MM-DD`.
+- **Errors are now RFC 9457 Problem Details** (`application/problem+json`)
+  with `{type, title, status, detail}`; the `type` URI points to an anchor in
+  [docs/errors.md](docs/errors.md). The old `{"error": ...}` shape is gone.
+- **Domains whose TLD has no parser now return JSON**
+  (`{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`)
+  instead of `text/plain`. Only `?raw=1` returns plain text.
+- Cache keys moved from `whois:` to `whois:v2:`; existing cache entries are
+  abandoned (no migration needed, they expire naturally).
+
 ### Changed
 - All Go packages moved under `internal/` and renamed to idiomatic Go names
   (`handle_resources`→`handlers`, `server_lists`→`serverlist`,

--- a/README.md
+++ b/README.md
@@ -301,9 +301,8 @@ curl http://localhost:8043/205794
 ```json
 {
   "type": "https://github.com/KincaidYang/whois/blob/main/docs/errors.md#not-found",
-  "title": "Resource Not Found",
-  "status": 404,
-  "detail": "the queried resource was not found in the registry"
+  "title": "Resource not found",
+  "status": 404
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -155,26 +155,38 @@ curl http://localhost:8043/example.com
 返回结果
 ```json
 {
-    "Domain Name": "EXAMPLE.COM",
-    "Registrar": "RESERVED-Internet Assigned Numbers Authority",
-    "Registrar IANA ID": "376",
-    "Domain Status": [
-        "client delete prohibited",
-        "client transfer prohibited",
-        "client update prohibited"
-    ],
-    "Creation Date": "1995-08-14T04:00:00Z",
-    "Registry Expiry Date": "2024-08-13T04:00:00Z",
-    "Updated Date": "2023-08-14T07:01:38Z",
-    "Name Server": [
-        "A.IANA-SERVERS.NET",
-        "B.IANA-SERVERS.NET"
-    ],
-    "DNSSEC": "signedDelegation",
-    "DNSSEC DS Data": "370 13 2 BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C",
-    "Last Update of Database": "2024-01-16T10:26:40Z"
+  "objectClassName": "domain",
+  "ldhName": "example.com",
+  "registrar": "RESERVED-Internet Assigned Numbers Authority",
+  "registrarIanaId": "376",
+  "status": [
+    "client delete prohibited",
+    "client transfer prohibited",
+    "client update prohibited"
+  ],
+  "registrationDate": "1995-08-14T04:00:00Z",
+  "expirationDate": "2026-08-13T04:00:00Z",
+  "lastChangedDate": "2025-08-14T07:01:34Z",
+  "nameservers": [
+    "a.iana-servers.net",
+    "b.iana-servers.net"
+  ],
+  "secureDNS": {
+    "delegationSigned": true,
+    "dsData": [
+      {
+        "keyTag": 370,
+        "algorithm": 13,
+        "digestType": 2,
+        "digest": "BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C"
+      }
+    ]
+  },
+  "lastUpdateOfRdapDb": "2026-01-16T10:26:40Z"
 }
 ```
+
+字段名与词汇遵循 [RDAP（RFC 9083）](https://www.rfc-editor.org/rfc/rfc9083)规范：`objectClassName` 标识对象类型（`domain` / `ip network` / `autnum`），日期统一为 RFC 3339 UTC 格式。查询 IDN 域名时会额外返回 `unicodeName` 字段。对于无法解析的 ccTLD，返回 `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`。
 
 #### 查询域名原始 WHOIS 文本
 添加 `?raw=1` 参数可获取未解析的 WHOIS 原文（`text/plain`），仅支持域名查询（IP/ASN 走 RDAP，无原文形式）。原文查询直接访问 WHOIS 服务器（跳过 RDAP），若该 TLD 没有已知 WHOIS 服务器则返回 404。
@@ -193,18 +205,20 @@ curl http://localhost:8043/1.12.34.56
 返回结果
 ```json
 {
-  "IP Network": "1.12.0.0 - 1.15.255.255",
-  "Address Range": "1.12.0.0 - 1.15.255.255",
-  "Network Name": "TencentCloud",
-  "CIDR": "1.12.0.0/14",
-  "Network Type": "ALLOCATED PORTABLE",
-  "Country": "CN",
-  "Status": [
+  "objectClassName": "ip network",
+  "handle": "1.12.0.0 - 1.15.255.255",
+  "startAddress": "1.12.0.0",
+  "endAddress": "1.15.255.255",
+  "cidr": "1.12.0.0/14",
+  "name": "TencentCloud",
+  "type": "ALLOCATED PORTABLE",
+  "country": "CN",
+  "status": [
     "active"
   ],
-  "Creation Date": "2010-05-10T22:46:58Z",
-  "Updated Date": "2023-11-28T00:51:33Z",
-  "Remarks": [
+  "registrationDate": "2010-05-10T22:46:58Z",
+  "lastChangedDate": "2023-11-28T00:51:33Z",
+  "remarks": [
     {
       "title": "description",
       "description": [
@@ -224,18 +238,20 @@ curl http://localhost:8043/2402:4e00::
 返回结果
 ```json
 {
-  "IP Network": "2402:4e00::/32",
-  "Address Range": "2402:4e00:: - 2402:4e00:ffff:ffff:ffff:ffff:ffff:ffff",
-  "Network Name": "TencentCloud",
-  "CIDR": "2402:4e00::/32",
-  "Network Type": "ALLOCATED PORTABLE",
-  "Country": "CN",
-  "Status": [
+  "objectClassName": "ip network",
+  "handle": "2402:4e00::/32",
+  "startAddress": "2402:4e00::",
+  "endAddress": "2402:4e00:ffff:ffff:ffff:ffff:ffff:ffff",
+  "cidr": "2402:4e00::/32",
+  "name": "TencentCloud",
+  "type": "ALLOCATED PORTABLE",
+  "country": "CN",
+  "status": [
     "active"
   ],
-  "Creation Date": "2010-05-12T23:13:32Z",
-  "Updated Date": "2024-01-31T06:27:10Z",
-  "Remarks": [
+  "registrationDate": "2010-05-12T23:13:32Z",
+  "lastChangedDate": "2024-01-31T06:27:10Z",
+  "remarks": [
     {
       "title": "description",
       "description": [
@@ -258,13 +274,14 @@ curl http://localhost:8043/205794
 返回结果
 ```json
 {
-  "AS Number": "AS205794",
-  "Network Name": "RTTW-AS",
-  "Status": [
+  "objectClassName": "autnum",
+  "handle": "AS205794",
+  "name": "RTTW-AS",
+  "status": [
     "active"
   ],
-  "Creation Date": "2022-04-14T12:24:55Z",
-  "Updated Date": "2024-03-21T07:27:44Z",
+  "registrationDate": "2022-04-14T12:24:55Z",
+  "lastChangedDate": "2024-03-21T07:27:44Z",
   "remarks": [
     {
       "title": "",
@@ -277,6 +294,20 @@ curl http://localhost:8043/205794
   ]
 }
 ```
+
+#### 错误响应
+错误响应遵循 [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) 规范，`Content-Type` 为 `application/problem+json`：
+
+```json
+{
+  "type": "https://github.com/KincaidYang/whois/blob/main/docs/errors.md#not-found",
+  "title": "Resource Not Found",
+  "status": 404,
+  "detail": "the queried resource was not found in the registry"
+}
+```
+
+全部错误类型见 [docs/errors.md](docs/errors.md)。
 
 ### MCP 集成
 
@@ -294,9 +325,7 @@ curl http://localhost:8043/205794
 **MCP 服务器地址：** `http://ip:端口/mcp`
 
 ## 已知问题
-程序向注册局查询 Whois 信息主要依靠 RDAP 协议查询，但由于大部分 ccTLD 不支持 RDAP 协议，程序会对其原始的 Whois 信息格式化后返回 JSON 数据，但由于本人精力有限，未对所有的 ccTLD 后缀进行适配，程序可能会直接返回 `text` 数据，如您常用的后缀没用被覆盖，可以提交 Issue 或者贡献匹配规则至 `whois_parsers.go` 文件中，在此表示感谢！
-
-您可根据`content-type`来判断返回数据格式。
+程序向注册局查询 Whois 信息主要依靠 RDAP 协议查询，但由于大部分 ccTLD 不支持 RDAP 协议，程序会对其原始的 Whois 信息格式化后返回 JSON 数据。由于本人精力有限，未对所有的 ccTLD 后缀进行适配，未适配的后缀会返回 `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`，如您常用的后缀没有被覆盖，可以提交 Issue 或者贡献匹配规则至 `internal/whois/whois_parsers.go` 文件中，在此表示感谢！
 
 ## 项目依赖
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -289,9 +289,8 @@ Error responses follow [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc
 ```json
 {
   "type": "https://github.com/KincaidYang/whois/blob/main/docs/errors.md#not-found",
-  "title": "Resource Not Found",
-  "status": 404,
-  "detail": "the queried resource was not found in the registry"
+  "title": "Resource not found",
+  "status": 404
 }
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -159,26 +159,38 @@ curl http://localhost:8043/example.com
 Response:
 ```json
 {
-    "Domain Name": "EXAMPLE.COM",
-    "Registrar": "RESERVED-Internet Assigned Numbers Authority",
-    "Registrar IANA ID": "376",
-    "Domain Status": [
-        "client delete prohibited",
-        "client transfer prohibited",
-        "client update prohibited"
-    ],
-    "Creation Date": "1995-08-14T04:00:00Z",
-    "Registry Expiry Date": "2024-08-13T04:00:00Z",
-    "Updated Date": "2023-08-14T07:01:38Z",
-    "Name Server": [
-        "A.IANA-SERVERS.NET",
-        "B.IANA-SERVERS.NET"
-    ],
-    "DNSSEC": "signedDelegation",
-    "DNSSEC DS Data": "370 13 2 BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C",
-    "Last Update of Database": "2024-01-16T10:26:40Z"
+  "objectClassName": "domain",
+  "ldhName": "example.com",
+  "registrar": "RESERVED-Internet Assigned Numbers Authority",
+  "registrarIanaId": "376",
+  "status": [
+    "client delete prohibited",
+    "client transfer prohibited",
+    "client update prohibited"
+  ],
+  "registrationDate": "1995-08-14T04:00:00Z",
+  "expirationDate": "2026-08-13T04:00:00Z",
+  "lastChangedDate": "2025-08-14T07:01:34Z",
+  "nameservers": [
+    "a.iana-servers.net",
+    "b.iana-servers.net"
+  ],
+  "secureDNS": {
+    "delegationSigned": true,
+    "dsData": [
+      {
+        "keyTag": 370,
+        "algorithm": 13,
+        "digestType": 2,
+        "digest": "BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C"
+      }
+    ]
+  },
+  "lastUpdateOfRdapDb": "2026-01-16T10:26:40Z"
 }
 ```
+
+Field names and vocabulary follow [RDAP (RFC 9083)](https://www.rfc-editor.org/rfc/rfc9083): `objectClassName` identifies the object type (`domain` / `ip network` / `autnum`), and dates are normalized to RFC 3339 UTC. IDN domains additionally include a `unicodeName` field. For ccTLDs without a parser, the response is `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`.
 
 #### Query Raw WHOIS Text for a Domain
 
@@ -201,15 +213,17 @@ curl http://localhost:8043/1.12.34.56
 Response:
 ```json
 {
-  "IP Network": "1.12.0.0 - 1.15.255.255",
-  "Address Range": "1.12.0.0 - 1.15.255.255",
-  "Network Name": "TencentCloud",
-  "CIDR": "1.12.0.0/14",
-  "Network Type": "ALLOCATED PORTABLE",
-  "Country": "CN",
-  "Status": ["active"],
-  "Creation Date": "2010-05-10T22:46:58Z",
-  "Updated Date": "2023-11-28T00:51:33Z"
+  "objectClassName": "ip network",
+  "handle": "1.12.0.0 - 1.15.255.255",
+  "startAddress": "1.12.0.0",
+  "endAddress": "1.15.255.255",
+  "cidr": "1.12.0.0/14",
+  "name": "TencentCloud",
+  "type": "ALLOCATED PORTABLE",
+  "country": "CN",
+  "status": ["active"],
+  "registrationDate": "2010-05-10T22:46:58Z",
+  "lastChangedDate": "2023-11-28T00:51:33Z"
 }
 ```
 
@@ -222,15 +236,17 @@ curl http://localhost:8043/2402:4e00::
 Response:
 ```json
 {
-  "IP Network": "2402:4e00::/32",
-  "Address Range": "2402:4e00:: - 2402:4e00:ffff:ffff:ffff:ffff:ffff:ffff",
-  "Network Name": "TencentCloud",
-  "CIDR": "2402:4e00::/32",
-  "Network Type": "ALLOCATED PORTABLE",
-  "Country": "CN",
-  "Status": ["active"],
-  "Creation Date": "2010-05-12T23:13:32Z",
-  "Updated Date": "2024-01-31T06:27:10Z"
+  "objectClassName": "ip network",
+  "handle": "2402:4e00::/32",
+  "startAddress": "2402:4e00::",
+  "endAddress": "2402:4e00:ffff:ffff:ffff:ffff:ffff:ffff",
+  "cidr": "2402:4e00::/32",
+  "name": "TencentCloud",
+  "type": "ALLOCATED PORTABLE",
+  "country": "CN",
+  "status": ["active"],
+  "registrationDate": "2010-05-12T23:13:32Z",
+  "lastChangedDate": "2024-01-31T06:27:10Z"
 }
 ```
 
@@ -247,11 +263,12 @@ curl http://localhost:8043/205794
 Response:
 ```json
 {
-  "AS Number": "AS205794",
-  "Network Name": "RTTW-AS",
-  "Status": ["active"],
-  "Creation Date": "2022-04-14T12:24:55Z",
-  "Updated Date": "2024-03-21T07:27:44Z",
+  "objectClassName": "autnum",
+  "handle": "AS205794",
+  "name": "RTTW-AS",
+  "status": ["active"],
+  "registrationDate": "2022-04-14T12:24:55Z",
+  "lastChangedDate": "2024-03-21T07:27:44Z",
   "remarks": [
     {
       "title": "",
@@ -264,6 +281,21 @@ Response:
   ]
 }
 ```
+
+#### Error Responses
+
+Error responses follow [RFC 9457 Problem Details](https://www.rfc-editor.org/rfc/rfc9457) with `Content-Type: application/problem+json`:
+
+```json
+{
+  "type": "https://github.com/KincaidYang/whois/blob/main/docs/errors.md#not-found",
+  "title": "Resource Not Found",
+  "status": 404,
+  "detail": "the queried resource was not found in the registry"
+}
+```
+
+See [docs/errors.md](docs/errors.md) for the full list of problem types.
 
 ### MCP Integration
 
@@ -282,9 +314,7 @@ Accepts a domain name, IPv4/v6 address, or ASN (e.g. `AS12345`). Returns the sam
 
 ## Known Issues
 
-The program queries WHOIS information from registries primarily using the RDAP protocol. However, since most ccTLDs do not support RDAP, the program will format and return the original WHOIS information as JSON data. Due to limited resources, not all ccTLD suffixes have been adapted, and the program may directly return `text` data. If your commonly used suffix is not covered, please submit an Issue or contribute matching rules to the `whois_parsers.go` file. Thank you!
-
-You can determine the response data format by checking the `content-type` header.
+The program queries WHOIS information from registries primarily using the RDAP protocol. However, since most ccTLDs do not support RDAP, the program will format and return the original WHOIS information as JSON data. Due to limited resources, not all ccTLD suffixes have been adapted; unadapted suffixes return `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`. If your commonly used suffix is not covered, please submit an Issue or contribute matching rules to `internal/whois/whois_parsers.go`. Thank you!
 
 ## Dependencies
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,49 @@
+# Error Types
+
+Error responses follow [RFC 9457 (Problem Details for HTTP APIs)](https://www.rfc-editor.org/rfc/rfc9457)
+and are served with `Content-Type: application/problem+json`:
+
+```json
+{
+  "type": "https://github.com/KincaidYang/whois/blob/main/docs/errors.md#not-found",
+  "title": "Resource not found",
+  "status": 404
+}
+```
+
+`type` and `title` are stable identifiers you can switch on; `detail`, when
+present, is human-readable context that may change between releases.
+
+## not-found
+
+**Status: 404.** The domain, IP network, or ASN is not registered, or the
+registry returned no data for it. Not-found results are negatively cached for
+a short time (`cache.negativecacheexpiration`, default 60s).
+
+## query-denied
+
+**Status: 403.** The upstream registry refused to answer the query (some
+registries deny queries from data centers or rate-limit by source). Denied
+results are negatively cached like not-found.
+
+## bad-request
+
+**Status: 400.** The input is not a valid domain, IP address, or ASN — or a
+query parameter combination is unsupported (e.g. `?raw=1` on an IP/ASN query,
+which has no raw WHOIS form).
+
+## rate-limited
+
+**Status: 429.** The server's concurrent-request limit (`ratelimit` in
+config) was reached. Retry after a short delay.
+
+## query-failed
+
+**Status: 500.** The upstream WHOIS/RDAP query failed (network error, upstream
+timeout, malformed upstream response). Transient — retrying later usually
+succeeds. Details are logged server-side with the request's `X-Request-ID`.
+
+## internal-error
+
+**Status: 500.** An unexpected server-side error (cache backend failure and
+similar). Details are logged server-side with the request's `X-Request-ID`.

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -18,6 +18,31 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
+// CacheKeyPrefix namespaces all cache entries. The version segment is bumped
+// whenever the response format changes, so entries cached by an older release
+// are never served in the old format after an upgrade.
+const CacheKeyPrefix = "whois:v2:"
+
+// finalizeDomainInfo fills the fields shared by every domain response that
+// the parsers cannot know themselves: the Unicode form of the name (IDN) and
+// non-nil slices so the JSON contains [] instead of null.
+func finalizeDomainInfo(info *model.DomainInfo, domain string) {
+	if info.LdhName == "" {
+		info.LdhName = domain
+	}
+	if info.UnicodeName == "" {
+		if u, err := idna.ToUnicode(info.LdhName); err == nil {
+			info.UnicodeName = u
+		}
+	}
+	if info.Status == nil {
+		info.Status = []string{}
+	}
+	if info.Nameservers == nil {
+		info.Nameservers = []string{}
+	}
+}
+
 // whoisParsers is a map from top-level domain (TLD) to a function that can parse
 // the WHOIS response for that TLD into a DomainInfo structure.
 // Currently, it includes parsers for the following TLDs: cn, xn--fiqs8s, xn--fiqz9s,
@@ -147,6 +172,7 @@ func queryRDAPDomain(ctx context.Context, domain, tld, key string) (queryOutcome
 	if err != nil {
 		return queryOutcome{}, err
 	}
+	finalizeDomainInfo(&domainInfo, domain)
 
 	resultBytes, err := json.Marshal(domainInfo)
 	if err != nil {
@@ -185,11 +211,24 @@ func queryWhoisDomain(ctx context.Context, domain, tld, key string) (queryOutcom
 
 	parseFunc, ok := whoisParsers[tld]
 	if !ok {
-		// If there's no available parsing rule, return the original WHOIS data as text/plain
-		if err := utils.SetToCache(ctx, config.CacheManager, key, queryResult, config.CacheExpiration); err != nil {
+		// No parser for this TLD: wrap the raw WHOIS text in the regular JSON
+		// object (unparsed=true) so the endpoint's content type stays stable.
+		// Clients that want the bare text use ?raw=1.
+		info := model.DomainInfo{
+			ObjectClassName: model.ObjectClassDomain,
+			Unparsed:        true,
+			RawText:         queryResult,
+		}
+		finalizeDomainInfo(&info, domain)
+		resultBytes, err := json.Marshal(info)
+		if err != nil {
+			return queryOutcome{}, err
+		}
+		result := string(resultBytes)
+		if err := utils.SetToCache(ctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
 			slog.WarnContext(ctx, "cache write error", "key", key, "err", err)
 		}
-		return queryOutcome{body: queryResult, contentType: "text/plain; charset=utf-8"}, nil
+		return queryOutcome{body: result, contentType: "application/json"}, nil
 	}
 
 	var domainInfo model.DomainInfo
@@ -198,6 +237,7 @@ func queryWhoisDomain(ctx context.Context, domain, tld, key string) (queryOutcom
 		// "resource not found" or other parsing error during the WHOIS parsing
 		return queryOutcome{}, err
 	}
+	finalizeDomainInfo(&domainInfo, domain)
 
 	resultBytes, err := json.Marshal(domainInfo)
 	if err != nil {

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -67,7 +67,7 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	query := strings.TrimSpace(strings.ToLower(input.Query))
 
 	rc := newResponseCapture()
-	const cacheKeyPrefix = "whois:"
+	const cacheKeyPrefix = handlers.CacheKeyPrefix
 
 	if net.ParseIP(query) != nil {
 		handlers.HandleIP(ctx, rc, query, cacheKeyPrefix)

--- a/internal/model/asn.go
+++ b/internal/model/asn.go
@@ -1,11 +1,13 @@
 package model
 
-// ASNInfo represents the information about an Autonomous System Number (ASN).
+// ASNInfo is the API representation of an autonomous system number. Field
+// names follow the RDAP autnum object (RFC 9083 section 5.5).
 type ASNInfo struct {
-	ASN          string   `json:"AS Number"`     // ASN is the Autonomous System Number.
-	ASName       string   `json:"Network Name"`  // ASName is the name of the network.
-	ASStatus     []string `json:"Status"`        // ASStatus is the status of the ASN.
-	CreationDate string   `json:"Creation Date"` // CreationDate is the creation date of the ASN.
-	UpdatedDate  string   `json:"Updated Date"`  // UpdatedDate is the updated date of the ASN.
-	Remarks      []Remark `json:"Remarks"`       // Remarks contains additional information about the ASN.
+	ObjectClassName  string   `json:"objectClassName"` // always ObjectClassAutnum
+	Handle           string   `json:"handle"`
+	Name             string   `json:"name,omitempty"`
+	Status           []string `json:"status"`
+	RegistrationDate string   `json:"registrationDate,omitempty"`
+	LastChangedDate  string   `json:"lastChangedDate,omitempty"`
+	Remarks          []Remark `json:"remarks,omitempty"`
 }

--- a/internal/model/domain.go
+++ b/internal/model/domain.go
@@ -1,16 +1,46 @@
 package model
 
-// DomainInfo represents the information about a domain.
+// RDAP object class names (RFC 9083 section 4.7) used as the
+// objectClassName discriminator on responses.
+const (
+	ObjectClassDomain    = "domain"
+	ObjectClassIPNetwork = "ip network"
+	ObjectClassAutnum    = "autnum"
+)
+
+// DSData is a DNSSEC delegation signer record (RFC 9083 section 5.3).
+type DSData struct {
+	KeyTag     int    `json:"keyTag"`
+	Algorithm  int    `json:"algorithm"`
+	DigestType int    `json:"digestType"`
+	Digest     string `json:"digest"`
+}
+
+// SecureDNS describes the DNSSEC state of a domain (RFC 9083 section 5.3).
+type SecureDNS struct {
+	DelegationSigned bool     `json:"delegationSigned"`
+	DSData           []DSData `json:"dsData,omitempty"`
+}
+
+// DomainInfo is the API representation of a domain. Field names follow the
+// RDAP JSON vocabulary (RFC 9083); dates are RFC 3339 UTC (date-only when the
+// registry provides no time of day).
 type DomainInfo struct {
-	DomainName         string   `json:"Domain Name"`             // DomainName is the name of the domain.
-	Registrar          string   `json:"Registrar"`               // Registrar is the registrar of the domain.
-	RegistrarIANAID    string   `json:"Registrar IANA ID"`       // RegistrarIANAID is the IANA ID of the registrar.
-	DomainStatus       []string `json:"Domain Status"`           // DomainStatus is the status of the domain.
-	CreationDate       string   `json:"Creation Date"`           // CreationDate is the creation date of the domain.
-	RegistryExpiryDate string   `json:"Registry Expiry Date"`    // RegistryExpiryDate is the expiry date of the domain.
-	UpdatedDate        string   `json:"Updated Date"`            // UpdatedDate is the updated date of the domain.
-	NameServer         []string `json:"Name Server"`             // NameServer is the name server of the domain.
-	DNSSec             string   `json:"DNSSEC"`                  // DNSSec is the DNSSEC of the domain.
-	DNSSecDSData       []string `json:"DNSSEC DS Data"`          // DNSSecDSData is the DNSSEC DS Data of the domain.
-	LastUpdateOfRDAPDB string   `json:"Last Update of Database"` // LastUpdateOfRDAPDB is the last update of the database.
+	ObjectClassName    string     `json:"objectClassName"` // always ObjectClassDomain
+	LdhName            string     `json:"ldhName"`
+	UnicodeName        string     `json:"unicodeName,omitempty"`
+	Registrar          string     `json:"registrar,omitempty"`
+	RegistrarIANAID    string     `json:"registrarIanaId,omitempty"`
+	Status             []string   `json:"status"`
+	RegistrationDate   string     `json:"registrationDate,omitempty"`
+	ExpirationDate     string     `json:"expirationDate,omitempty"`
+	LastChangedDate    string     `json:"lastChangedDate,omitempty"`
+	Nameservers        []string   `json:"nameservers"`
+	SecureDNS          *SecureDNS `json:"secureDNS,omitempty"`
+	LastUpdateOfRdapDb string     `json:"lastUpdateOfRdapDb,omitempty"`
+
+	// Unparsed and RawText are set when no parser exists for the TLD: the
+	// registry's WHOIS text is returned verbatim instead of parsed fields.
+	Unparsed bool   `json:"unparsed,omitempty"`
+	RawText  string `json:"rawText,omitempty"`
 }

--- a/internal/model/ip.go
+++ b/internal/model/ip.go
@@ -1,21 +1,24 @@
 package model
 
-// IPInfo represents the information about an IP network.
+// IPInfo is the API representation of an IP network. Field names follow the
+// RDAP ip network object (RFC 9083 section 5.4).
 type IPInfo struct {
-	IP           string   `json:"IP Network"`    // IP is the IP network.
-	Range        string   `json:"Address Range"` // Range is the address range of the IP network.
-	NetName      string   `json:"Network Name"`  // NetName is the name of the network.
-	CIDR         string   `json:"CIDR"`          // CIDR is the CIDR of the IP network.
-	Networktype  string   `json:"Network Type"`  // Networktype is the type of the network.
-	Country      string   `json:"Country"`       // Country is the country of the IP network.
-	IPStatus     []string `json:"Status"`        // IPStatus is the status of the IP network.
-	CreationDate string   `json:"Creation Date"` // CreationDate is the creation date of the IP network.
-	UpdatedDate  string   `json:"Updated Date"`  // UpdatedDate is the updated date of the IP network.
-	Remarks      []Remark `json:"Remarks"`       // Remarks contains additional information about the IP network.
+	ObjectClassName  string   `json:"objectClassName"` // always ObjectClassIPNetwork
+	Handle           string   `json:"handle"`
+	StartAddress     string   `json:"startAddress,omitempty"`
+	EndAddress       string   `json:"endAddress,omitempty"`
+	CIDR             string   `json:"cidr,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	Country          string   `json:"country,omitempty"`
+	Status           []string `json:"status"`
+	RegistrationDate string   `json:"registrationDate,omitempty"`
+	LastChangedDate  string   `json:"lastChangedDate,omitempty"`
+	Remarks          []Remark `json:"remarks,omitempty"`
 }
 
-// Remark represents a single remark entry.
+// Remark is additional registry-provided information (RFC 9083 section 4.3).
 type Remark struct {
-	Title       string   `json:"title"`       // Title is the title of the remark.
-	Description []string `json:"description"` // Description contains the details of the remark.
+	Title       string   `json:"title"`
+	Description []string `json:"description"`
 }

--- a/internal/model/normalize.go
+++ b/internal/model/normalize.go
@@ -1,0 +1,81 @@
+package model
+
+import (
+	"strings"
+	"time"
+)
+
+// dateTimeLayouts are registry date layouts that include a time of day.
+// Layouts without a zone are interpreted in the location passed to
+// NormalizeDate.
+var dateTimeLayouts = []string{
+	time.RFC3339, // also accepts fractional seconds
+	"2006-01-02 15:04:05",
+	"2006-01-02 15:04",
+	"2006/01/02 15:04:05", // .jp
+}
+
+// dateOnlyLayouts are registry date layouts with no time of day. They are
+// normalized to RFC 3339 full-date (YYYY-MM-DD) without inventing a time,
+// since shifting a bare date into UTC could move it across midnight.
+var dateOnlyLayouts = []string{
+	"2006-01-02",
+	"02-01-2006", // .hk
+	"2006/01/02", // .jp
+	"02-Jan-2006",
+}
+
+// NormalizeDate parses a registry-provided date string and returns it as
+// RFC 3339 UTC, or as RFC 3339 full-date (YYYY-MM-DD) when the registry
+// provides no time of day. loc is the zone assumed for layouts that carry no
+// offset (use time.UTC when the registry documents UTC). The empty string is
+// returned unchanged; an unrecognized format returns ok=false with the
+// original string so callers can decide whether to keep or drop it.
+func NormalizeDate(s string, loc *time.Location) (string, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", true
+	}
+	if loc == nil {
+		loc = time.UTC
+	}
+	for _, layout := range dateTimeLayouts {
+		if t, err := time.ParseInLocation(layout, s, loc); err == nil {
+			return t.UTC().Format(time.RFC3339), true
+		}
+	}
+	for _, layout := range dateOnlyLayouts {
+		if t, err := time.ParseInLocation(layout, s, loc); err == nil {
+			return t.Format("2006-01-02"), true
+		}
+	}
+	return s, false
+}
+
+// CleanStatus normalizes registry status values: some registries append the
+// ICANN EPP reference URL after the value ("ok https://icann.org/epp#ok");
+// the URL is presentation noise and is stripped. Duplicates are removed,
+// order is preserved.
+func CleanStatus(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+	out := make([]string, 0, len(in))
+	seen := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if value, url, found := strings.Cut(s, " "); found &&
+			(strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "(http")) {
+			s = value
+		}
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/model/normalize_test.go
+++ b/internal/model/normalize_test.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNormalizeDate(t *testing.T) {
+	cst := time.FixedZone("CST", 8*3600)
+	tests := []struct {
+		in   string
+		loc  *time.Location
+		want string
+		ok   bool
+	}{
+		{"", nil, "", true},
+		{"2026-03-01T12:00:00Z", time.UTC, "2026-03-01T12:00:00Z", true},
+		{"2026-03-01T12:00:00.0Z", time.UTC, "2026-03-01T12:00:00Z", true},                   // fractional dropped
+		{"2026-03-01T12:00:00+08:00", time.UTC, "2026-03-01T04:00:00Z", true},                // offset honored
+		{"2026-03-01 12:00:00", cst, "2026-03-01T04:00:00Z", true},                           // zone-less in CST
+		{"2026-03-01", nil, "2026-03-01", true},                                              // date-only stays date-only
+		{"01-03-2026", nil, "2026-03-01", true},                                              // .hk DD-MM-YYYY
+		{"2026/03/01", nil, "2026-03-01", true},                                              // .jp
+		{"2026/03/01 09:00:00", time.FixedZone("JST", 9*3600), "2026-03-01T00:00:00Z", true}, // .jp datetime
+		{"not a date", nil, "not a date", false},                                             // passthrough
+	}
+	for _, tt := range tests {
+		got, ok := NormalizeDate(tt.in, tt.loc)
+		if got != tt.want || ok != tt.ok {
+			t.Errorf("NormalizeDate(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.ok)
+		}
+	}
+}
+
+func TestCleanStatus(t *testing.T) {
+	in := []string{
+		"clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+		"ok (https://www.icann.org/epp#ok)",
+		"active",
+		"active", // duplicate
+		"  spaced  ",
+	}
+	want := []string{"clientTransferProhibited", "ok", "active", "spaced"}
+	if got := CleanStatus(in); !reflect.DeepEqual(got, want) {
+		t.Errorf("CleanStatus = %v, want %v", got, want)
+	}
+	if got := CleanStatus(nil); got == nil || len(got) != 0 {
+		t.Errorf("CleanStatus(nil) = %v, want empty non-nil slice", got)
+	}
+}

--- a/internal/rdap/rdap_parse.go
+++ b/internal/rdap/rdap_parse.go
@@ -3,6 +3,8 @@ package rdap
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/KincaidYang/whois/internal/model"
 )
@@ -45,6 +47,7 @@ type rdapSecureDNS struct {
 
 type rdapDomainResponse struct {
 	LdhName     string           `json:"ldhName"`
+	UnicodeName string           `json:"unicodeName"`
 	Status      []string         `json:"status"`
 	Entities    []rdapEntity     `json:"entities"`
 	Events      []rdapEvent      `json:"events"`
@@ -123,8 +126,10 @@ func ParseRDAPResponseforDomain(response string) (model.DomainInfo, error) {
 	}
 
 	info := model.DomainInfo{
-		DomainName:   rdap.LdhName,
-		DomainStatus: rdap.Status,
+		ObjectClassName: model.ObjectClassDomain,
+		LdhName:         strings.ToLower(rdap.LdhName),
+		UnicodeName:     rdap.UnicodeName,
+		Status:          model.CleanStatus(rdap.Status),
 	}
 
 	// Extract registrar info from entities
@@ -140,33 +145,39 @@ func ParseRDAPResponseforDomain(response string) (model.DomainInfo, error) {
 		}
 	}
 
-	// Extract event dates
+	// Extract event dates, normalized to RFC 3339 UTC (unparseable values
+	// are passed through unchanged).
 	for _, event := range rdap.Events {
+		date, _ := model.NormalizeDate(event.EventDate, time.UTC)
 		switch event.EventAction {
 		case "registration":
-			info.CreationDate = event.EventDate
+			info.RegistrationDate = date
 		case "expiration":
-			info.RegistryExpiryDate = event.EventDate
+			info.ExpirationDate = date
 		case "last changed":
-			info.UpdatedDate = event.EventDate
+			info.LastChangedDate = date
 		case "last update of RDAP database":
-			info.LastUpdateOfRDAPDB = event.EventDate
+			info.LastUpdateOfRdapDb = date
 		}
 	}
 
 	// Extract nameservers
-	info.NameServer = make([]string, 0, len(rdap.Nameservers))
+	info.Nameservers = make([]string, 0, len(rdap.Nameservers))
 	for _, ns := range rdap.Nameservers {
-		info.NameServer = append(info.NameServer, ns.LdhName)
+		info.Nameservers = append(info.Nameservers, strings.ToLower(ns.LdhName))
 	}
 
 	// Extract DNSSEC info
-	info.DNSSec = "unsigned"
+	info.SecureDNS = &model.SecureDNS{}
 	if rdap.SecureDNS != nil && rdap.SecureDNS.DelegationSigned {
-		info.DNSSec = "signedDelegation"
+		info.SecureDNS.DelegationSigned = true
 		for _, ds := range rdap.SecureDNS.DsData {
-			info.DNSSecDSData = append(info.DNSSecDSData, fmt.Sprintf("%d %d %d %s",
-				ds.KeyTag, ds.Algorithm, ds.DigestType, ds.Digest))
+			info.SecureDNS.DSData = append(info.SecureDNS.DSData, model.DSData{
+				KeyTag:     ds.KeyTag,
+				Algorithm:  ds.Algorithm,
+				DigestType: ds.DigestType,
+				Digest:     ds.Digest,
+			})
 		}
 	}
 
@@ -181,23 +192,17 @@ func ParseRDAPResponseforIP(response string) (model.IPInfo, error) {
 	}
 
 	info := model.IPInfo{
-		IP:       rdap.Handle,
-		NetName:  rdap.Name,
-		Country:  rdap.Country,
-		IPStatus: rdap.Status,
-	}
-
-	if rdap.StartAddress != "" {
-		info.Range = rdap.StartAddress
-		if rdap.EndAddress != "" {
-			info.Range += " - " + rdap.EndAddress
-		}
+		ObjectClassName: model.ObjectClassIPNetwork,
+		Handle:          rdap.Handle,
+		StartAddress:    rdap.StartAddress,
+		EndAddress:      rdap.EndAddress,
+		Name:            rdap.Name,
+		Country:         rdap.Country,
+		Status:          model.CleanStatus(rdap.Status),
 	}
 
 	if rdap.Type != nil {
-		info.Networktype = *rdap.Type
-	} else {
-		info.Networktype = "Unknown"
+		info.Type = *rdap.Type
 	}
 
 	for _, cidr := range rdap.Cidr0Cidrs {
@@ -209,11 +214,12 @@ func ParseRDAPResponseforIP(response string) (model.IPInfo, error) {
 	}
 
 	for _, event := range rdap.Events {
+		date, _ := model.NormalizeDate(event.EventDate, time.UTC)
 		switch event.EventAction {
 		case "registration":
-			info.CreationDate = event.EventDate
+			info.RegistrationDate = date
 		case "last changed":
-			info.UpdatedDate = event.EventDate
+			info.LastChangedDate = date
 		}
 	}
 
@@ -235,17 +241,19 @@ func ParseRDAPResponseforASN(response string) (model.ASNInfo, error) {
 	}
 
 	info := model.ASNInfo{
-		ASN:      rdap.Handle,
-		ASName:   rdap.Name,
-		ASStatus: rdap.Status,
+		ObjectClassName: model.ObjectClassAutnum,
+		Handle:          rdap.Handle,
+		Name:            rdap.Name,
+		Status:          model.CleanStatus(rdap.Status),
 	}
 
 	for _, event := range rdap.Events {
+		date, _ := model.NormalizeDate(event.EventDate, time.UTC)
 		switch event.EventAction {
 		case "registration":
-			info.CreationDate = event.EventDate
+			info.RegistrationDate = date
 		case "last changed":
-			info.UpdatedDate = event.EventDate
+			info.LastChangedDate = date
 		}
 	}
 

--- a/internal/utils/response.go
+++ b/internal/utils/response.go
@@ -18,16 +18,36 @@ const (
 	ErrorTypeBadRequest
 )
 
-// ErrorResponse represents a standard error response
-type ErrorResponse struct {
-	Error string `json:"error"`
+// problemTypeBase is the documentation URL prefix for problem type URIs
+// (RFC 9457 section 3.1.1). Each error kind is an anchor in docs/errors.md.
+const problemTypeBase = "https://github.com/KincaidYang/whois/blob/main/docs/errors.md"
+
+// Problem is an RFC 9457 "problem details" error response, served as
+// application/problem+json.
+type Problem struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail,omitempty"`
 }
 
-// writeJSONError writes a JSON error response safely
-func writeJSONError(w http.ResponseWriter, statusCode int, message string) {
-	w.Header().Set("Content-Type", "application/json")
+// writeProblem writes an RFC 9457 problem details response.
+func writeProblem(w http.ResponseWriter, statusCode int, typeAnchor, title, detail string) {
+	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(statusCode)
-	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: message})
+	_ = json.NewEncoder(w).Encode(Problem{
+		Type:   problemTypeBase + "#" + typeAnchor,
+		Title:  title,
+		Status: statusCode,
+		Detail: detail,
+	})
+}
+
+// WriteRateLimited writes the 429 problem response used when the concurrency
+// limiter rejects a request.
+func WriteRateLimited(w http.ResponseWriter) {
+	writeProblem(w, http.StatusTooManyRequests, "rate-limited",
+		"Too many concurrent requests", "")
 }
 
 // HandleQueryError handles common query errors with appropriate HTTP responses.
@@ -37,53 +57,34 @@ func writeJSONError(w http.ResponseWriter, statusCode int, message string) {
 func HandleQueryError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrResourceNotFound), errors.Is(err, ErrDomainNotFound):
-		writeJSONError(w, http.StatusNotFound, "Resource not found")
+		writeProblem(w, http.StatusNotFound, "not-found", "Resource not found", "")
 	case errors.Is(err, ErrQueryDenied):
-		writeJSONError(w, http.StatusForbidden, "The registry denied the query")
+		writeProblem(w, http.StatusForbidden, "query-denied", "The registry denied the query", "")
 	default:
 		slog.ErrorContext(ctx, "query failed", "err", err)
-		writeJSONError(w, http.StatusInternalServerError, "Query failed. Please try again later.")
+		writeProblem(w, http.StatusInternalServerError, "query-failed",
+			"Query failed", "Please try again later.")
 	}
 }
 
-// HandleHTTPError handles different types of HTTP errors
+// HandleHTTPError handles different types of HTTP errors. message becomes the
+// problem detail; the title is fixed per error type.
 func HandleHTTPError(w http.ResponseWriter, errorType ErrorType, message string) {
-	var statusCode int
-
 	switch errorType {
 	case ErrorTypeNotFound:
-		statusCode = http.StatusNotFound
-		if message == "" {
-			message = "Resource not found"
-		}
+		writeProblem(w, http.StatusNotFound, "not-found", "Resource not found", message)
 	case ErrorTypeForbidden:
-		statusCode = http.StatusForbidden
-		if message == "" {
-			message = "Access forbidden"
-		}
-	case ErrorTypeInternalServer:
-		statusCode = http.StatusInternalServerError
-		if message == "" {
-			message = "Internal server error"
-		}
+		writeProblem(w, http.StatusForbidden, "query-denied", "Access forbidden", message)
 	case ErrorTypeBadRequest:
-		statusCode = http.StatusBadRequest
-		if message == "" {
-			message = "Bad request"
-		}
+		writeProblem(w, http.StatusBadRequest, "bad-request", "Bad request", message)
 	default:
-		statusCode = http.StatusInternalServerError
-		if message == "" {
-			message = "Unknown error"
-		}
+		writeProblem(w, http.StatusInternalServerError, "internal-error", "Internal server error", message)
 	}
-
-	writeJSONError(w, statusCode, message)
 }
 
 // HandleInternalError handles internal server errors. The error is logged in
 // full; the client only sees a generic message.
 func HandleInternalError(ctx context.Context, w http.ResponseWriter, err error) {
 	slog.ErrorContext(ctx, "internal error", "err", err)
-	writeJSONError(w, http.StatusInternalServerError, "Internal server error")
+	writeProblem(w, http.StatusInternalServerError, "internal-error", "Internal server error", "")
 }

--- a/internal/utils/response_test.go
+++ b/internal/utils/response_test.go
@@ -15,16 +15,13 @@ func TestHandleHTTPError(t *testing.T) {
 		errorType  ErrorType
 		message    string
 		wantStatus int
-		wantMsg    string
+		wantTitle  string
 	}{
-		{ErrorTypeNotFound, "not here", http.StatusNotFound, "not here"},
+		{ErrorTypeNotFound, "not here", http.StatusNotFound, "Resource not found"},
 		{ErrorTypeNotFound, "", http.StatusNotFound, "Resource not found"},
-		{ErrorTypeForbidden, "denied", http.StatusForbidden, "denied"},
-		{ErrorTypeForbidden, "", http.StatusForbidden, "Access forbidden"},
-		{ErrorTypeInternalServer, "oops", http.StatusInternalServerError, "oops"},
-		{ErrorTypeInternalServer, "", http.StatusInternalServerError, "Internal server error"},
-		{ErrorTypeBadRequest, "bad input", http.StatusBadRequest, "bad input"},
-		{ErrorTypeBadRequest, "", http.StatusBadRequest, "Bad request"},
+		{ErrorTypeForbidden, "denied", http.StatusForbidden, "Access forbidden"},
+		{ErrorTypeInternalServer, "oops", http.StatusInternalServerError, "Internal server error"},
+		{ErrorTypeBadRequest, "bad input", http.StatusBadRequest, "Bad request"},
 	}
 
 	for _, tt := range tests {
@@ -34,16 +31,25 @@ func TestHandleHTTPError(t *testing.T) {
 		if w.Code != tt.wantStatus {
 			t.Errorf("HandleHTTPError(%v, %q): status=%d, want %d", tt.errorType, tt.message, w.Code, tt.wantStatus)
 		}
-		if ct := w.Header().Get("Content-Type"); ct != "application/json" {
-			t.Errorf("Content-Type=%q, want application/json", ct)
+		if ct := w.Header().Get("Content-Type"); ct != "application/problem+json" {
+			t.Errorf("Content-Type=%q, want application/problem+json", ct)
 		}
-		var body ErrorResponse
+		var body Problem
 		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
 			t.Errorf("response body is not valid JSON: %v", err)
 			continue
 		}
-		if body.Error != tt.wantMsg {
-			t.Errorf("body.Error=%q, want %q", body.Error, tt.wantMsg)
+		if body.Title != tt.wantTitle {
+			t.Errorf("body.Title=%q, want %q", body.Title, tt.wantTitle)
+		}
+		if body.Status != tt.wantStatus {
+			t.Errorf("body.Status=%d, want %d", body.Status, tt.wantStatus)
+		}
+		if body.Detail != tt.message {
+			t.Errorf("body.Detail=%q, want %q", body.Detail, tt.message)
+		}
+		if !strings.Contains(body.Type, "docs/errors.md#") {
+			t.Errorf("body.Type=%q, want a docs/errors.md anchor URI", body.Type)
 		}
 	}
 }
@@ -64,6 +70,9 @@ func TestHandleQueryError(t *testing.T) {
 		if w.Code != tt.wantStatus {
 			t.Errorf("HandleQueryError(%v): status=%d, want %d", tt.err, w.Code, tt.wantStatus)
 		}
+		if ct := w.Header().Get("Content-Type"); ct != "application/problem+json" {
+			t.Errorf("Content-Type=%q, want application/problem+json", ct)
+		}
 	}
 }
 
@@ -72,6 +81,21 @@ func TestHandleInternalError(t *testing.T) {
 	HandleInternalError(context.Background(), w, ErrResourceNotFound)
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status=%d, want 500", w.Code)
+	}
+}
+
+func TestWriteRateLimited(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteRateLimited(w)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("status=%d, want 429", w.Code)
+	}
+	var body Problem
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("response body is not valid JSON: %v", err)
+	}
+	if body.Title != "Too many concurrent requests" {
+		t.Errorf("body.Title=%q", body.Title)
 	}
 }
 
@@ -84,15 +108,15 @@ func TestHandleQueryErrorSanitizesUnexpectedErrors(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status=%d, want 500", w.Code)
 	}
-	var body ErrorResponse
+	var body Problem
 	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
 		t.Fatalf("response body is not valid JSON: %v", err)
 	}
-	if strings.Contains(body.Error, "whois.internal.example") {
-		t.Errorf("error message leaks upstream host: %q", body.Error)
+	if strings.Contains(body.Title+body.Detail, "whois.internal.example") {
+		t.Errorf("error message leaks upstream host: %+v", body)
 	}
-	if body.Error != "Query failed. Please try again later." {
-		t.Errorf("body.Error=%q, want generic message", body.Error)
+	if body.Title != "Query failed" {
+		t.Errorf("body.Title=%q, want generic message", body.Title)
 	}
 }
 
@@ -102,12 +126,12 @@ func TestHandleInternalErrorSanitizes(t *testing.T) {
 	w := httptest.NewRecorder()
 	HandleInternalError(context.Background(), w, errors.New("redis: connection pool timeout at 10.0.0.5:6379"))
 
-	var body ErrorResponse
+	var body Problem
 	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
 		t.Fatalf("response body is not valid JSON: %v", err)
 	}
-	if body.Error != "Internal server error" {
-		t.Errorf("body.Error=%q, want %q", body.Error, "Internal server error")
+	if body.Title != "Internal server error" || strings.Contains(body.Detail, "10.0.0.5") {
+		t.Errorf("unexpected body: %+v", body)
 	}
 }
 

--- a/internal/whois/whois_parsers.go
+++ b/internal/whois/whois_parsers.go
@@ -2,11 +2,19 @@ package whois
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/KincaidYang/whois/internal/model"
 	"github.com/KincaidYang/whois/internal/utils"
+)
+
+// Registry-local zones for WHOIS responses whose timestamps carry no offset.
+var (
+	zoneCST = time.FixedZone("CST", 8*3600) // .cn .tw .mo (China Standard Time)
+	zoneSGT = time.FixedZone("SGT", 8*3600) // .sg
+	zoneJST = time.FixedZone("JST", 9*3600) // .jp
 )
 
 // 预编译正则表达式（所有解析器共享，避免每次调用重复编译）
@@ -121,51 +129,109 @@ var (
 	reJPUpdatedDate  = regexp.MustCompile(`\[最終更新\]\s+(.*)`)
 	// 工具正则
 	reJPExpiryInStatus = regexp.MustCompile(`\((\d{4}/\d{2}/\d{2})\)`)
-	reJPTimezone       = regexp.MustCompile(`\s*\([A-Z]+\)\s*$`)
+	reTZSuffix         = regexp.MustCompile(`\s*\([A-Z]+\)\s*$`)
 	reMultiSpace       = regexp.MustCompile(`\s+`)
 )
 
-func ParseWhoisResponseCN(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+// newDomainInfo seeds a DomainInfo with the v2 invariants shared by every
+// WHOIS parser: the object class discriminator and the queried name (already
+// punycode-lowercased by the handler).
+func newDomainInfo(domain string) model.DomainInfo {
+	return model.DomainInfo{
+		ObjectClassName: model.ObjectClassDomain,
+		LdhName:         strings.ToLower(domain),
+	}
+}
 
-	// 解析创建日期
+// normDate converts a registry date to RFC 3339 UTC (or RFC 3339 full-date
+// when no time of day is present), interpreting zone-less timestamps in loc.
+// Unrecognized formats are passed through unchanged rather than dropped.
+func normDate(s string, loc *time.Location) string {
+	s = strings.TrimSpace(reTZSuffix.ReplaceAllString(s, ""))
+	out, _ := model.NormalizeDate(s, loc)
+	return out
+}
+
+// secureDNSFromString maps a registry's DNSSEC field text to the structured
+// secureDNS object. Registries phrase the signed state in several ways.
+func secureDNSFromString(s string) *model.SecureDNS {
+	v := strings.ToLower(strings.TrimSpace(s))
+	signed := strings.HasPrefix(v, "signed") || v == "yes" || v == "active" || v == "valid"
+	return &model.SecureDNS{DelegationSigned: signed}
+}
+
+// parseDSRecord parses a textual DS record ("keyTag algorithm digestType
+// digest...") into a structured DSData. Returns false when the text does not
+// follow that shape.
+func parseDSRecord(raw string) (model.DSData, bool) {
+	fields := strings.Fields(raw)
+	if len(fields) < 4 {
+		return model.DSData{}, false
+	}
+	keyTag, err1 := strconv.Atoi(fields[0])
+	alg, err2 := strconv.Atoi(fields[1])
+	digestType, err3 := strconv.Atoi(fields[2])
+	if err1 != nil || err2 != nil || err3 != nil {
+		return model.DSData{}, false
+	}
+	return model.DSData{
+		KeyTag:     keyTag,
+		Algorithm:  alg,
+		DigestType: digestType,
+		Digest:     strings.Join(fields[3:], ""),
+	}, true
+}
+
+// attachDSData parses raw DS text into info.SecureDNS.DSData; the signed flag
+// is forced on since a DS record implies a signed delegation.
+func attachDSData(info *model.DomainInfo, raw string) {
+	if info.SecureDNS == nil {
+		info.SecureDNS = &model.SecureDNS{}
+	}
+	info.SecureDNS.DelegationSigned = true
+	if ds, ok := parseDSRecord(raw); ok {
+		info.SecureDNS.DSData = append(info.SecureDNS.DSData, ds)
+	}
+}
+
+// lowerAll lowercases every entry (nameserver hostnames are normalized to
+// lowercase, matching the RDAP path).
+func lowerAll(in []string) []string {
+	for i, s := range in {
+		in[i] = strings.ToLower(strings.TrimSpace(s))
+	}
+	return in
+}
+
+func ParseWhoisResponseCN(response string, domain string) (model.DomainInfo, error) {
+	domainInfo := newDomainInfo(domain)
+
+	// 解析创建日期（CNNIC 时间为北京时间，转换为 UTC）
 	matchCreationDate := reCNCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		// 解析原始时间字符串
-		t, err := time.Parse("2006-01-02 15:04:05", matchCreationDate[1])
-		if err != nil {
-			return model.DomainInfo{}, err
-		}
-		// 将时间转换为 UTC，并格式化为新的字符串
-		domainInfo.CreationDate = t.Add(-8 * time.Hour).Format(time.RFC3339Nano)
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], zoneCST)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reCNExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		// 解析原始时间字符串
-		t, err := time.Parse("2006-01-02 15:04:05", matchExpiryDate[1])
-		if err != nil {
-			return model.DomainInfo{}, err
-		}
-		// 将时间转换为 UTC，并格式化为新的字符串
-		domainInfo.RegistryExpiryDate = t.Add(-8 * time.Hour).Format(time.RFC3339Nano)
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], zoneCST)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reCNNameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = match[1]
+			domainInfo.Nameservers[i] = match[1]
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reCNDNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = matchDNSSEC[1]
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析注册商
@@ -177,60 +243,49 @@ func ParseWhoisResponseCN(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reCNDomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = match[1]
+			domainInfo.Status[i] = match[1]
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 设置数据库更新时间为数据处理时间
-	now := time.Now().UTC().Format(time.RFC3339)
-	domainInfo.LastUpdateOfRDAPDB = now
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
 	return domainInfo, nil
 }
-func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
 
-	// 解析创建日期
+func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, error) {
+	domainInfo := newDomainInfo(domain)
+
+	// 解析创建日期（HKIRC 只给日期，保持 RFC 3339 full-date）
 	matchCreationDate := reHKCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		CreationDate := strings.TrimSpace(matchCreationDate[1])
-		parsedDate, err := time.Parse("02-01-2006", CreationDate)
-		if err == nil {
-			domainInfo.CreationDate = parsedDate.Format("2006-01-02")
-		}
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], nil)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reHKExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		expiryDate := strings.TrimSpace(matchExpiryDate[1])
-		parsedDate, err := time.Parse("02-01-2006", expiryDate)
-		if err == nil {
-			domainInfo.RegistryExpiryDate = parsedDate.Format("2006-01-02")
-		}
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], nil)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reHKNameServer.FindStringSubmatch(response)
 	if len(matchNameServers) > 1 {
 		nameServers := strings.Split(strings.TrimSpace(matchNameServers[1]), "\n")
-		domainInfo.NameServer = make([]string, len(nameServers))
-		for i, ns := range nameServers {
-			domainInfo.NameServer[i] = strings.TrimSpace(ns)
-		}
+		domainInfo.Nameservers = lowerAll(nameServers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reHKDNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = strings.TrimSpace(matchDNSSEC[1])
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析注册商
@@ -242,14 +297,13 @@ func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatus := reHKDomainStatus.FindStringSubmatch(response)
 	if len(matchDomainStatus) > 1 {
-		domainInfo.DomainStatus = []string{strings.TrimSpace(matchDomainStatus[1])}
+		domainInfo.Status = model.CleanStatus([]string{matchDomainStatus[1]})
 	}
 
 	// 设置数据库更新时间为数据处理时间
-	now := time.Now().UTC().Format(time.RFC3339)
-	domainInfo.LastUpdateOfRDAPDB = now
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
@@ -257,8 +311,7 @@ func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, err
 }
 
 func ParseWhoisResponseTW(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析注册商
 	matchRegistrar := reTWRegistrar.FindStringSubmatch(response)
@@ -269,63 +322,50 @@ func ParseWhoisResponseTW(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reTWDomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = strings.TrimSpace(match[1])
+			domainInfo.Status[i] = strings.TrimSpace(match[1])
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
-	// 解析创建日期
+	// 解析创建日期（TWNIC 时间为台北时间，转换为 UTC）
 	matchCreationDate := reTWCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		t, err := time.Parse("2006-01-02 15:04:05", matchCreationDate[1])
-		if err != nil {
-			return model.DomainInfo{}, err
-		}
-		// 将时间转换为 UTC，并格式化为新的字符串
-		domainInfo.CreationDate = t.Add(-8 * time.Hour).Format(time.RFC3339Nano)
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], zoneCST)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reTWExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		t, err := time.Parse("2006-01-02 15:04:05", matchExpiryDate[1])
-		if err != nil {
-			return model.DomainInfo{}, err
-		}
-		// 将时间转换为 UTC，并格式化为新的字符串
-		domainInfo.RegistryExpiryDate = t.Add(-8 * time.Hour).Format(time.RFC3339Nano)
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], zoneCST)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reTWNameServer.FindStringSubmatch(response)
 	if len(matchNameServers) > 1 {
 		servers := strings.Split(strings.TrimSpace(matchNameServers[1]), "\n")
-		domainInfo.NameServer = make([]string, len(servers))
-		for i, server := range servers {
-			domainInfo.NameServer[i] = strings.TrimSpace(server)
-		}
+		domainInfo.Nameservers = lowerAll(servers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reTWDNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = matchDNSSEC[1]
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 设置数据库更新时间为数据处理时间
-	now := time.Now().UTC().Format(time.RFC3339)
-	domainInfo.LastUpdateOfRDAPDB = now
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
 	return domainInfo, nil
 }
+
 func ParseWhoisResponseSO(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析注册商
 	matchRegistrar := reSORegistrar.FindStringSubmatch(response)
@@ -336,10 +376,11 @@ func ParseWhoisResponseSO(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reSODomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = match[1]
+			domainInfo.Status[i] = match[1]
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 解析 Registrar IANA ID
@@ -351,57 +392,58 @@ func ParseWhoisResponseSO(response string, domain string) (model.DomainInfo, err
 	// 解析创建日期
 	matchCreationDate := reSOCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = matchCreationDate[1]
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], time.UTC)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reSOExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = matchExpiryDate[1]
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], time.UTC)
 	}
 
 	// 解析更新日期
 	matchUpdatedDate := reSOUpdatedDate.FindStringSubmatch(response)
 	if len(matchUpdatedDate) > 1 {
-		domainInfo.UpdatedDate = matchUpdatedDate[1]
+		domainInfo.LastChangedDate = normDate(matchUpdatedDate[1], time.UTC)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reSONameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = match[1]
+			domainInfo.Nameservers[i] = match[1]
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reSODNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = matchDNSSEC[1]
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析 DNSSEC DS Data
 	matchDNSSecDSData := reSODNSSecDSData.FindStringSubmatch(response)
 	if len(matchDNSSecDSData) > 1 {
-		domainInfo.DNSSecDSData = []string{matchDNSSecDSData[1]}
+		attachDSData(&domainInfo, matchDNSSecDSData[1])
 	}
 
 	// 解析数据库更新时间
 	matchLastUpdateOfRDAPDB := reSOLastUpdateOfRDAPDB.FindStringSubmatch(response)
 	if len(matchLastUpdateOfRDAPDB) > 1 {
-		domainInfo.LastUpdateOfRDAPDB = strings.TrimSuffix(matchLastUpdateOfRDAPDB[1], " <<<")
+		domainInfo.LastUpdateOfRdapDb = normDate(strings.TrimSuffix(matchLastUpdateOfRDAPDB[1], " <<<"), time.UTC)
 	}
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
 	return domainInfo, nil
 }
+
 func ParseWhoisResponseRU(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析注册商
 	matchRegistrar := reRURegistrar.FindStringSubmatch(response)
@@ -412,40 +454,42 @@ func ParseWhoisResponseRU(response string, domain string) (model.DomainInfo, err
 	// 解析创建日期
 	matchCreationDate := reRUCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = matchCreationDate[1]
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], time.UTC)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reRUExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = matchExpiryDate[1]
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], time.UTC)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reRUNameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = match[1]
+			domainInfo.Nameservers[i] = match[1]
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析域名状态
 	matchDomainStatuses := reRUDomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = match[1]
+			domainInfo.Status[i] = match[1]
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 解析数据库更新时间
 	matchLastUpdateOfRDAPDB := reRULastUpdateOfRDAPDB.FindStringSubmatch(response)
 	if len(matchLastUpdateOfRDAPDB) > 1 {
-		domainInfo.LastUpdateOfRDAPDB = matchLastUpdateOfRDAPDB[1]
+		domainInfo.LastUpdateOfRdapDb = normDate(matchLastUpdateOfRDAPDB[1], time.UTC)
 	}
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
@@ -453,40 +497,40 @@ func ParseWhoisResponseRU(response string, domain string) (model.DomainInfo, err
 }
 
 func ParseWhoisResponseSB(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析创建日期
 	matchCreationDate := reSBCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = matchCreationDate[1]
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], time.UTC)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reSBExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = matchExpiryDate[1]
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], time.UTC)
 	}
 
 	// 解析更新日期
 	matchUpdatedDate := reSBUpdatedDate.FindStringSubmatch(response)
 	if len(matchUpdatedDate) > 1 {
-		domainInfo.UpdatedDate = matchUpdatedDate[1]
+		domainInfo.LastChangedDate = normDate(matchUpdatedDate[1], time.UTC)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reSBNameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = match[1]
+			domainInfo.Nameservers[i] = match[1]
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reSBDNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = matchDNSSEC[1]
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析注册商
@@ -498,10 +542,11 @@ func ParseWhoisResponseSB(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reSBDomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = match[1]
+			domainInfo.Status[i] = match[1]
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 解析 Registrar IANA ID
@@ -513,52 +558,48 @@ func ParseWhoisResponseSB(response string, domain string) (model.DomainInfo, err
 	// 解析 DNSSEC DS Data
 	matchDNSSecDSData := reSBDNSSecDSData.FindStringSubmatch(response)
 	if len(matchDNSSecDSData) > 1 {
-		domainInfo.DNSSecDSData = []string{matchDNSSecDSData[1]}
+		attachDSData(&domainInfo, matchDNSSecDSData[1])
 	}
 
 	// 解析数据库更新时间
 	matchLastUpdateOfRDAPDB := reSBLastUpdateOfRDAPDB.FindStringSubmatch(response)
 	if len(matchLastUpdateOfRDAPDB) > 1 {
-		domainInfo.LastUpdateOfRDAPDB = strings.TrimSuffix(matchLastUpdateOfRDAPDB[1], " <<<")
+		domainInfo.LastUpdateOfRdapDb = normDate(strings.TrimSuffix(matchLastUpdateOfRDAPDB[1], " <<<"), time.UTC)
 	}
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
 	return domainInfo, nil
 }
-func ParseWhoisResponseMO(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
 
-	// Parse creation date
+func ParseWhoisResponseMO(response string, domain string) (model.DomainInfo, error) {
+	domainInfo := newDomainInfo(domain)
+
+	// Parse creation date (MONIC local time is UTC+8)
 	matchCreationDate := reMOCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = matchCreationDate[1]
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], zoneCST)
 	}
 
 	// Parse expiry date
 	matchExpiryDate := reMOExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = matchExpiryDate[1]
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], zoneCST)
 	}
 
 	// Parse name servers
 	matchNameServers := reMONameServer.FindStringSubmatch(response)
 	if len(matchNameServers) > 1 {
 		nameServers := strings.Split(strings.TrimSpace(matchNameServers[1]), "\n")
-		domainInfo.NameServer = make([]string, len(nameServers))
-		for i, ns := range nameServers {
-			domainInfo.NameServer[i] = strings.TrimSpace(ns)
-		}
+		domainInfo.Nameservers = lowerAll(nameServers)
 	}
 
 	// 设置数据库更新时间为数据处理时间
-	now := time.Now().UTC().Format(time.RFC3339)
-	domainInfo.LastUpdateOfRDAPDB = now
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
-	if domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
@@ -566,8 +607,7 @@ func ParseWhoisResponseMO(response string, domain string) (model.DomainInfo, err
 }
 
 func ParseWhoisResponseAU(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 清理响应数据
 	cleanedResponse := strings.ReplaceAll(response, "\r", "")
@@ -575,34 +615,35 @@ func ParseWhoisResponseAU(response string, domain string) (model.DomainInfo, err
 	// 解析创建日期
 	matchCreationDate := reAUCreationDate.FindStringSubmatch(cleanedResponse)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = matchCreationDate[1]
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], time.UTC)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reAUExpiryDate.FindStringSubmatch(cleanedResponse)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = matchExpiryDate[1]
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], time.UTC)
 	}
 
 	// 解析更新日期
 	matchUpdatedDate := reAUUpdatedDate.FindStringSubmatch(cleanedResponse)
 	if len(matchUpdatedDate) > 1 {
-		domainInfo.UpdatedDate = matchUpdatedDate[1]
+		domainInfo.LastChangedDate = normDate(matchUpdatedDate[1], time.UTC)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reAUNameServer.FindAllStringSubmatch(cleanedResponse, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = match[1]
+			domainInfo.Nameservers[i] = match[1]
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reAUDNSSEC.FindStringSubmatch(cleanedResponse)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = matchDNSSEC[1]
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析注册商
@@ -614,10 +655,11 @@ func ParseWhoisResponseAU(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reAUDomainStatus.FindAllStringSubmatch(cleanedResponse, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = strings.TrimSpace(match[1])
+			domainInfo.Status[i] = strings.TrimSpace(match[1])
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 注册商 IANA ID 在给定示例中未提供，若需要解析请确保有正确格式的数据并使用相应正则表达式
@@ -629,13 +671,13 @@ func ParseWhoisResponseAU(response string, domain string) (model.DomainInfo, err
 	// 解析 DNSSEC DS Data
 	matchDNSSecDSData := reAUDNSSecDSData.FindStringSubmatch(cleanedResponse)
 	if len(matchDNSSecDSData) > 1 {
-		domainInfo.DNSSecDSData = []string{matchDNSSecDSData[1]}
+		attachDSData(&domainInfo, matchDNSSecDSData[1])
 	}
 
 	// 解析 Last update of WHOIS database
 	matchLastUpdateOfRDAPDB := reAULastUpdateOfRDAPDB.FindStringSubmatch(cleanedResponse)
 	if len(matchLastUpdateOfRDAPDB) > 1 {
-		domainInfo.LastUpdateOfRDAPDB = matchLastUpdateOfRDAPDB[1]
+		domainInfo.LastUpdateOfRdapDb = normDate(matchLastUpdateOfRDAPDB[1], time.UTC)
 	}
 
 	if domainInfo.Registrar == "" {
@@ -646,41 +688,40 @@ func ParseWhoisResponseAU(response string, domain string) (model.DomainInfo, err
 }
 
 func ParseWhoisResponseSG(response string, domain string) (model.DomainInfo, error) {
-	// SG匹配有问题，有时间再修改了
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
-	// 解析创建日期
+	// 解析创建日期（SGNIC 时间为新加坡时间，转换为 UTC）
 	matchCreationDate := reSGCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = strings.TrimRight(matchCreationDate[1], "\r")
+		domainInfo.RegistrationDate = normDate(strings.TrimRight(matchCreationDate[1], "\r"), zoneSGT)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reSGExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = strings.TrimRight(matchExpiryDate[1], "\r")
+		domainInfo.ExpirationDate = normDate(strings.TrimRight(matchExpiryDate[1], "\r"), zoneSGT)
 	}
 
 	// 解析更新日期
 	matchUpdatedDate := reSGUpdatedDate.FindStringSubmatch(response)
 	if len(matchUpdatedDate) > 1 {
-		domainInfo.UpdatedDate = strings.TrimRight(matchUpdatedDate[1], "\r")
+		domainInfo.LastChangedDate = normDate(strings.TrimRight(matchUpdatedDate[1], "\r"), zoneSGT)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reSGNameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = strings.TrimRight(match[1], "\r")
+			domainInfo.Nameservers[i] = strings.TrimRight(match[1], "\r")
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reSGDNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = strings.TrimRight(matchDNSSEC[1], "\r\t")
+		domainInfo.SecureDNS = secureDNSFromString(strings.TrimRight(matchDNSSEC[1], "\r\t"))
 	}
 
 	// 解析注册商
@@ -692,13 +733,14 @@ func ParseWhoisResponseSG(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reSGDomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = strings.TrimRight(match[1], "\r")
+			domainInfo.Status[i] = strings.TrimRight(match[1], "\r")
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
@@ -706,8 +748,7 @@ func ParseWhoisResponseSG(response string, domain string) (model.DomainInfo, err
 }
 
 func ParseWhoisResponseLA(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析注册商
 	matchRegistrar := reLARegistrar.FindStringSubmatch(response)
@@ -727,43 +768,45 @@ func ParseWhoisResponseLA(response string, domain string) (model.DomainInfo, err
 	// 解析域名状态
 	matchDomainStatuses := reLADomainStatus.FindAllStringSubmatch(response, -1)
 	if len(matchDomainStatuses) > 0 {
-		domainInfo.DomainStatus = make([]string, len(matchDomainStatuses))
+		domainInfo.Status = make([]string, len(matchDomainStatuses))
 		for i, match := range matchDomainStatuses {
-			domainInfo.DomainStatus[i] = strings.TrimSpace(match[1])
+			domainInfo.Status[i] = strings.TrimSpace(match[1])
 		}
+		domainInfo.Status = model.CleanStatus(domainInfo.Status)
 	}
 
 	// 解析创建日期
 	matchCreationDate := reLACreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
-		domainInfo.CreationDate = strings.TrimSpace(matchCreationDate[1])
+		domainInfo.RegistrationDate = normDate(matchCreationDate[1], time.UTC)
 	}
 
 	// 解析过期日期
 	matchExpiryDate := reLAExpiryDate.FindStringSubmatch(response)
 	if len(matchExpiryDate) > 1 {
-		domainInfo.RegistryExpiryDate = strings.TrimSpace(matchExpiryDate[1])
+		domainInfo.ExpirationDate = normDate(matchExpiryDate[1], time.UTC)
 	}
 
 	// 解析更新日期
 	matchUpdatedDate := reLAUpdatedDate.FindStringSubmatch(response)
 	if len(matchUpdatedDate) > 1 {
-		domainInfo.UpdatedDate = strings.TrimSpace(matchUpdatedDate[1])
+		domainInfo.LastChangedDate = normDate(matchUpdatedDate[1], time.UTC)
 	}
 
 	// 解析名称服务器
 	matchNameServers := reLANameServer.FindAllStringSubmatch(response, -1)
 	if len(matchNameServers) > 0 {
-		domainInfo.NameServer = make([]string, len(matchNameServers))
+		domainInfo.Nameservers = make([]string, len(matchNameServers))
 		for i, match := range matchNameServers {
-			domainInfo.NameServer[i] = strings.TrimSpace(match[1])
+			domainInfo.Nameservers[i] = strings.TrimSpace(match[1])
 		}
+		domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 	}
 
 	// 解析 DNSSEC
 	matchDNSSEC := reLADNSSEC.FindStringSubmatch(response)
 	if len(matchDNSSEC) > 1 {
-		domainInfo.DNSSec = strings.TrimSpace(matchDNSSEC[1])
+		domainInfo.SecureDNS = secureDNSFromString(matchDNSSEC[1])
 	}
 
 	// 解析数据库更新时间
@@ -771,11 +814,11 @@ func ParseWhoisResponseLA(response string, domain string) (model.DomainInfo, err
 	if len(matchLastUpdateOfRDAPDB) > 1 {
 		// 去除末尾的 " <<<" 标记
 		dbUpdate := strings.TrimSpace(matchLastUpdateOfRDAPDB[1])
-		domainInfo.LastUpdateOfRDAPDB = strings.TrimSuffix(dbUpdate, " <<<")
+		domainInfo.LastUpdateOfRdapDb = normDate(strings.TrimSuffix(dbUpdate, " <<<"), time.UTC)
 	}
 
 	// 验证必要字段
-	if domainInfo.Registrar == "" || domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.Registrar == "" || domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 
@@ -784,14 +827,12 @@ func ParseWhoisResponseLA(response string, domain string) (model.DomainInfo, err
 
 // ParseWhoisResponseJP parses WHOIS response for .jp domains (including .co.jp and other variants)
 func ParseWhoisResponseJP(response string, domain string) (model.DomainInfo, error) {
-	var domainInfo model.DomainInfo
-	domainInfo.DomainName = domain
+	domainInfo := newDomainInfo(domain)
 
 	// 解析域名 - 尝试两种格式
-	domainInfo.DomainName = matchFirstGroup(reJPDomainName, response,
-		func() string { return matchFirstGroup(reJPDomainNameAlt, response, nil) })
-	if domainInfo.DomainName == "" {
-		domainInfo.DomainName = domain
+	if name := matchFirstGroup(reJPDomainName, response,
+		func() string { return matchFirstGroup(reJPDomainNameAlt, response, nil) }); name != "" {
+		domainInfo.LdhName = strings.ToLower(name)
 	}
 
 	// 解析注册人/组织 - 尝试两种格式
@@ -799,41 +840,35 @@ func ParseWhoisResponseJP(response string, domain string) (model.DomainInfo, err
 		func() string { return matchFirstGroup(reJPOrganization, response, nil) })
 
 	// 解析名称服务器 - 尝试两种格式
-	domainInfo.NameServer = matchAllFirstGroup(reJPNameServer, response)
-	if len(domainInfo.NameServer) == 0 {
-		domainInfo.NameServer = matchAllFirstGroup(reJPNameServerAlt, response)
+	domainInfo.Nameservers = matchAllFirstGroup(reJPNameServer, response)
+	if len(domainInfo.Nameservers) == 0 {
+		domainInfo.Nameservers = matchAllFirstGroup(reJPNameServerAlt, response)
 	}
+	domainInfo.Nameservers = lowerAll(domainInfo.Nameservers)
 
 	// 解析 DNSSEC - 支持 [Signing Key] 和 s. [署名鍵] 两种格式
-	domainInfo.DNSSec = "unsigned"
+	domainInfo.SecureDNS = &model.SecureDNS{}
 	if signingKeyRaw := extractSigningKey(response); signingKeyRaw != "" {
-		domainInfo.DNSSec = "signedDelegation"
-		domainInfo.DNSSecDSData = []string{signingKeyRaw}
+		attachDSData(&domainInfo, signingKeyRaw)
 	}
 
 	// 解析注册日期 (格式: 2001/05/23)
 	if dateStr := matchFirstGroup(reJPCreationDate, response, nil); dateStr != "" {
-		if t, err := time.Parse("2006/01/02", dateStr); err == nil {
-			domainInfo.CreationDate = t.Format("2006-01-02")
-		}
+		domainInfo.RegistrationDate = normDate(dateStr, zoneJST)
 	}
 
 	// 解析过期日期 - 优先 [有効期限] 字段，再从 [状態] 中提取
 	if dateStr := matchFirstGroup(reJPExpiryDate, response, nil); dateStr != "" {
-		if t, err := time.Parse("2006/01/02", dateStr); err == nil {
-			domainInfo.RegistryExpiryDate = t.Format("2006-01-02")
-		}
+		domainInfo.ExpirationDate = normDate(dateStr, zoneJST)
 	}
 
 	// 解析 [状態] - 同时提取过期日期(如有)和状态文本
 	var statuses []string
 	if statusStr := matchFirstGroup(reJPStatus, response, nil); statusStr != "" {
 		// 从状态中提取过期日期 (适用于 co.jp: "Connected (2026/10/31)")
-		if domainInfo.RegistryExpiryDate == "" {
+		if domainInfo.ExpirationDate == "" {
 			if matchExpiry := reJPExpiryInStatus.FindStringSubmatch(statusStr); len(matchExpiry) > 1 {
-				if t, err := time.Parse("2006/01/02", matchExpiry[1]); err == nil {
-					domainInfo.RegistryExpiryDate = t.Format("2006-01-02")
-				}
+				domainInfo.ExpirationDate = normDate(matchExpiry[1], zoneJST)
 			}
 		}
 		// 清理状态文本（移除日期部分）
@@ -850,22 +885,19 @@ func ParseWhoisResponseJP(response string, domain string) (model.DomainInfo, err
 		}
 	}
 	if len(statuses) > 0 {
-		domainInfo.DomainStatus = statuses
+		domainInfo.Status = model.CleanStatus(statuses)
 	}
 
 	// 解析最终更新时间 (格式: 2025/06/01 01:05:04 (JST))
 	if dateStr := matchFirstGroup(reJPUpdatedDate, response, nil); dateStr != "" {
-		dateStr = reJPTimezone.ReplaceAllString(dateStr, "")
-		if t, err := time.Parse("2006/01/02 15:04:05", dateStr); err == nil {
-			domainInfo.UpdatedDate = t.Add(-9 * time.Hour).Format(time.RFC3339)
-		}
+		domainInfo.LastChangedDate = normDate(dateStr, zoneJST)
 	}
 
 	// 设置数据库更新时间为当前时间
-	domainInfo.LastUpdateOfRDAPDB = time.Now().UTC().Format(time.RFC3339)
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
 	// 验证必要字段
-	if domainInfo.CreationDate == "" || domainInfo.RegistryExpiryDate == "" {
+	if domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}
 

--- a/internal/whois/whois_parsers_test.go
+++ b/internal/whois/whois_parsers_test.go
@@ -21,13 +21,14 @@ Domain Status: active`
 
 	domain := "example.cn"
 	expected := model.DomainInfo{
-		DomainName:         domain,
-		CreationDate:       "2025-03-01T04:00:00Z", // Converted to UTC
-		RegistryExpiryDate: "2026-03-01T04:00:00Z",
-		NameServer:         []string{"ns1.example.com", "ns2.example.com"},
-		DNSSec:             "unsigned",
-		Registrar:          "Example Registrar",
-		DomainStatus:       []string{"active"},
+		ObjectClassName:  model.ObjectClassDomain,
+		LdhName:          domain,
+		RegistrationDate: "2025-03-01T04:00:00Z", // Converted from CST to UTC
+		ExpirationDate:   "2026-03-01T04:00:00Z",
+		Nameservers:      []string{"ns1.example.com", "ns2.example.com"},
+		SecureDNS:        &model.SecureDNS{DelegationSigned: false},
+		Registrar:        "Example Registrar",
+		Status:           []string{"active"},
 	}
 
 	domainInfo, err := ParseWhoisResponseCN(response, domain)
@@ -35,13 +36,13 @@ Domain Status: active`
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Validate that LastUpdateOfRDAPDB is a valid RFC3339 timestamp
-	if _, err := time.Parse(time.RFC3339, domainInfo.LastUpdateOfRDAPDB); err != nil {
-		t.Errorf("LastUpdateOfRDAPDB is not a valid RFC3339 timestamp: %v", domainInfo.LastUpdateOfRDAPDB)
+	// Validate that LastUpdateOfRdapDb is a valid RFC3339 timestamp
+	if _, err := time.Parse(time.RFC3339, domainInfo.LastUpdateOfRdapDb); err != nil {
+		t.Errorf("LastUpdateOfRdapDb is not a valid RFC3339 timestamp: %v", domainInfo.LastUpdateOfRdapDb)
 	}
 
-	// Ignore LastUpdateOfRDAPDB field for comparison
-	domainInfo.LastUpdateOfRDAPDB = ""
+	// Ignore LastUpdateOfRdapDb field for comparison
+	domainInfo.LastUpdateOfRdapDb = ""
 	if !reflect.DeepEqual(domainInfo, expected) {
 		t.Errorf("expected %+v, got %+v", expected, domainInfo)
 	}
@@ -86,8 +87,8 @@ URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
 	}
 
 	// 验证域名
-	if domainInfo.DomainName != domain {
-		t.Errorf("Expected domain name %s, got %s", domain, domainInfo.DomainName)
+	if domainInfo.LdhName != domain {
+		t.Errorf("Expected ldhName %s, got %s", domain, domainInfo.LdhName)
 	}
 
 	// 验证注册商
@@ -96,69 +97,58 @@ URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
 		t.Errorf("Expected registrar %s, got %s", expectedRegistrar, domainInfo.Registrar)
 	}
 
-	// 验证创建日期
-	expectedCreationDate := "2000-11-20T01:00:00.0Z"
-	if domainInfo.CreationDate != expectedCreationDate {
-		t.Errorf("Expected creation date %s, got %s", expectedCreationDate, domainInfo.CreationDate)
+	// 验证创建日期（归一化为 RFC 3339 UTC，小数秒被丢弃）
+	expectedCreationDate := "2000-11-20T01:00:00Z"
+	if domainInfo.RegistrationDate != expectedCreationDate {
+		t.Errorf("Expected registration date %s, got %s", expectedCreationDate, domainInfo.RegistrationDate)
 	}
 
 	// 验证过期日期
-	expectedExpiryDate := "2026-11-20T23:59:59.0Z"
-	if domainInfo.RegistryExpiryDate != expectedExpiryDate {
-		t.Errorf("Expected expiry date %s, got %s", expectedExpiryDate, domainInfo.RegistryExpiryDate)
+	expectedExpiryDate := "2026-11-20T23:59:59Z"
+	if domainInfo.ExpirationDate != expectedExpiryDate {
+		t.Errorf("Expected expiration date %s, got %s", expectedExpiryDate, domainInfo.ExpirationDate)
 	}
 
 	// 验证更新日期
-	expectedUpdatedDate := "2016-10-17T04:13:14.0Z"
-	if domainInfo.UpdatedDate != expectedUpdatedDate {
-		t.Errorf("Expected updated date %s, got %s", expectedUpdatedDate, domainInfo.UpdatedDate)
+	expectedUpdatedDate := "2016-10-17T04:13:14Z"
+	if domainInfo.LastChangedDate != expectedUpdatedDate {
+		t.Errorf("Expected lastChanged date %s, got %s", expectedUpdatedDate, domainInfo.LastChangedDate)
 	}
 
-	// 验证名称服务器
-	if len(domainInfo.NameServer) != 6 {
-		t.Errorf("Expected 6 name servers, got %d", len(domainInfo.NameServer))
-	}
+	// 验证名称服务器（统一小写）
 	expectedNameServers := []string{
-		"NS0.CENTRALNIC-DNS.COM",
-		"NS1.CENTRALNIC-DNS.COM",
-		"NS2.CENTRALNIC-DNS.COM",
-		"NS3.CENTRALNIC-DNS.COM",
-		"NS4.CENTRALNIC-DNS.COM",
-		"NS5.CENTRALNIC-DNS.COM",
+		"ns0.centralnic-dns.com",
+		"ns1.centralnic-dns.com",
+		"ns2.centralnic-dns.com",
+		"ns3.centralnic-dns.com",
+		"ns4.centralnic-dns.com",
+		"ns5.centralnic-dns.com",
 	}
-	for i, expectedNS := range expectedNameServers {
-		if i < len(domainInfo.NameServer) && domainInfo.NameServer[i] != expectedNS {
-			t.Errorf("Expected name server[%d] %s, got %s", i, expectedNS, domainInfo.NameServer[i])
-		}
+	if !reflect.DeepEqual(domainInfo.Nameservers, expectedNameServers) {
+		t.Errorf("Nameservers: got %v, want %v", domainInfo.Nameservers, expectedNameServers)
 	}
 
 	// 验证 DNSSEC
-	expectedDNSSEC := "unsigned"
-	if domainInfo.DNSSec != expectedDNSSEC {
-		t.Errorf("Expected DNSSEC %s, got %s", expectedDNSSEC, domainInfo.DNSSec)
+	if domainInfo.SecureDNS == nil || domainInfo.SecureDNS.DelegationSigned {
+		t.Errorf("SecureDNS: got %+v, want unsigned", domainInfo.SecureDNS)
 	}
 
-	// 验证域名状态
-	if len(domainInfo.DomainStatus) != 5 {
-		t.Errorf("Expected 5 domain statuses, got %d", len(domainInfo.DomainStatus))
-	}
+	// 验证域名状态（EPP 引用 URL 被剥离）
 	expectedStatuses := []string{
-		"serverTransferProhibited https://icann.org/epp#serverTransferProhibited",
-		"serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited",
-		"serverDeleteProhibited https://icann.org/epp#serverDeleteProhibited",
-		"serverRenewProhibited https://icann.org/epp#serverRenewProhibited",
-		"clientTransferProhibited https://icann.org/epp#clientTransferProhibited",
+		"serverTransferProhibited",
+		"serverUpdateProhibited",
+		"serverDeleteProhibited",
+		"serverRenewProhibited",
+		"clientTransferProhibited",
 	}
-	for i, expectedStatus := range expectedStatuses {
-		if i < len(domainInfo.DomainStatus) && domainInfo.DomainStatus[i] != expectedStatus {
-			t.Errorf("Expected domain status[%d] %s, got %s", i, expectedStatus, domainInfo.DomainStatus[i])
-		}
+	if !reflect.DeepEqual(domainInfo.Status, expectedStatuses) {
+		t.Errorf("Status: got %v, want %v", domainInfo.Status, expectedStatuses)
 	}
 
-	// 验证数据库最后更新时间
-	expectedDBUpdate := "2025-10-12T05:44:20.0Z"
-	if domainInfo.LastUpdateOfRDAPDB != expectedDBUpdate {
-		t.Errorf("Expected last update of DB %s, got %s", expectedDBUpdate, domainInfo.LastUpdateOfRDAPDB)
+	// 验证数据库最后更新时间（归一化为 RFC 3339 UTC）
+	expectedDBUpdate := "2025-10-12T05:44:20Z"
+	if domainInfo.LastUpdateOfRdapDb != expectedDBUpdate {
+		t.Errorf("Expected last update of DB %s, got %s", expectedDBUpdate, domainInfo.LastUpdateOfRdapDb)
 	}
 
 	// 验证 Registrar IANA ID 为空（因为原始数据中是空的）
@@ -209,20 +199,20 @@ func TestParseWhoisResponseHK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if info.DomainName != domain {
-		t.Errorf("DomainName: got %q, want %q", info.DomainName, domain)
+	if info.LdhName != domain {
+		t.Errorf("LdhName: got %q, want %q", info.LdhName, domain)
 	}
 	if info.Registrar != "Example HK Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01" {
-		t.Errorf("CreationDate: got %q, want 2010-03-01", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01" {
+		t.Errorf("RegistrationDate: got %q, want 2010-03-01", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01" {
-		t.Errorf("RegistryExpiryDate: got %q, want 2026-03-01", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01" {
+		t.Errorf("ExpirationDate: got %q, want 2026-03-01", info.ExpirationDate)
 	}
-	if info.DNSSec != "unsigned" {
-		t.Errorf("DNSSec: got %q", info.DNSSec)
+	if info.SecureDNS == nil || info.SecureDNS.DelegationSigned {
+		t.Errorf("SecureDNS: got %+v, want unsigned", info.SecureDNS)
 	}
 }
 
@@ -254,17 +244,17 @@ Domain servers in listed order:
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
 	// Dates converted from CST (UTC+8) to UTC: 08:00:00 CST = 00:00:00 UTC
-	if info.CreationDate == "" {
-		t.Error("CreationDate is empty")
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q, want 2010-03-01T00:00:00Z", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate == "" {
-		t.Error("RegistryExpiryDate is empty")
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q, want 2026-03-01T00:00:00Z", info.ExpirationDate)
 	}
-	if len(info.DomainStatus) == 0 || info.DomainStatus[0] != "active" {
-		t.Errorf("DomainStatus: got %v", info.DomainStatus)
+	if len(info.Status) == 0 || info.Status[0] != "active" {
+		t.Errorf("Status: got %v", info.Status)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
 }
 
@@ -296,17 +286,17 @@ Last update of WHOIS database: 2025-10-12T05:44:20Z <<<`
 	if info.Registrar != "Example SO Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01T00:00:00Z" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01T00:00:00Z" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
 	if info.RegistrarIANAID != "1234" {
 		t.Errorf("RegistrarIANAID: got %q", info.RegistrarIANAID)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
 }
 
@@ -338,17 +328,17 @@ Last updated on 2025-10-12T05:44:20Z`
 	if info.Registrar != "Example RU Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01T00:00:00Z" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01T00:00:00Z" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
-	if len(info.DomainStatus) == 0 {
-		t.Error("DomainStatus is empty")
+	if len(info.Status) == 0 {
+		t.Error("Status is empty")
 	}
 }
 
@@ -379,11 +369,11 @@ Last update of WHOIS database: 2025-10-12T05:44:20Z <<<`
 	if info.Registrar != "Example SB Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01T00:00:00Z" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01T00:00:00Z" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
 }
 
@@ -411,17 +401,17 @@ Domain name servers:
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if info.DomainName != domain {
-		t.Errorf("DomainName: got %q", info.DomainName)
+	if info.LdhName != domain {
+		t.Errorf("LdhName: got %q", info.LdhName)
 	}
-	if info.CreationDate != "2010-03-01" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
 }
 
@@ -453,17 +443,17 @@ func TestParseWhoisResponseAU(t *testing.T) {
 	if info.Registrar != "Example AU Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01T00:00:00Z" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01T00:00:00Z" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
-	if len(info.DomainStatus) == 0 || info.DomainStatus[0] != "serverHold" {
-		t.Errorf("DomainStatus: got %v", info.DomainStatus)
+	if len(info.Status) == 0 || info.Status[0] != "serverHold" {
+		t.Errorf("Status: got %v", info.Status)
 	}
 }
 
@@ -493,14 +483,14 @@ func TestParseWhoisResponseSG(t *testing.T) {
 	if info.Registrar != "Example SG Registrar" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01T00:00:00Z" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01T00:00:00Z" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01T00:00:00Z" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01T00:00:00Z" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
 	}
 }
 
@@ -527,20 +517,27 @@ func TestParseWhoisResponseJP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	if info.LdhName != "example.jp" {
+		t.Errorf("LdhName: got %q, want example.jp (lowercased from response)", info.LdhName)
+	}
 	if info.Registrar != "Example JP Corp" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.CreationDate != "2010-03-01" {
-		t.Errorf("CreationDate: got %q", info.CreationDate)
+	if info.RegistrationDate != "2010-03-01" {
+		t.Errorf("RegistrationDate: got %q", info.RegistrationDate)
 	}
-	if info.RegistryExpiryDate != "2026-03-01" {
-		t.Errorf("RegistryExpiryDate: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01" {
+		t.Errorf("ExpirationDate: got %q", info.ExpirationDate)
 	}
-	if len(info.NameServer) != 2 {
-		t.Errorf("NameServer count: got %d, want 2", len(info.NameServer))
+	// 2025/01/01 09:00:00 JST = 2025-01-01T00:00:00Z
+	if info.LastChangedDate != "2025-01-01T00:00:00Z" {
+		t.Errorf("LastChangedDate: got %q, want 2025-01-01T00:00:00Z", info.LastChangedDate)
 	}
-	if info.DNSSec != "unsigned" {
-		t.Errorf("DNSSec: got %q, want unsigned", info.DNSSec)
+	if len(info.Nameservers) != 2 {
+		t.Errorf("Nameservers count: got %d, want 2", len(info.Nameservers))
+	}
+	if info.SecureDNS == nil || info.SecureDNS.DelegationSigned {
+		t.Errorf("SecureDNS: got %+v, want unsigned", info.SecureDNS)
 	}
 }
 
@@ -560,8 +557,8 @@ p. [ネームサーバ] ns1.example.co.jp
 	if info.Registrar != "Example CO JP Corp" {
 		t.Errorf("Registrar: got %q", info.Registrar)
 	}
-	if info.RegistryExpiryDate != "2026-03-01" {
-		t.Errorf("RegistryExpiryDate from status: got %q", info.RegistryExpiryDate)
+	if info.ExpirationDate != "2026-03-01" {
+		t.Errorf("ExpirationDate from status: got %q", info.ExpirationDate)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -56,9 +56,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	default:
 		config.Wg.Done()
 		slog.WarnContext(r.Context(), "rate limit reached", "path", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusTooManyRequests)
-		_, _ = fmt.Fprint(w, `{"error":"too many concurrent requests"}`)
+		utils.WriteRateLimited(w)
 		metrics.HTTPRequestsTotal.WithLabelValues("unknown", "429").Inc()
 		return
 	}
@@ -77,7 +75,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	rawValue := r.URL.Query().Get("raw")
 	raw := r.URL.Query().Has("raw") && rawValue != "0" && rawValue != "false"
 
-	cacheKeyPrefix := "whois:"
+	cacheKeyPrefix := handlers.CacheKeyPrefix
 	sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
 	start := time.Now()
 

--- a/main_domain_test.go
+++ b/main_domain_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
 	"golang.org/x/net/idna"
 )
 
@@ -32,7 +33,7 @@ func TestHandlerUnknownTLD(t *testing.T) {
 // as text/plain, covering the content-type sniffing branch in HandleDomain.
 func TestHandlerTextPlainCacheHit(t *testing.T) {
 	domain := "textplaintest99999.cn"
-	key := "whois:" + domain
+	key := handlers.CacheKeyPrefix + domain
 	cached := "Domain Name: textplaintest99999.cn\nRaw WHOIS text, not JSON\n"
 	ctx := context.Background()
 	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
@@ -62,8 +63,8 @@ func TestHandlerIDNCacheHit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("idna.ToASCII: %v", err)
 	}
-	key := "whois:" + punycode
-	cached := `{"domainName":"` + punycode + `"}`
+	key := handlers.CacheKeyPrefix + punycode
+	cached := `{"ldhName":"` + punycode + `"}`
 	ctx := context.Background()
 	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
 		t.Fatalf("failed to seed cache: %v", err)
@@ -85,7 +86,7 @@ func TestHandlerIDNCacheHit(t *testing.T) {
 // 404 rather than as a normal payload, exercising the read-side interception.
 func TestHandlerNegativeCacheHit(t *testing.T) {
 	domain := "negativecachetest99999.cn"
-	key := "whois:" + domain
+	key := handlers.CacheKeyPrefix + domain
 	ctx := context.Background()
 	// Seed a not-found negative marker (same encoding CacheNegativeResult writes).
 	if err := config.CacheManager.Set(ctx, key, "\x00neg:notfound", time.Minute); err != nil {
@@ -104,8 +105,8 @@ func TestHandlerNegativeCacheHit(t *testing.T) {
 // TestHandlerIPCacheHit confirms the IP branch resolves and serves cached data.
 func TestHandlerIPCacheHit(t *testing.T) {
 	ip := "192.0.2.1"
-	key := "whois:" + ip
-	cached := `{"ipNetwork":"192.0.2.0/24"}`
+	key := handlers.CacheKeyPrefix + ip
+	cached := `{"objectClassName":"ip network","handle":"192.0.2.0/24"}`
 	ctx := context.Background()
 	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
 		t.Fatalf("failed to seed cache: %v", err)

--- a/main_feature_test.go
+++ b/main_feature_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
 	"github.com/KincaidYang/whois/internal/utils"
 )
 
@@ -71,12 +72,12 @@ func TestHandlerRawCacheHit(t *testing.T) {
 	domain := "rawcachetest99999.cn"
 	rawText := "Domain Name: rawcachetest99999.cn\nRegistrar: Example Registrar\n"
 	ctx := context.Background()
-	if err := config.CacheManager.Set(ctx, "whois:raw:"+domain, rawText, time.Minute); err != nil {
+	if err := config.CacheManager.Set(ctx, handlers.CacheKeyPrefix+"raw:"+domain, rawText, time.Minute); err != nil {
 		t.Fatalf("failed to seed raw cache: %v", err)
 	}
 	// Seed a parsed result under the normal key to prove the raw path does
 	// not read it.
-	if err := config.CacheManager.Set(ctx, "whois:"+domain, `{"domainName":"parsed"}`, time.Minute); err != nil {
+	if err := config.CacheManager.Set(ctx, handlers.CacheKeyPrefix+domain, `{"ldhName":"parsed"}`, time.Minute); err != nil {
 		t.Fatalf("failed to seed parsed cache: %v", err)
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -42,8 +42,8 @@ func TestHandlerRateLimit(t *testing.T) {
 
 func TestHandlerCacheHit(t *testing.T) {
 	domain := "cachehittest99999.cn"
-	key := "whois:" + domain
-	cached := `{"domainName":"cachehittest99999.cn","creationDate":"2020-01-01T00:00:00Z"}`
+	key := handlers.CacheKeyPrefix + domain
+	cached := `{"objectClassName":"domain","ldhName":"cachehittest99999.cn","registrationDate":"2020-01-01T00:00:00Z"}`
 	ctx := context.Background()
 	if err := config.CacheManager.Set(ctx, key, cached, time.Minute); err != nil {
 		t.Fatalf("failed to seed cache: %v", err)


### PR DESCRIPTION
## Summary

v0.8.0 的破坏性更新：API 响应体全面对齐 RDAP 规范。

- **响应字段全部 camelCase + RDAP（RFC 9083）词汇**：每个对象带 `objectClassName`（`domain` / `ip network` / `autnum`）；域名 `ldhName`/`unicodeName`、`registrationDate`/`expirationDate`/`lastChangedDate`、小写 `nameservers`、结构化 `secureDNS{delegationSigned, dsData[]}`；IP 拆分 `startAddress`/`endAddress`；ASN 用 `handle`/`name`。完整字段映射表见 CHANGELOG。
- **日期归一化为 RFC 3339 UTC**（`internal/model/normalize.go`）：RDAP 与全部 11 个 ccTLD WHOIS 解析器统一处理；注册局本地时区（.cn/.tw/.mo/.sg UTC+8、.jp UTC+9）转 UTC；纯日期保持 `YYYY-MM-DD` 不做时区平移。
- **status 清洗**：剥离 ICANN EPP 参考 URL 尾巴并去重。
- **错误响应改为 RFC 9457 Problem Details**（`application/problem+json`），`type` URI 指向新增的 `docs/errors.md` 锚点。
- **无解析器 TLD 返回 JSON**（`unparsed: true` + `rawText`），仅 `?raw=1` 返回 text/plain，Content-Type 不再随 TLD 漂移。
- **缓存键前缀 `whois:` → `whois:v2:`**，旧缓存自然过期，无需迁移。
- README（中/英）示例全部更新为 v2 格式；CHANGELOG 增加 Breaking 小节含字段映射表。

## Test plan

- [x] `go test ./...` 全绿（含重写的 parser/normalize/response/handler 测试）
- [x] `gofmt -l .` / `go vet ./...` 干净
- [x] `golangci-lint run` (v2.12.2) 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)