### PR TITLE
feat!: grouped camelCase config, typed paths, cache headers, CORS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of `text/plain`. Only `?raw=1` returns plain text.
 - Cache keys moved from `whois:` to `whois:v2:`; existing cache entries are
   abandoned (no migration needed, they expire naturally).
+- **Configuration file restructured.** Keys are grouped by function and use
+  camelCase, matching the API field style. Unknown keys and pre-v0.9 keys now
+  fail at startup with a migration hint instead of being silently ignored.
+  Environment variable names (`WHOIS_*`) are unchanged. Key mapping:
+
+  | Old | New |
+  |---|---|
+  | `port` | `server.port` |
+  | `ratelimit` | `server.rateLimit` |
+  | `loglevel` | `log.level` |
+  | `cacheexpiration` | `cache.expiration` |
+  | `cache.negativecacheexpiration` | `cache.negativeExpiration` |
+  | `cache.requireredis` | `cache.requireRedis` |
+  | `cache.memorymaxsize` | `cache.memoryMaxSize` |
+  | `cache.memorycleaninterval` | `cache.memoryCleanInterval` |
+  | `redis.tlsskipverify` | `redis.tlsSkipVerify` |
+  | `proxyserver` | `proxy.server` |
+  | `proxyusername` | `proxy.username` |
+  | `proxypassword` | `proxy.password` |
+  | `proxysuffixes` | `proxy.suffixes` |
+  | `bootstrapinterval` | `bootstrap.interval` |
+  | `mcp.localhostprotection` | `mcp.localhostProtection` |
+
+### Added
+- RFC 9082-style typed query paths: `/domain/{name}`, `/ip/{addr}`,
+  `/autnum/{asn}` — return 400 when the resource is not of the path's type.
+  The auto-detecting root path is unchanged.
+- `X-Cache: HIT/MISS` on query responses and
+  `Cache-Control: public, max-age=<cache.expiration>` on successful ones.
+- CORS: `Access-Control-Allow-Origin: *` on all responses, with preflight
+  `OPTIONS` support.
+- `cache.expiration` now defaults to 3600 when unset.
+- `CHANGELOG.md` (this file) and `SECURITY.md`.
+- golangci-lint in CI.
 
 ### Changed
 - All Go packages moved under `internal/` and renamed to idiomatic Go names
@@ -70,10 +104,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rdap_tools`→`rdap`, `rdap_tools/structs`→`model`, `whois_tools`→`whois`,
   `mcp_server`→`mcp`). No behavior change; the module no longer exposes any
   importable Go API.
-
-### Added
-- `CHANGELOG.md` (this file) and `SECURITY.md`.
-- golangci-lint in CI.
 
 ## [0.7.0] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -37,38 +37,41 @@ go build
 ```bash
 vim config.yaml
 ```
-> ⚠️ 配置文件的 YAML 键名**区分大小写**，请全部使用小写（如 `cacheexpiration`、`requireredis`、`proxyserver`），否则该项不会被解析、回退到默认值。
+> ⚠️ 配置项按功能分组，键名为 **camelCase**（与 API 响应字段风格一致）。未知键或旧版（v0.9 之前）的扁平键会在启动时报错并给出迁移提示，不会再静默回退到默认值。
 
 ```yaml
+server:
+  port: 8043                   # 服务监听端口
+  rateLimit: 60                # 并发限制，即程序向上游whois服务器发起的最大并发请求数
+
+log:
+  level: "info"                # 日志级别：debug、info、warn、error（默认：info）
+
+cache:
+  expiration: 3600             # 缓存过期时间，单位：秒（默认：3600）
+  negativeExpiration: 60       # “未找到/被拒”结果的缓存时间，单位：秒（默认: 60；设为负数则禁用）
+  requireRedis: false          # false=允许Redis失败时降级到内存缓存，true=Redis必须可用否则程序退出
+  memoryMaxSize: 10000         # 内存缓存最大条目数，超过此数量按 LRU 淘汰最久未使用条目（默认: 10000）
+  memoryCleanInterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
+
 redis:
-  addr: "redis:6379"          # Redis服务器地址
+  addr: "redis:6379"           # Redis服务器地址
   password: ""                 # Redis密码，如无密码则留空
   db: 0                        # Redis数据库编号
   tls: false                   # 通过不可信网络连接 Redis 时建议开启 TLS
-  tlsskipverify: false         # 跳过证书校验（不推荐，仅自签名证书场景使用）
-cacheexpiration: 3600          # 缓存过期时间，单位：秒
+  tlsSkipVerify: false         # 跳过证书校验（不推荐，仅自签名证书场景使用）
 
-# 高级缓存配置（可选，新版本功能）
-cache:
-  requireredis: false          # false=允许Redis失败时降级到内存缓存，true=Redis必须可用否则程序退出
-  memorymaxsize: 10000         # 内存缓存最大条目数，超过此数量按 LRU 淘汰最久未使用条目（默认: 10000）
-  memorycleaninterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
-  negativecacheexpiration: 60  # “未找到/被拒”结果的缓存时间，单位：秒（默认: 60；设为负数则禁用）
+proxy:
+  server: ""                   # 代理服务器地址，留空表示不使用代理
+  username: ""                 # 代理服务器用户名（如需认证）
+  password: ""                 # 代理服务器密码（如需认证）
+  suffixes: []                 # 需要使用代理的TLD后缀列表；填 ["all"] 表示全部走代理
 
-port: 8043                     # 服务监听端口
-ratelimit: 50                  # 并发限制，即程序向上游whois服务器发起的最大并发请求数
-
-# 代理配置（可选）
-proxyserver: "http://127.0.0.1:8080"  # 代理服务器地址
-proxysuffixes: []                      # 需要使用代理的TLD后缀列表，留空表示不使用代理；填 ["all"] 表示全部走代理
-proxyusername: ""                      # 代理服务器用户名（如需认证）
-proxypassword: ""                      # 代理服务器密码（如需认证）
-
-loglevel: "info"                       # 日志级别：debug、info、warn、error（默认：info）
-bootstrapinterval: 86400               # RDAP 服务器列表从 IANA 刷新间隔，单位：秒；0 或不填则禁用（推荐：86400）
+bootstrap:
+  interval: 86400              # RDAP 服务器列表从 IANA 刷新间隔，单位：秒；0 则禁用（推荐：86400）
 
 mcp:
-  localhostprotection: false           # /mcp 端点的 DNS rebinding 保护：开启后只接受 Host 为 localhost 的请求。反向代理部署保持 false；本机直连部署建议设为 true
+  localhostProtection: false   # /mcp 端点的 DNS rebinding 保护：开启后只接受 Host 为 localhost 的请求。反向代理部署保持 false；本机直连部署建议设为 true
 ```
 
 部分配置项可通过环境变量覆盖（优先级高于配置文件），如 `WHOIS_REDIS_ADDR`、`WHOIS_REDIS_TLS`、`WHOIS_PORT`、`WHOIS_RATE_LIMIT`、`WHOIS_CACHE_EXPIRATION`、`WHOIS_NEGATIVE_CACHE_EXPIRATION`、`WHOIS_LOG_LEVEL`、`WHOIS_MCP_LOCALHOST_PROTECTION` 等。
@@ -147,6 +150,19 @@ GET 请求
 部署后直接通过浏览器访问`http://ip:端口/你想查的域名或ip或asn`，默认端口`8043`，示例`http://1.2.3.4:8043/examlpe.com`,详细示例请参考下方
 
 > 支持直接查询国际化域名（IDN，含中文、带变音符号等 Unicode 域名），程序会自动转换为 Punycode 后查询，例如 `http://1.2.3.4:8043/例子.cn`。
