### PR TITLE
fix: cache key prefix whois:v2: → whois:v1:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Domains whose TLD has no parser now return JSON**
   (`{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`)
   instead of `text/plain`. Only `?raw=1` returns plain text.
-- Cache keys moved from `whois:` to `whois:v2:`; existing cache entries are
+- Cache keys moved from `whois:` to `whois:v1:` (the first version of the
+  format that will stabilize in 1.0); entries cached by older releases are
   abandoned (no migration needed, they expire naturally).
 - **Configuration file restructured.** Keys are grouped by function and use
   camelCase, matching the API field style. Unknown keys and pre-v0.9 keys now

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -21,7 +21,7 @@ import (
 // CacheKeyPrefix namespaces all cache entries. The version segment is bumped
 // whenever the response format changes, so entries cached by an older release
 // are never served in the old format after an upgrade.
-const CacheKeyPrefix = "whois:v2:"
+const CacheKeyPrefix = "whois:v1:"
 
 // finalizeDomainInfo fills the fields shared by every domain response that
 // the parsers cannot know themselves: the Unicode form of the name (IDN) and


### PR DESCRIPTION
缓存键前缀从 \`whois:v2:\` 改为 \`whois:v1:\`：含义是「1.0 稳定格式的第 1 版」，与即将发布的 v1.0.0 对齐；旧的无版本 \`whois:\` 前缀代表 v0.7 及更早的旧格式。版本段本身保留——它防止升级后 Redis 中旧格式缓存（最长存活 cache.expiration 秒）被原样返回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)