+
+#### 类型化查询路径
+除根路径自动识别外，还提供 [RFC 9082](https://www.rfc-editor.org/rfc/rfc9082) 风格的类型化路径，适合程序化调用——资源类型不匹配时直接返回 400，不会被识别成其他类型：
+
+```bash
+curl http://localhost:8043/domain/example.com
+curl http://localhost:8043/ip/192.0.2.1
+curl http://localhost:8043/autnum/205794    # 也接受 as205794 / AS205794
+```
+
+#### 缓存与跨域
+- 成功响应带 `X-Cache: HIT/MISS` 头标识是否命中服务端缓存，以及 `Cache-Control: public, max-age=<缓存秒数>` 供客户端/CDN 缓存。
+- 所有响应带 `Access-Control-Allow-Origin: *`，可直接在浏览器前端跨域调用。
 
 #### 查询域名 Whois 信息
 ```bash

--- a/README_EN.md
+++ b/README_EN.md
@@ -47,38 +47,41 @@ This program requires Redis service support. You can refer to https://redis.io/d
 vim config.yaml
 ```
 
-> ⚠️ YAML keys in the config file are **case-sensitive** — use all lowercase (e.g. `cacheexpiration`, `requireredis`, `proxyserver`), otherwise the key is ignored and falls back to its default.
+> ⚠️ Configuration keys are grouped by function and use **camelCase** (matching the API response field style). Unknown keys and the pre-v0.9 flat keys fail at startup with a migration hint instead of being silently ignored.
 
 ```yaml
+server:
+  port: 8043                   # Server listening port
+  rateLimit: 60                # Concurrency limit for upstream WHOIS server requests
+
+log:
+  level: "info"                # Log level: debug, info, warn, error (default: info)
+
+cache:
+  expiration: 3600             # Cache expiration time in seconds (default: 3600)
+  negativeExpiration: 60       # How long "not found / denied" results are cached, in seconds (default: 60; set negative to disable)
+  requireRedis: false          # false=allow fallback to memory cache when Redis fails, true=Redis must be available or program exits
+  memoryMaxSize: 10000         # Maximum entries in memory cache; least-recently-used entries are evicted past this (default: 10000)
+  memoryCleanInterval: 300     # Memory cache cleanup interval in seconds (default: 300)
+
 redis:
   addr: "redis:6379"           # Redis server address
   password: ""                 # Redis password, leave empty if none
   db: 0                        # Redis database number
   tls: false                   # Enable TLS when Redis is reached over an untrusted network
-  tlsskipverify: false         # Skip certificate verification (not recommended; self-signed certs only)
-cacheexpiration: 3600          # Cache expiration time in seconds
+  tlsSkipVerify: false         # Skip certificate verification (not recommended; self-signed certs only)
 
-# Advanced cache configuration (optional, new feature)
-cache:
-  requireredis: false          # false=allow fallback to memory cache when Redis fails, true=Redis must be available or program exits
-  memorymaxsize: 10000         # Maximum entries in memory cache; least-recently-used entries are evicted past this (default: 10000)
-  memorycleaninterval: 300     # Memory cache cleanup interval in seconds (default: 300)
-  negativecacheexpiration: 60  # How long "not found / denied" results are cached, in seconds (default: 60; set negative to disable)
+proxy:
+  server: ""                   # Proxy server address; empty disables proxying
+  username: ""                 # Proxy server username (if authentication required)
+  password: ""                 # Proxy server password (if authentication required)
+  suffixes: []                 # TLD suffixes that use the proxy; ["all"] routes everything through the proxy
 
-port: 8043                     # Server listening port
-ratelimit: 50                  # Concurrency limit for upstream WHOIS server requests
-
-# Proxy configuration (optional)
-proxyserver: "http://127.0.0.1:8080"  # Proxy server address
-proxysuffixes: []                      # TLD suffixes that use the proxy; empty to disable; ["all"] routes everything through the proxy
-proxyusername: ""                      # Proxy server username (if authentication required)
-proxypassword: ""                      # Proxy server password (if authentication required)
-
-loglevel: "info"                       # Log level: debug, info, warn, error (default: info)
-bootstrapinterval: 86400               # RDAP server list refresh interval in seconds; 0 or unset disables fetching (recommended: 86400)
+bootstrap:
+  interval: 86400              # RDAP server list refresh interval in seconds; 0 disables fetching (recommended: 86400)
 
 mcp:
-  localhostprotection: false           # DNS-rebinding protection for /mcp: only accept requests whose Host header is localhost. Keep false behind a reverse proxy; set true for direct localhost deployments
+  localhostProtection: false   # DNS-rebinding protection for /mcp: only accept requests whose Host header is localhost. Keep false behind a reverse proxy; set true for direct localhost deployments
 ```
 
 Selected options can be overridden via environment variables (which take precedence over the config file), e.g. `WHOIS_REDIS_ADDR`, `WHOIS_REDIS_TLS`, `WHOIS_PORT`, `WHOIS_RATE_LIMIT`, `WHOIS_CACHE_EXPIRATION`, `WHOIS_NEGATIVE_CACHE_EXPIRATION`, `WHOIS_LOG_LEVEL`, `WHOIS_MCP_LOCALHOST_PROTECTION`.
@@ -147,6 +150,21 @@ GET requests
 #### Browser Access
 
 After deployment, access `http://ip:port/domain-or-ip-or-asn` via browser. Default port is `8043`, e.g., `http://1.2.3.4:8043/example.com`
+
+#### Typed Query Paths
+
+Besides the auto-detecting root path, [RFC 9082](https://www.rfc-editor.org/rfc/rfc9082)-style typed paths are available, suited to programmatic use — a resource of the wrong type returns 400 instead of being interpreted as another type:
+
+```bash
+curl http://localhost:8043/domain/example.com
+curl http://localhost:8043/ip/192.0.2.1
+curl http://localhost:8043/autnum/205794    # as205794 / AS205794 also accepted
+```
+
+#### Caching and CORS
+
+- Successful responses carry `X-Cache: HIT/MISS` indicating whether the server cache was hit, plus `Cache-Control: public, max-age=<cache seconds>` for client/CDN caching.
+- Every response carries `Access-Control-Allow-Origin: *`, so the API can be called cross-origin from browser frontends directly.
 
 > Internationalized domain names (IDN, including Unicode domains with non-ASCII characters) can be queried directly; the program converts them to Punycode automatically, e.g. `http://1.2.3.4:8043/例子.cn`.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,5 +31,5 @@ remain anonymous).
 ## Scope notes
 
 This service is designed to be deployed behind a reverse proxy. Rate limiting
-exists in-process (`ratelimit`), but per-IP limiting and TLS termination are
+exists in-process (`server.rateLimit`), but per-IP limiting and TLS termination are
 expected to be handled at the proxy layer.

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,27 @@
+server:
+  # Port the HTTP server listens on.
+  port: 8043
+  # Maximum number of concurrent requests; further requests get 429.
+  rateLimit: 60
+
+log:
+  # Minimum log level: debug, info, warn, error.
+  level: "info"
+
+cache:
+  # How long successful results are cached, in seconds.
+  expiration: 3600
+  # How long not-found/denied results are cached, in seconds.
+  # Set to a negative value to disable negative caching.
+  negativeExpiration: 60
+  # Fail at startup when Redis is unavailable instead of falling back to the
+  # in-memory cache.
+  requireRedis: false
+  # Maximum number of entries in the in-memory fallback cache.
+  memoryMaxSize: 10000
+  # Interval for evicting expired in-memory entries, in seconds.
+  memoryCleanInterval: 300
+
 redis:
   addr: "127.0.0.1:6379"
   password: ""
@@ -5,23 +29,24 @@ redis:
   # Enable TLS when Redis is reached over an untrusted network.
   tls: false
   # Skip server certificate verification (not recommended).
-  tlsskipverify: false
-cacheexpiration: 3600
-cache:
-  requireredis: false
-  memorymaxsize: 10000
-  memorycleaninterval: 300
-  negativecacheexpiration: 60
-port: 8043
-ratelimit: 60
-proxyserver: "http://127.0.0.1:8080"
-proxysuffixes: []
-proxyusername: ""
-proxypassword: ""
-loglevel: "info"
-bootstrapinterval: 86400
+  tlsSkipVerify: false
+
+proxy:
+  # HTTP proxy for RDAP queries to the TLDs listed in suffixes.
+  # Leave server empty to disable proxying.
+  server: ""
+  username: ""
+  password: ""
+  # TLDs queried through the proxy; the special value "all" proxies every TLD.
+  suffixes: []
+
+bootstrap:
+  # How often to refresh RDAP server lists from IANA, in seconds.
+  # 0 disables refreshing.
+  interval: 86400
+
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose
   # Host header is not localhost. Keep false behind a reverse proxy; set true
   # when the server is reached directly on localhost.
-  localhostprotection: false
+  localhostProtection: false

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -18,7 +18,7 @@ present, is human-readable context that may change between releases.
 
 **Status: 404.** The domain, IP network, or ASN is not registered, or the
 registry returned no data for it. Not-found results are negatively cached for
-a short time (`cache.negativecacheexpiration`, default 60s).
+a short time (`cache.negativeExpiration`, default 60s).
 
 ## query-denied
 
@@ -34,7 +34,7 @@ which has no raw WHOIS form).
 
 ## rate-limited
 
-**Status: 429.** The server's concurrent-request limit (`ratelimit` in
+**Status: 429.** The server's concurrent-request limit (`server.rateLimit` in
 config) was reached. Retry after a short delay.
 
 ## query-failed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -104,24 +107,41 @@ func initLogger(levelStr string) {
 	}))))
 }
 
-func init() {
+var loadOnce sync.Once
+
+// Load reads the configuration file, applies environment overrides and
+// initializes all package state (logger, Redis client, cache manager).
+// It must be called once at startup before any other package is used;
+// repeated calls are no-ops. On configuration errors it logs and exits.
+func Load() {
+	loadOnce.Do(load)
+}
+
+func load() {
 	// Initialize version info from build info (Go 1.18+)
 	initVersionInfo()
 
-	var config Config
-
 	// Load configuration from file
-	loadConfigFromFile(&config)
+	data, ext, err := readConfigFile()
+	if err != nil {
+		slog.Error("failed to open configuration file", "err", err)
+		os.Exit(1)
+	}
+	config, err := parseConfig(data, ext)
+	if err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
 
 	// Override configuration with environment variables if they exist
 	overrideConfigWithEnv(&config)
 
 	// Set up structured logger as early as possible so all subsequent
 	// init messages use the configured level and JSON format.
-	initLogger(config.LogLevel)
+	initLogger(config.Log.Level)
 
-	// Apply default values for cache configuration (backward compatibility)
-	applyDefaultCacheConfig(&config)
+	// Apply default values for anything left unset
+	applyDefaults(&config)
 
 	// Initialize the Redis client with custom options
 	options := &redis.Options{
@@ -152,40 +172,43 @@ func init() {
 	redis.SetLogger(&discardLogger{})
 
 	// Set the cache expiration time
-	CacheExpiration = time.Duration(config.CacheExpiration) * time.Second
+	CacheExpiration = time.Duration(config.Cache.Expiration) * time.Second
 
 	// Set cache configuration
 	RequireRedis = config.Cache.RequireRedis
 	MemoryMaxSize = config.Cache.MemoryMaxSize
 	MemoryCleanInterval = time.Duration(config.Cache.MemoryCleanInterval) * time.Second
-	NegativeCacheExpiration = time.Duration(config.Cache.NegativeCacheExpiration) * time.Second
+	NegativeCacheExpiration = time.Duration(config.Cache.NegativeExpiration) * time.Second
 
 	// Initialize cache manager with fallback
 	initializeCacheManager()
 
 	// Set the port the server listens on
-	Port = config.Port
+	Port = config.Server.Port
 
 	// Set the number of concurrent requests
-	RateLimit = config.RateLimit
+	RateLimit = config.Server.RateLimit
 	ConcurrencyLimiter = make(chan struct{}, RateLimit)
 
 	// Set the proxy server
-	ProxyServer = config.ProxyServer
-	ProxyUsername = config.ProxyUsername
-	ProxyPassword = config.ProxyPassword
-	ProxySuffixes = config.ProxySuffixes
+	ProxyServer = config.Proxy.Server
+	ProxyUsername = config.Proxy.Username
+	ProxyPassword = config.Proxy.Password
+	ProxySuffixes = config.Proxy.Suffixes
 
 	// Set the bootstrap interval
-	BootstrapInterval = time.Duration(config.BootstrapInterval) * time.Second
+	BootstrapInterval = time.Duration(config.Bootstrap.Interval) * time.Second
 
 	// Set MCP endpoint options
 	MCPLocalhostProtection = config.MCP.LocalhostProtection
 }
 
-// applyDefaultCacheConfig sets default values for cache configuration if not specified
-func applyDefaultCacheConfig(config *Config) {
-	// RequireRedis defaults to false (allow fallback to memory) - no action needed as bool defaults to false
+// applyDefaults sets default values for configuration left unset
+func applyDefaults(config *Config) {
+	// Default: cache successful results for one hour
+	if config.Cache.Expiration == 0 {
+		config.Cache.Expiration = 3600
+	}
 
 	// Default: 10000 entries max in memory cache
 	if config.Cache.MemoryMaxSize == 0 {
@@ -199,20 +222,19 @@ func applyDefaultCacheConfig(config *Config) {
 
 	// Default: cache not-found/denied results for 60 seconds.
 	// A negative value disables negative caching; only 0 (unset) gets the default.
-	if config.Cache.NegativeCacheExpiration == 0 {
-		config.Cache.NegativeCacheExpiration = 60
+	if config.Cache.NegativeExpiration == 0 {
+		config.Cache.NegativeExpiration = 60
 	}
 
 	// Default port: 8043
-	if config.Port == 0 {
-		config.Port = 8043
+	if config.Server.Port == 0 {
+		config.Server.Port = 8043
 	}
 
 	// Default rate limit: 100 concurrent requests
-	if config.RateLimit == 0 {
-		config.RateLimit = 100
+	if config.Server.RateLimit == 0 {
+		config.Server.RateLimit = 100
 	}
-
 }
 
 // initializeCacheManager sets up the cache with Redis primary and memory fallback
@@ -240,37 +262,127 @@ func initializeCacheManager() {
 	slog.Info("cache configuration", "memory_max_entries", MemoryMaxSize, "clean_interval", MemoryCleanInterval)
 }
 
-func loadConfigFromFile(config *Config) {
-	configFile, err := os.Open("config.yaml")
-	if err != nil {
-		configFile, err = os.Open("config.json")
-		if err != nil {
-			slog.Error("failed to open configuration file", "err", err)
-			os.Exit(1)
+// readConfigFile reads config.yaml (or config.json) and returns the raw bytes
+// together with the file extension that selects the parser.
+func readConfigFile() ([]byte, string, error) {
+	for _, name := range []string{"config.yaml", "config.yml", "config.json"} {
+		data, err := os.ReadFile(name)
+		if err == nil {
+			return data, strings.ToLower(filepath.Ext(name)), nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, "", err
 		}
 	}
-	defer func() { _ = configFile.Close() }()
+	return nil, "", fmt.Errorf("no config.yaml or config.json found in the working directory")
+}
 
-	fileExt := strings.ToLower(filepath.Ext(configFile.Name()))
-	switch fileExt {
+// legacyKeys maps configuration keys from the pre-v0.9 layout (lowercased)
+// to their new dotted location, used to build migration error messages.
+var legacyKeys = map[string]string{
+	// old top-level keys, now grouped
+	"cacheexpiration":   "cache.expiration",
+	"port":              "server.port",
+	"ratelimit":         "server.rateLimit",
+	"proxyserver":       "proxy.server",
+	"proxyusername":     "proxy.username",
+	"proxypassword":     "proxy.password",
+	"proxysuffixes":     "proxy.suffixes",
+	"loglevel":          "log.level",
+	"bootstrapinterval": "bootstrap.interval",
+	// old nested keys whose spelling changed (the old YAML tags were
+	// all-lowercase; the new ones are camelCase)
+	"redis.tlsskipverify":           "redis.tlsSkipVerify",
+	"cache.requireredis":            "cache.requireRedis",
+	"cache.memorymaxsize":           "cache.memoryMaxSize",
+	"cache.memorycleaninterval":     "cache.memoryCleanInterval",
+	"cache.negativecacheexpiration": "cache.negativeExpiration",
+	"mcp.localhostprotection":       "mcp.localhostProtection",
+}
+
+// groupKeys are the only keys allowed at the top level of the configuration.
+var groupKeys = map[string]bool{
+	"server": true, "log": true, "cache": true, "redis": true,
+	"proxy": true, "bootstrap": true, "mcp": true,
+}
+
+// detectLegacyKeys returns an error describing every pre-v0.9 key found in
+// the raw configuration, so users get one complete migration list instead of
+// a bare "unknown field" decode error.
+func detectLegacyKeys(raw map[string]interface{}) error {
+	var found []string
+	appendLegacy := func(key string) {
+		if newKey, ok := legacyKeys[strings.ToLower(key)]; ok {
+			found = append(found, fmt.Sprintf("%q is now %q", key, newKey))
+		}
+	}
+	for key, value := range raw {
+		if !groupKeys[strings.ToLower(key)] {
+			appendLegacy(key)
+			continue
+		}
+		nested, ok := value.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for nestedKey := range nested {
+			// Exact match only: the legacy nested keys are all-lowercase
+			// forms of the new camelCase keys, so a case-insensitive match
+			// would flag the new spelling too.
+			if newKey, ok := legacyKeys[strings.ToLower(key)+"."+nestedKey]; ok {
+				found = append(found, fmt.Sprintf("%q is now %q", key+"."+nestedKey, newKey))
+			}
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	sort.Strings(found)
+	return fmt.Errorf("configuration uses the pre-v0.9 layout; please migrate: %s (see CHANGELOG.md for the full mapping)",
+		strings.Join(found, "; "))
+}
+
+// parseConfig decodes the configuration, rejecting unknown fields and
+// pre-v0.9 keys with a migration hint. ext is ".yaml", ".yml" or ".json".
+func parseConfig(data []byte, ext string) (Config, error) {
+	var config Config
+
+	// First pass: decode generically to detect legacy keys with a helpful
+	// message before the strict decode rejects them as unknown fields.
+	raw := map[string]interface{}{}
+	switch ext {
 	case ".yaml", ".yml":
-		decoder := yaml.NewDecoder(configFile)
-		err = decoder.Decode(config)
-		if err != nil {
-			slog.Error("failed to decode YAML configuration", "err", err)
-			os.Exit(1)
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return config, fmt.Errorf("failed to decode YAML configuration: %w", err)
 		}
 	case ".json":
-		decoder := json.NewDecoder(configFile)
-		err = decoder.Decode(config)
-		if err != nil {
-			slog.Error("failed to decode JSON configuration", "err", err)
-			os.Exit(1)
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return config, fmt.Errorf("failed to decode JSON configuration: %w", err)
 		}
 	default:
-		slog.Error("unsupported configuration file format", "ext", fileExt)
-		os.Exit(1)
+		return config, fmt.Errorf("unsupported configuration file format: %s", ext)
 	}
+	if err := detectLegacyKeys(raw); err != nil {
+		return config, err
+	}
+
+	// Second pass: strict decode, so typos and unknown keys fail loudly
+	// instead of being silently ignored.
+	switch ext {
+	case ".yaml", ".yml":
+		decoder := yaml.NewDecoder(bytes.NewReader(data))
+		decoder.KnownFields(true)
+		if err := decoder.Decode(&config); err != nil {
+			return config, fmt.Errorf("failed to decode YAML configuration: %w", err)
+		}
+	case ".json":
+		decoder := json.NewDecoder(bytes.NewReader(data))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&config); err != nil {
+			return config, fmt.Errorf("failed to decode JSON configuration: %w", err)
+		}
+	}
+	return config, nil
 }
 
 func overrideConfigWithEnv(config *Config) {
@@ -293,14 +405,12 @@ func overrideConfigWithEnv(config *Config) {
 		config.Redis.TLSSkipVerify = redisTLSSkipVerify == "true" || redisTLSSkipVerify == "1"
 	}
 
-	// Override general configuration
+	// Override cache configuration
 	if cacheExpiration := os.Getenv("WHOIS_CACHE_EXPIRATION"); cacheExpiration != "" {
 		if cacheInt, err := strconv.Atoi(cacheExpiration); err == nil {
-			config.CacheExpiration = cacheInt
+			config.Cache.Expiration = cacheInt
 		}
 	}
-
-	// Override cache configuration
 	if requireRedis := os.Getenv("WHOIS_REQUIRE_REDIS"); requireRedis != "" {
 		config.Cache.RequireRedis = requireRedis == "true" || requireRedis == "1"
 	}
@@ -316,34 +426,38 @@ func overrideConfigWithEnv(config *Config) {
 	}
 	if negativeCacheExpiration := os.Getenv("WHOIS_NEGATIVE_CACHE_EXPIRATION"); negativeCacheExpiration != "" {
 		if exp, err := strconv.Atoi(negativeCacheExpiration); err == nil {
-			config.Cache.NegativeCacheExpiration = exp
+			config.Cache.NegativeExpiration = exp
 		}
 	}
 
+	// Override server configuration
 	if port := os.Getenv("WHOIS_PORT"); port != "" {
 		if portInt, err := strconv.Atoi(port); err == nil {
-			config.Port = portInt
+			config.Server.Port = portInt
 		}
 	}
 	if rateLimit := os.Getenv("WHOIS_RATE_LIMIT"); rateLimit != "" {
 		if rateInt, err := strconv.Atoi(rateLimit); err == nil {
-			config.RateLimit = rateInt
+			config.Server.RateLimit = rateInt
 		}
 	}
+
+	// Override proxy configuration
 	if proxyServer := os.Getenv("WHOIS_PROXY_SERVER"); proxyServer != "" {
-		config.ProxyServer = proxyServer
+		config.Proxy.Server = proxyServer
 	}
 	if proxyUsername := os.Getenv("WHOIS_PROXY_USERNAME"); proxyUsername != "" {
-		config.ProxyUsername = proxyUsername
+		config.Proxy.Username = proxyUsername
 	}
 	if proxyPassword := os.Getenv("WHOIS_PROXY_PASSWORD"); proxyPassword != "" {
-		config.ProxyPassword = proxyPassword
+		config.Proxy.Password = proxyPassword
 	}
 	if proxySuffixes := os.Getenv("WHOIS_PROXY_SUFFIXES"); proxySuffixes != "" {
-		config.ProxySuffixes = strings.Split(proxySuffixes, ",")
+		config.Proxy.Suffixes = strings.Split(proxySuffixes, ",")
 	}
+
 	if logLevel := os.Getenv("WHOIS_LOG_LEVEL"); logLevel != "" {
-		config.LogLevel = logLevel
+		config.Log.Level = logLevel
 	}
 	if mcpProtection := os.Getenv("WHOIS_MCP_LOCALHOST_PROTECTION"); mcpProtection != "" {
 		config.MCP.LocalhostProtection = mcpProtection == "true" || mcpProtection == "1"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+const validYAML = `
+server:
+  port: 9999
+  rateLimit: 7
+log:
+  level: "debug"
+cache:
+  expiration: 1234
+  negativeExpiration: 30
+  requireRedis: true
+  memoryMaxSize: 50
+  memoryCleanInterval: 60
+redis:
+  addr: "redis.example:6379"
+  password: "secret"
+  db: 2
+  tls: true
+  tlsSkipVerify: true
+proxy:
+  server: "http://proxy.example:8080"
+  username: "u"
+  password: "p"
+  suffixes: ["cn", "jp"]
+bootstrap:
+  interval: 3600
+mcp:
+  localhostProtection: true
+`
+
+func TestParseConfigYAML(t *testing.T) {
+	cfg, err := parseConfig([]byte(validYAML), ".yaml")
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.Server.Port != 9999 || cfg.Server.RateLimit != 7 {
+		t.Errorf("server: %+v", cfg.Server)
+	}
+	if cfg.Log.Level != "debug" {
+		t.Errorf("log.level: %q", cfg.Log.Level)
+	}
+	if cfg.Cache.Expiration != 1234 || cfg.Cache.NegativeExpiration != 30 ||
+		!cfg.Cache.RequireRedis || cfg.Cache.MemoryMaxSize != 50 || cfg.Cache.MemoryCleanInterval != 60 {
+		t.Errorf("cache: %+v", cfg.Cache)
+	}
+	if cfg.Redis.Addr != "redis.example:6379" || !cfg.Redis.TLS || !cfg.Redis.TLSSkipVerify || cfg.Redis.DB != 2 {
+		t.Errorf("redis: %+v", cfg.Redis)
+	}
+	if cfg.Proxy.Server != "http://proxy.example:8080" || len(cfg.Proxy.Suffixes) != 2 {
+		t.Errorf("proxy: %+v", cfg.Proxy)
+	}
+	if cfg.Bootstrap.Interval != 3600 {
+		t.Errorf("bootstrap.interval: %d", cfg.Bootstrap.Interval)
+	}
+	if !cfg.MCP.LocalhostProtection {
+		t.Errorf("mcp.localhostProtection: false")
+	}
+}
+
+func TestParseConfigJSON(t *testing.T) {
+	cfg, err := parseConfig([]byte(`{"server": {"port": 8080}, "log": {"level": "warn"}}`), ".json")
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.Server.Port != 8080 || cfg.Log.Level != "warn" {
+		t.Errorf("got %+v", cfg)
+	}
+}
+
+func TestParseConfigLegacyTopLevelKeys(t *testing.T) {
+	legacy := `
+redis:
+  addr: "127.0.0.1:6379"
+cacheexpiration: 3600
+port: 8043
+ratelimit: 60
+loglevel: "info"
+`
+	_, err := parseConfig([]byte(legacy), ".yaml")
+	if err == nil {
+		t.Fatal("expected migration error for legacy keys")
+	}
+	for _, hint := range []string{"pre-v0.9", `"cacheexpiration" is now "cache.expiration"`, `"port" is now "server.port"`, `"ratelimit" is now "server.rateLimit"`, `"loglevel" is now "log.level"`} {
+		if !strings.Contains(err.Error(), hint) {
+			t.Errorf("error %q missing hint %q", err, hint)
+		}
+	}
+}
+
+func TestParseConfigLegacyNestedKeys(t *testing.T) {
+	legacy := `
+redis:
+  addr: "127.0.0.1:6379"
+  tlsskipverify: true
+cache:
+  requireredis: true
+  negativecacheexpiration: 60
+mcp:
+  localhostprotection: true
+`
+	_, err := parseConfig([]byte(legacy), ".yaml")
+	if err == nil {
+		t.Fatal("expected migration error for legacy nested keys")
+	}
+	for _, hint := range []string{`"redis.tlsskipverify" is now "redis.tlsSkipVerify"`, `"cache.requireredis" is now "cache.requireRedis"`, `"cache.negativecacheexpiration" is now "cache.negativeExpiration"`, `"mcp.localhostprotection" is now "mcp.localhostProtection"`} {
+		if !strings.Contains(err.Error(), hint) {
+			t.Errorf("error %q missing hint %q", err, hint)
+		}
+	}
+}
+
+func TestParseConfigLegacyJSONKeys(t *testing.T) {
+	// The legacy JSON layout used camelCase top-level keys; the migration
+	// check matches them case-insensitively.
+	_, err := parseConfig([]byte(`{"cacheExpiration": 3600, "logLevel": "info"}`), ".json")
+	if err == nil || !strings.Contains(err.Error(), `"cacheExpiration" is now "cache.expiration"`) {
+		t.Errorf("expected migration error, got %v", err)
+	}
+}
+
+func TestParseConfigUnknownKey(t *testing.T) {
+	_, err := parseConfig([]byte("server:\n  prot: 8043\n"), ".yaml")
+	if err == nil {
+		t.Fatal("expected error for unknown key (typo)")
+	}
+}
+
+func TestParseConfigUnsupportedExt(t *testing.T) {
+	if _, err := parseConfig([]byte("x"), ".toml"); err == nil {
+		t.Fatal("expected error for unsupported extension")
+	}
+}
+
+func TestApplyDefaults(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	if cfg.Server.Port != 8043 || cfg.Server.RateLimit != 100 {
+		t.Errorf("server defaults: %+v", cfg.Server)
+	}
+	if cfg.Cache.Expiration != 3600 || cfg.Cache.NegativeExpiration != 60 ||
+		cfg.Cache.MemoryMaxSize != 10000 || cfg.Cache.MemoryCleanInterval != 300 {
+		t.Errorf("cache defaults: %+v", cfg.Cache)
+	}
+
+	// A negative value disables negative caching and must survive defaulting.
+	cfg.Cache.NegativeExpiration = -1
+	applyDefaults(&cfg)
+	if cfg.Cache.NegativeExpiration != -1 {
+		t.Errorf("negative NegativeExpiration overwritten: %d", cfg.Cache.NegativeExpiration)
+	}
+}

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -1,56 +1,74 @@
 package config
 
-// Config represents the configuration for the application.
+// Config represents the configuration for the application. YAML and JSON tags
+// are identical camelCase; keys from the pre-v0.9 flat layout are rejected at
+// load time with a migration hint (see legacyKeys in config.go).
 type Config struct {
-	// Redis holds the configuration for the Redis database.
-	// It includes the address, password, and database number.
+	// Server holds the HTTP server settings.
+	Server struct {
+		// Port is the port number the server listens on (default: 8043).
+		Port int `json:"port" yaml:"port"`
+		// RateLimit is the maximum number of concurrent requests (default: 100).
+		RateLimit int `json:"rateLimit" yaml:"rateLimit"`
+	} `json:"server" yaml:"server"`
+	// Log holds logging settings.
+	Log struct {
+		// Level sets the minimum log level: debug, info, warn, error (default: info).
+		Level string `json:"level" yaml:"level"`
+	} `json:"log" yaml:"log"`
+	// Cache holds cache settings.
+	Cache struct {
+		// Expiration is how long (in seconds) successful results are cached
+		// (default: 3600).
+		Expiration int `json:"expiration" yaml:"expiration"`
+		// NegativeExpiration is how long (in seconds) "not found" / "denied"
+		// results are cached to avoid hammering upstream servers. Default: 60.
+		// Set to a negative value to disable negative caching.
+		NegativeExpiration int `json:"negativeExpiration" yaml:"negativeExpiration"`
+		// RequireRedis makes startup fail when Redis is unavailable instead of
+		// falling back to the in-memory cache (default: false).
+		RequireRedis bool `json:"requireRedis" yaml:"requireRedis"`
+		// MemoryMaxSize is the maximum number of entries in the in-memory
+		// fallback cache (default: 10000).
+		MemoryMaxSize int `json:"memoryMaxSize" yaml:"memoryMaxSize"`
+		// MemoryCleanInterval is the interval (in seconds) for evicting expired
+		// in-memory entries (default: 300).
+		MemoryCleanInterval int `json:"memoryCleanInterval" yaml:"memoryCleanInterval"`
+	} `json:"cache" yaml:"cache"`
+	// Redis holds the connection settings for the Redis cache backend.
 	Redis struct {
-		Addr     string `json:"addr" yaml:"addr"`         // Addr is the address of the Redis server.
-		Password string `json:"password" yaml:"password"` // Password is the password for the Redis server.
-		DB       int    `json:"db" yaml:"db"`             // DB is the database number for the Redis server.
+		Addr     string `json:"addr" yaml:"addr"`
+		Password string `json:"password" yaml:"password"`
+		DB       int    `json:"db" yaml:"db"`
 		// TLS enables TLS for the Redis connection. Use when Redis is reached
 		// over an untrusted network so the password is not sent in cleartext.
 		TLS bool `json:"tls" yaml:"tls"`
 		// TLSSkipVerify disables server certificate verification (not
 		// recommended; only for self-signed certificates in trusted networks).
-		TLSSkipVerify bool `json:"tlsSkipVerify" yaml:"tlsskipverify"`
+		TLSSkipVerify bool `json:"tlsSkipVerify" yaml:"tlsSkipVerify"`
 	} `json:"redis" yaml:"redis"`
-	// CacheExpiration is the expiration time for the cache, in seconds.
-	CacheExpiration int `json:"cacheExpiration" yaml:"cacheexpiration"`
-	// Cache holds advanced cache configuration (optional, for backward compatibility)
-	Cache struct {
-		RequireRedis        bool `json:"requireRedis" yaml:"requireredis"`               // RequireRedis determines if Redis is required (default: false)
-		MemoryMaxSize       int  `json:"memoryMaxSize" yaml:"memorymaxsize"`             // MemoryMaxSize is the maximum number of entries in memory cache (default: 10000)
-		MemoryCleanInterval int  `json:"memoryCleanInterval" yaml:"memorycleaninterval"` // MemoryCleanInterval is the interval to clean expired entries in seconds (default: 300)
-		// NegativeCacheExpiration is how long (in seconds) "not found" / "denied"
-		// results are cached to avoid hammering upstream servers. Default: 60.
-		// Set to a negative value to disable negative caching.
-		NegativeCacheExpiration int `json:"negativeCacheExpiration" yaml:"negativecacheexpiration"`
-	} `json:"cache" yaml:"cache"`
-	// Port is the port number for the server.
-	Port int `json:"port" yaml:"port"`
-	// RateLimit is the maximum number of requests that a client can make in a specified period of time.
-	RateLimit int `json:"ratelimit" yaml:"ratelimit"`
-	// ProxyServer is the proxy server to use for certain TLDs.
-	ProxyServer string `json:"proxyServer" yaml:"proxyserver"`
-	// ProxyUsername is the username for the proxy server.
-	ProxyUsername string `json:"proxyUsername" yaml:"proxyusername"`
-	// ProxyPassword is the password for the proxy server.
-	ProxyPassword string `json:"proxyPassword" yaml:"proxypassword"`
-	// ProxySuffixes is the list of TLDs that use a proxy server.
-	ProxySuffixes []string `json:"proxySuffixes" yaml:"proxysuffixes"`
-	// LogLevel sets the minimum log level: debug, info, warn, error (default: info).
-	LogLevel string `json:"logLevel" yaml:"loglevel"`
-	// BootstrapInterval is how often (in seconds) to refresh RDAP server lists
-	// from IANA bootstrap data. 0 or unset disables all fetching; set to 86400
-	// in the default config.yaml to enable 24-hour refresh.
-	BootstrapInterval int `json:"bootstrapInterval" yaml:"bootstrapinterval"`
+	// Proxy routes RDAP queries for selected TLDs through an HTTP proxy.
+	Proxy struct {
+		// Server is the proxy URL; empty disables proxying.
+		Server   string `json:"server" yaml:"server"`
+		Username string `json:"username" yaml:"username"`
+		Password string `json:"password" yaml:"password"`
+		// Suffixes is the list of TLDs queried through the proxy; the special
+		// value "all" proxies every TLD.
+		Suffixes []string `json:"suffixes" yaml:"suffixes"`
+	} `json:"proxy" yaml:"proxy"`
+	// Bootstrap controls refreshing RDAP server lists from IANA.
+	Bootstrap struct {
+		// Interval is how often (in seconds) to refresh. 0 or unset disables
+		// all fetching; the default config.yaml sets 86400 (24 hours).
+		Interval int `json:"interval" yaml:"interval"`
+	} `json:"bootstrap" yaml:"bootstrap"`
 	// MCP holds settings for the MCP Streamable HTTP endpoint (/mcp).
 	MCP struct {
 		// LocalhostProtection enables DNS-rebinding protection, which rejects
 		// requests whose Host header is not localhost. Keep false (default)
 		// behind a reverse proxy, where the Host header is the public domain;
 		// set true when the server is reached directly on localhost.
-		LocalhostProtection bool `json:"localhostProtection" yaml:"localhostprotection"`
+		LocalhostProtection bool `json:"localhostProtection" yaml:"localhostProtection"`
 	} `json:"mcp" yaml:"mcp"`
 }

--- a/internal/handlers/asn.go
+++ b/internal/handlers/asn.go
@@ -36,9 +36,11 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 		return
 	}
 	if cacheResult.Found {
+		w.Header().Set("X-Cache", "HIT")
 		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
 			return
 		}
+		setCacheControl(w)
 		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
 		return
 	}
@@ -75,6 +77,8 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 	}
 
 	// Return the RDAP information
+	w.Header().Set("X-Cache", "MISS")
+	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)
 }

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -114,6 +114,7 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	}
 
 	if cacheResult.Found {
+		w.Header().Set("X-Cache", "HIT")
 		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
 			return
 		}
@@ -121,6 +122,7 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 		if len(cacheResult.Data) == 0 || cacheResult.Data[0] != '{' {
 			contentType = "text/plain; charset=utf-8"
 		}
+		setCacheControl(w)
 		utils.HandleCacheResponse(w, cacheResult.Data, contentType)
 		return
 	}
@@ -156,6 +158,8 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 		return
 	}
 
+	w.Header().Set("X-Cache", "MISS")
+	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)
 }

--- a/internal/handlers/headers.go
+++ b/internal/handlers/headers.go
@@ -1,0 +1,14 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/KincaidYang/whois/internal/config"
+)
+
+// setCacheControl tells clients they may cache a successful response for as
+// long as the server itself caches it.
+func setCacheControl(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(config.CacheExpiration.Seconds())))
+}

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -24,9 +24,11 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 		return
 	}
 	if cacheResult.Found {
+		w.Header().Set("X-Cache", "HIT")
 		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
 			return
 		}
+		setCacheControl(w)
 		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
 		return
 	}
@@ -64,6 +66,8 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 	}
 
 	// Return the RDAP information
+	w.Header().Set("X-Cache", "MISS")
+	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)
 }

--- a/internal/rdap/rdap_query.go
+++ b/internal/rdap/rdap_query.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/KincaidYang/whois/internal/config"
@@ -20,13 +21,19 @@ import (
 const maxResponseSize = 2 << 20 // 2 MiB
 
 // proxyClient is a pre-built HTTP client for proxied RDAP requests.
-// Initialized once at startup to enable connection pool reuse across requests.
+// Built once on first use (after config.Load has run) to enable connection
+// pool reuse across requests.
 var proxyClient *http.Client
 
 // proxySuffixSet is a set built from config.ProxySuffixes for O(1) lookup.
 var proxySuffixSet map[string]struct{}
 
-func init() {
+// proxyOnce defers proxy setup until the first query, because the config
+// package no longer initializes itself in init(); proxy settings only exist
+// once config.Load has been called.
+var proxyOnce sync.Once
+
+func initProxy() {
 	if config.ProxyServer != "" {
 		proxyURL, err := url.Parse(config.ProxyServer)
 		if err == nil {
@@ -54,6 +61,7 @@ func init() {
 // getHTTPClient returns an HTTP client with appropriate proxy settings.
 // Returns the pre-built proxyClient for proxied TLDs, or config.HttpClient otherwise.
 func getHTTPClient(tld string) *http.Client {
+	proxyOnce.Do(initProxy)
 	if proxyClient != nil {
 		_, matchTLD := proxySuffixSet[tld]
 		_, matchAll := proxySuffixSet["all"]

--- a/main.go
+++ b/main.go
@@ -49,7 +49,70 @@ func withRequestID(next http.Handler) http.Handler {
 	})
 }
 
+// withCORS allows cross-origin browser access: every response carries
+// Access-Control-Allow-Origin and preflight OPTIONS requests are answered
+// directly.
+func withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "X-Request-ID, X-Cache")
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+			w.Header().Set("Access-Control-Max-Age", "86400")
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// registerRoutes attaches all endpoints to mux.
+func registerRoutes(mux *http.ServeMux) {
+	// Health check endpoints
+	mux.HandleFunc("/health", handlers.HandleHealth)
+	mux.HandleFunc("/ready", handlers.HandleReady)
+	mux.HandleFunc("/info", handlers.HandleInfo)
+
+	// Prometheus metrics endpoint
+	mux.Handle("/metrics", promhttp.Handler())
+
+	// MCP Streamable HTTP endpoint
+	mux.Handle("/mcp", mcp.NewHandler(config.Version))
+
+	// RFC 9082-style typed query paths
+	mux.HandleFunc("/domain/{resource}", typedHandler("domain"))
+	mux.HandleFunc("/ip/{resource}", typedHandler("ip"))
+	mux.HandleFunc("/autnum/{resource}", typedHandler("asn"))
+
+	// Main query handler (auto-detects the resource type)
+	mux.HandleFunc("/", handler)
+}
+
+// handler serves the root path, auto-detecting whether the resource is a
+// domain, IP address, or ASN.
 func handler(w http.ResponseWriter, r *http.Request) {
+	serve(w, r, strings.TrimPrefix(r.URL.Path, "/"), "")
+}
+
+// typedHandler serves the RFC 9082-style typed paths (/domain/{resource},
+// /ip/{resource}, /autnum/{resource}); want names the resource type the path
+// requires.
+func typedHandler(want string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serve(w, r, r.PathValue("resource"), want)
+	}
+}
+
+// typedPathError maps a required resource type to the 400 message returned
+// when the supplied resource is not of that type.
+var typedPathError = map[string]string{
+	"domain": "The /domain/ path requires a valid domain name.",
+	"ip":     "The /ip/ path requires a valid IPv4 or IPv6 address.",
+	"asn":    "The /autnum/ path requires a valid AS number.",
+}
+
+func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 	config.Wg.Add(1)
 	select {
 	case config.ConcurrencyLimiter <- struct{}{}:
@@ -67,7 +130,6 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), config.RequestTimeout)
 	defer cancel()
-	resource := strings.TrimPrefix(r.URL.Path, "/")
 	resource = strings.ToLower(resource)
 
 	// ?raw requests the unparsed WHOIS text (domains only; RDAP-backed IP
@@ -82,23 +144,32 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	var resourceType string
 	if net.ParseIP(resource) != nil {
 		resourceType = "ip"
+	} else if utils.IsASN(resource) {
+		resourceType = "asn"
+	} else if utils.IsDomain(resource) {
+		resourceType = "domain"
+	} else {
+		resourceType = "unknown"
+	}
+
+	switch {
+	case want != "" && resourceType != want:
+		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, typedPathError[want])
+	case resourceType == "ip":
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
 			handlers.HandleIP(ctx, sw, resource, cacheKeyPrefix)
 		}
-	} else if utils.IsASN(resource) {
-		resourceType = "asn"
+	case resourceType == "asn":
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
 			handlers.HandleASN(ctx, sw, resource, cacheKeyPrefix)
 		}
-	} else if utils.IsDomain(resource) {
-		resourceType = "domain"
+	case resourceType == "domain":
 		handlers.HandleDomain(ctx, sw, resource, cacheKeyPrefix, raw)
-	} else {
-		resourceType = "unknown"
+	default:
 		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Invalid input. Please provide a valid domain, IP, or ASN.")
 	}
 
@@ -108,6 +179,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	// Load configuration and initialize logger, Redis client and cache.
+	config.Load()
 
 	// Start RDAP bootstrap refresh (initial fetch + periodic updates).
 	// Disabled when BootstrapInterval is 0 or unset.
@@ -117,23 +190,11 @@ func main() {
 		serverlist.StartBootstrapRefresh(bootstrapCtx, config.HttpClient, config.BootstrapInterval)
 	}
 
-	// Health check endpoints
-	http.HandleFunc("/health", handlers.HandleHealth)
-	http.HandleFunc("/ready", handlers.HandleReady)
-	http.HandleFunc("/info", handlers.HandleInfo)
-
-	// Prometheus metrics endpoint
-	http.Handle("/metrics", promhttp.Handler())
-
-	// MCP Streamable HTTP endpoint
-	http.Handle("/mcp", mcp.NewHandler(config.Version))
-
-	// Main query handler
-	http.HandleFunc("/", handler)
+	registerRoutes(http.DefaultServeMux)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),
-		Handler: withRequestID(http.DefaultServeMux),
+		Handler: withRequestID(withCORS(http.DefaultServeMux)),
 		// WriteTimeout must exceed the upstream query timeout (WHOIS/RDAP
 		// each allow up to 10s), since the handler queries upstream
 		// synchronously before writing the response.

--- a/main_routes_test.go
+++ b/main_routes_test.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
+)
+
+// newTestMux builds the same routing table main() installs, on a private mux.
+func newTestMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	registerRoutes(mux)
+	return mux
+}
+
+// TestTypedPathMismatch verifies each typed path rejects resources of the
+// wrong type with a 400 problem response.
+func TestTypedPathMismatch(t *testing.T) {
+	mux := newTestMux()
+	for _, path := range []string{
+		"/domain/192.0.2.1",
+		"/domain/as13335",
+		"/ip/example.com",
+		"/ip/as13335",
+		"/autnum/example.com",
+		"/autnum/192.0.2.1",
+	} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", path, w.Code)
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+			t.Errorf("%s: expected problem+json, got %q", path, ct)
+		}
+	}
+}
+
+// TestTypedPathIPCacheHit verifies /ip/ resolves the same cache entries as
+// the auto-detecting root path.
+func TestTypedPathIPCacheHit(t *testing.T) {
+	ip := "192.0.2.77"
+	key := handlers.CacheKeyPrefix + ip
+	cached := `{"objectClassName":"ip network","handle":"192.0.2.0/24"}`
+	if err := config.CacheManager.Set(context.Background(), key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/ip/"+ip, nil)
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "192.0.2.0/24") {
+		t.Errorf("response body missing cached data: %s", w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+	if cc := w.Header().Get("Cache-Control"); !strings.HasPrefix(cc, "public, max-age=") {
+		t.Errorf("Cache-Control: got %q", cc)
+	}
+}
+
+// TestTypedPathAutnumCacheHit verifies /autnum/ accepts both bare and
+// AS-prefixed numbers and resolves the shared cache key.
+func TestTypedPathAutnumCacheHit(t *testing.T) {
+	key := handlers.CacheKeyPrefix + "64511"
+	cached := `{"objectClassName":"autnum","handle":"AS64511"}`
+	if err := config.CacheManager.Set(context.Background(), key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	for _, path := range []string{"/autnum/64511", "/autnum/as64511", "/autnum/AS64511"} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		newTestMux().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: expected 200, got %d", path, w.Code)
+			continue
+		}
+		if !strings.Contains(w.Body.String(), "AS64511") {
+			t.Errorf("%s: response body missing cached data: %s", path, w.Body.String())
+		}
+	}
+}
+
+// TestTypedPathDomainUnknownTLD verifies /domain/ reaches the domain handler
+// (network-free no-server branch).
+func TestTypedPathDomainUnknownTLD(t *testing.T) {
+	req := httptest.NewRequest("GET", "/domain/example.zzqqxxnotld", nil)
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
+		t.Errorf("unexpected body: %s", w.Body.String())
+	}
+}
+
+// TestCORSPreflight verifies OPTIONS requests are answered by the CORS
+// middleware without reaching the query handler.
+func TestCORSPreflight(t *testing.T) {
+	req := httptest.NewRequest("OPTIONS", "/example.com", nil)
+	req.Header.Set("Origin", "https://example.org")
+	w := httptest.NewRecorder()
+	withCORS(newTestMux()).ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin: got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "GET") {
+		t.Errorf("Access-Control-Allow-Methods: got %q", got)
+	}
+}
+
+// TestCORSHeaderOnResponse verifies normal responses carry the CORS headers.
+func TestCORSHeaderOnResponse(t *testing.T) {
+	req := httptest.NewRequest("GET", "/not_a_valid_input!!", nil)
+	w := httptest.NewRecorder()
+	withCORS(newTestMux()).ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin: got %q", got)
+	}
+	if got := w.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(got, "X-Cache") {
+		t.Errorf("Access-Control-Expose-Headers: got %q", got)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +12,13 @@ import (
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/handlers"
 )
+
+// TestMain loads the configuration once for the whole package, mirroring the
+// explicit config.Load() call in main().
+func TestMain(m *testing.M) {
+	config.Load()
+	os.Exit(m.Run())
+}
 
 func TestHandlerBadRequest(t *testing.T) {
 	req := httptest.NewRequest("GET", "/not_a_valid_input!!", nil)
@@ -58,6 +66,12 @@ func TestHandlerCacheHit(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), "cachehittest99999.cn") {
 		t.Errorf("response body missing cached domain: %s", w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+	if cc := w.Header().Get("Cache-Control"); !strings.HasPrefix(cc, "public, max-age=") {
+		t.Errorf("Cache-Control: got %q", cc)
 	}
 }
 


### PR DESCRIPTION
## Summary

v0.8.0 的第二部分破坏性更新（与 #11 一起构成 v0.8.0）：配置文件重构 + HTTP 层完善。

- **config.yaml 重组（Breaking）**：按功能分为 `server/log/cache/redis/proxy/bootstrap/mcp` 七组，键名 camelCase 与 API 字段风格一致；严格解析（yaml `KnownFields` / json `DisallowUnknownFields`），未知键和 v0.9 之前的旧键启动时报错并给出完整迁移清单（如 `"ratelimit" is now "server.rateLimit"`），不再静默回退默认值。环境变量名（`WHOIS_*`）不变。完整映射表见 CHANGELOG。
- **config.init() → 显式 config.Load()**：副作用移出 init，main() 首行显式调用（sync.Once 防重）；rdap 代理客户端改为首次查询时惰性构建（原先依赖 config 的 init 顺序）。config 包首次有了独立单元测试。
- **RFC 9082 风格类型化路径**：`/domain/{name}`、`/ip/{addr}`、`/autnum/{asn}`（bare/as/AS 前缀均可），资源类型与路径不匹配返回 400 problem；根路径自动识别保留不变。
- **缓存响应头**：查询响应带 `X-Cache: HIT/MISS`，成功响应带 `Cache-Control: public, max-age=<cache.expiration>`。
- **CORS**：所有响应 `Access-Control-Allow-Origin: *`，支持 OPTIONS 预检，`Expose-Headers: X-Request-ID, X-Cache`。
- `cache.expiration` 未配置时默认 3600。
- README 中英：配置示例改新格式、新增类型化路径与缓存/跨域小节；docs/errors.md、SECURITY.md 旧键引用同步更新。

## Test plan

- [x] `go test ./...` 全绿（新增 config 解析/旧键检测/默认值测试、类型化路径/X-Cache/CORS 路由测试）
- [x] `gofmt -l .` / `go vet ./...` 干净
- [x] `golangci-lint run` (v2.12.2) 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)