### PR TITLE
feat: CIDR prefix queries + OpenAPI 3.1 endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RFC 9082-style typed query paths: `/domain/{name}`, `/ip/{addr}`,
   `/autnum/{asn}` — return 400 when the resource is not of the path's type.
   The auto-detecting root path is unchanged.
+- CIDR prefix queries for IP networks, e.g. `/ip/192.0.2.0/24` or
+  `/2001:db8::/32` (also via MCP).
+- OpenAPI 3.1 description of the service at `/openapi.json`.
 - `X-Cache: HIT/MISS` on query responses and
   `Cache-Control: public, max-age=<cache.expiration>` on successful ones.
 - CORS: `Access-Control-Allow-Origin: *` on all responses, with preflight

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ mcp:
 | `GET /ready` | 就绪检查 - 检查缓存和并发容量状态 |
 | `GET /info` | 运行时信息 - 版本、运行时间、Go 版本等 |
 | `GET /metrics` | Prometheus 指标 - 请求计数、延迟、缓存命中率、上游查询耗时 |
+| `GET /openapi.json` | OpenAPI 3.1 规范 - 全部端点与响应 schema 的机器可读描述 |
 | `POST /mcp` | MCP Streamable HTTP 端点 - 供 AI 助手集成使用 |
 
 **示例：**
@@ -159,6 +160,16 @@ curl http://localhost:8043/domain/example.com
 curl http://localhost:8043/ip/192.0.2.1
 curl http://localhost:8043/autnum/205794    # 也接受 as205794 / AS205794
 ```
+
+IP 查询支持 **CIDR 前缀**（根路径和 `/ip/` 均可）：
+
+```bash
+curl http://localhost:8043/ip/192.0.2.0/24
+curl http://localhost:8043/2001:db8::/32
+```
+
+#### OpenAPI 规范
+服务在 `/openapi.json` 提供 OpenAPI 3.1 描述文档，包含全部端点、响应 schema（RDAP 词汇）和错误格式，可直接导入 Postman/Swagger UI 等工具。
 
 #### 缓存与跨域
 - 成功响应带 `X-Cache: HIT/MISS` 头标识是否命中服务端缓存，以及 `Cache-Control: public, max-age=<缓存秒数>` 供客户端/CDN 缓存。
@@ -335,7 +346,7 @@ curl http://localhost:8043/205794
 { "query": "example.com" }
 ```
 
-支持域名、IPv4/v6 地址或 ASN（如 `AS12345`），返回结果与 REST API 完全一致。
+支持域名、IPv4/v6 地址或 CIDR 前缀、ASN（如 `AS12345`），返回结果与 REST API 完全一致。
 
 **MCP 服务器地址：** `http://ip:端口/mcp`
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -116,6 +116,7 @@ The service provides the following health check endpoints:
 | `GET /ready` | Readiness probe - checks cache and capacity status |
 | `GET /info` | Runtime information - version, uptime, Go version, etc. |
 | `GET /metrics` | Prometheus metrics - request count, latency, cache hit rate, upstream query duration |
+| `GET /openapi.json` | OpenAPI 3.1 specification - machine-readable description of all endpoints and response schemas |
 | `POST /mcp` | MCP Streamable HTTP endpoint - for AI assistant integration |
 
 ### Process Daemon (Optional)
@@ -160,6 +161,17 @@ curl http://localhost:8043/domain/example.com
 curl http://localhost:8043/ip/192.0.2.1
 curl http://localhost:8043/autnum/205794    # as205794 / AS205794 also accepted
 ```
+
+IP queries accept **CIDR prefixes** (on both the root path and `/ip/`):
+
+```bash
+curl http://localhost:8043/ip/192.0.2.0/24
+curl http://localhost:8043/2001:db8::/32
+```
+
+#### OpenAPI Specification
+
+An OpenAPI 3.1 description of the service is available at `/openapi.json`, covering every endpoint, the response schemas (RDAP vocabulary) and the error format. It can be imported directly into Postman, Swagger UI and similar tools.
 
 #### Caching and CORS
 
@@ -325,7 +337,7 @@ The service exposes an [MCP (Model Context Protocol)](https://modelcontextprotoc
 { "query": "example.com" }
 ```
 
-Accepts a domain name, IPv4/v6 address, or ASN (e.g. `AS12345`). Returns the same JSON as the REST API.
+Accepts a domain name, IPv4/v6 address or CIDR prefix, or ASN (e.g. `AS12345`). Returns the same JSON as the REST API.
 
 **MCP server URL:** `http://ip:port/mcp`
 

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -1,3 +1,17 @@
+server:
+  port: 8043
+  rateLimit: 60
+
+log:
+  level: "info"
+
+cache:
+  expiration: 3600
+  negativeExpiration: 60
+  requireRedis: false
+  memoryMaxSize: 10000
+  memoryCleanInterval: 300
+
 redis:
   addr: "redis:6379"
   password: ""
@@ -5,23 +19,19 @@ redis:
   # Enable TLS when Redis is reached over an untrusted network.
   tls: false
   # Skip server certificate verification (not recommended).
-  tlsskipverify: false
-cacheexpiration: 3600
-cache:
-  requireredis: false
-  memorymaxsize: 10000
-  memorycleaninterval: 300
-  negativecacheexpiration: 60
-port: 8043
-ratelimit: 60
-proxyserver: "http://127.0.0.1:8080"
-proxysuffixes: []
-proxyusername: ""
-proxypassword: ""
-loglevel: "info"
-bootstrapinterval: 86400
+  tlsSkipVerify: false
+
+proxy:
+  server: ""
+  username: ""
+  password: ""
+  suffixes: []
+
+bootstrap:
+  interval: 86400
+
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose
   # Host header is not localhost. Keep false behind a reverse proxy; set true
   # when the server is reached directly on localhost.
-  localhostprotection: false
+  localhostProtection: false

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/rdap"
@@ -33,8 +34,13 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 		return
 	}
 
-	// Parse the IP and find the RDAP server URL
-	ip := net.ParseIP(resource)
+	// Parse the IP (for CIDR input, the prefix base address) and find the
+	// RDAP server URL
+	ipStr := resource
+	if i := strings.IndexByte(resource, '/'); i >= 0 {
+		ipStr = resource[:i]
+	}
+	ip := net.ParseIP(ipStr)
 	serverURL, _ := serverlist.LookupIPKey(ip)
 
 	// Query and parse the RDAP information, deduplicating concurrent misses

--- a/internal/handlers/openapi.go
+++ b/internal/handlers/openapi.go
@@ -1,0 +1,16 @@
+package handlers
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.json
+var openAPISpec []byte
+
+// HandleOpenAPI serves the embedded OpenAPI 3.1 description of this service.
+func HandleOpenAPI(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	_, _ = w.Write(openAPISpec)
+}

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -1,0 +1,679 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "whois",
+    "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details.",
+    "version": "0.8.0",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    }
+  },
+  "externalDocs": {
+    "description": "Project README",
+    "url": "https://github.com/KincaidYang/whois"
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
+  "paths": {
+    "/{resource}": {
+      "get": {
+        "operationId": "query",
+        "summary": "Query a domain, IP address/CIDR prefix, or ASN (auto-detected)",
+        "description": "The resource type is detected automatically: an IP address or CIDR prefix is looked up as an IP network, a number with optional `as`/`asn` prefix as an autnum, anything else as a domain name. Unicode (IDN) domain names are accepted and converted to punycode. For explicit typing use /domain/, /ip/ or /autnum/.",
+        "parameters": [
+          {
+            "name": "resource",
+            "in": "path",
+            "required": true,
+            "description": "Domain name (`example.com`, `例子.cn`), IP address (`192.0.2.1`, `2001:db8::`), CIDR prefix (`192.0.2.0/24`), or ASN (`205794`, `as205794`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/raw"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/QueryResult"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/QueryDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/domain/{name}": {
+      "get": {
+        "operationId": "queryDomain",
+        "summary": "Query a domain name (RFC 9082-style typed path)",
+        "description": "Returns 400 when the resource is not a valid domain name instead of auto-detecting another type.",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Domain name; Unicode (IDN) names are accepted.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/raw"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Domain registration data, or the raw WHOIS text when `raw` is set.",
+            "headers": {
+              "X-Cache": {
+                "$ref": "#/components/headers/X-Cache"
+              },
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Domain"
+                }
+              },
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "Unparsed WHOIS response (only with `?raw=1`)."
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/QueryDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/ip/{address}": {
+      "get": {
+        "operationId": "queryIP",
+        "summary": "Query an IP network (RFC 9082-style typed path)",
+        "description": "Accepts a single IPv4/IPv6 address or a CIDR prefix whose slash is part of the path, e.g. `/ip/192.0.2.0/24` or `/ip/2001:db8::/32`. Returns 400 when the resource is not a valid IP or prefix.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "description": "IP address (`192.0.2.1`) or CIDR prefix (`192.0.2.0/24`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "IP network registration data.",
+            "headers": {
+              "X-Cache": {
+                "$ref": "#/components/headers/X-Cache"
+              },
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IPNetwork"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/QueryDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/autnum/{asn}": {
+      "get": {
+        "operationId": "queryAutnum",
+        "summary": "Query an autonomous system number (RFC 9082-style typed path)",
+        "description": "Returns 400 when the resource is not a valid AS number.",
+        "parameters": [
+          {
+            "name": "asn",
+            "in": "path",
+            "required": true,
+            "description": "AS number, with optional case-insensitive `as`/`asn` prefix (`205794`, `as205794`, `AS205794`).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Autnum registration data.",
+            "headers": {
+              "X-Cache": {
+                "$ref": "#/components/headers/X-Cache"
+              },
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Autnum"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/QueryDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health",
+        "summary": "Liveness probe",
+        "responses": {
+          "200": {
+            "description": "Service is running.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ready": {
+      "get": {
+        "operationId": "ready",
+        "summary": "Readiness probe",
+        "responses": {
+          "200": {
+            "description": "Cache and concurrency capacity are available."
+          },
+          "503": {
+            "description": "A dependency is unavailable."
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "operationId": "info",
+        "summary": "Runtime information (version, uptime, Go version)",
+        "responses": {
+          "200": {
+            "description": "Runtime information.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "operationId": "metrics",
+        "summary": "Prometheus metrics",
+        "responses": {
+          "200": {
+            "description": "Metrics in Prometheus text exposition format.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "operationId": "openapi",
+        "summary": "This OpenAPI document",
+        "responses": {
+          "200": {
+            "description": "OpenAPI 3.1 description of this service.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp": {
+      "post": {
+        "operationId": "mcp",
+        "summary": "MCP Streamable HTTP endpoint",
+        "description": "Model Context Protocol endpoint exposing the `whois_lookup` tool for AI assistants. The message format is defined by the MCP specification, not this document.",
+        "externalDocs": {
+          "description": "Model Context Protocol",
+          "url": "https://modelcontextprotocol.io"
+        },
+        "responses": {
+          "200": {
+            "description": "MCP protocol response."
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "raw": {
+        "name": "raw",
+        "in": "query",
+        "required": false,
+        "description": "Return the unparsed WHOIS response as text/plain (domains only; IP and ASN lookups use RDAP, which has no raw-text form). `raw=0` and `raw=false` opt out; any other presence of the parameter opts in.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "headers": {
+      "X-Cache": {
+        "description": "Whether the response was served from the server-side cache (HIT) or fetched from the upstream registry (MISS).",
+        "schema": {
+          "type": "string",
+          "enum": ["HIT", "MISS"]
+        }
+      },
+      "Cache-Control": {
+        "description": "Successful responses are cacheable for the server's configured cache expiration: `public, max-age=<seconds>`.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "responses": {
+      "QueryResult": {
+        "description": "Registration data for the detected resource type, or the raw WHOIS text when `raw` is set on a domain query.",
+        "headers": {
+          "X-Cache": {
+            "$ref": "#/components/headers/X-Cache"
+          },
+          "Cache-Control": {
+            "$ref": "#/components/headers/Cache-Control"
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Domain"
+                },
+                {
+                  "$ref": "#/components/schemas/IPNetwork"
+                },
+                {
+                  "$ref": "#/components/schemas/Autnum"
+                }
+              ],
+              "discriminator": {
+                "propertyName": "objectClassName",
+                "mapping": {
+                  "domain": "#/components/schemas/Domain",
+                  "ip network": "#/components/schemas/IPNetwork",
+                  "autnum": "#/components/schemas/Autnum"
+                }
+              }
+            }
+          },
+          "text/plain": {
+            "schema": {
+              "type": "string",
+              "description": "Unparsed WHOIS response (only with `?raw=1` on a domain query)."
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "The input is not a valid domain, IP, CIDR prefix, or ASN — or the parameter combination is unsupported.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The resource is not registered or the registry returned no data.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "QueryDenied": {
+        "description": "The upstream registry refused to answer the query.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "The server's concurrent-request limit was reached; retry after a short delay.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "The upstream query failed or an unexpected server-side error occurred.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Problem": {
+        "type": "object",
+        "description": "RFC 9457 Problem Details. `type` and `title` are stable identifiers; `detail` is human-readable and may change between releases. See https://github.com/KincaidYang/whois/blob/main/docs/errors.md",
+        "required": ["type", "title", "status"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "format": "uri",
+            "description": "URI of the problem type's documentation anchor."
+          },
+          "title": {
+            "type": "string"
+          },
+          "status": {
+            "type": "integer"
+          },
+          "detail": {
+            "type": "string"
+          }
+        }
+      },
+      "Domain": {
+        "type": "object",
+        "description": "Domain registration data; field names follow the RDAP domain object (RFC 9083 section 5.3). Dates are RFC 3339 UTC, or `YYYY-MM-DD` when the registry publishes only a date.",
+        "required": ["objectClassName", "status", "nameservers"],
+        "properties": {
+          "objectClassName": {
+            "type": "string",
+            "const": "domain"
+          },
+          "ldhName": {
+            "type": "string",
+            "description": "Lowercase ASCII (punycode) domain name."
+          },
+          "unicodeName": {
+            "type": "string",
+            "description": "Unicode form of the name; present for IDN domains."
+          },
+          "registrar": {
+            "type": "string"
+          },
+          "registrarIanaId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Status values with ICANN EPP reference URLs stripped and duplicates removed."
+          },
+          "registrationDate": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "lastChangedDate": {
+            "type": "string"
+          },
+          "nameservers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Lowercase nameserver host names."
+          },
+          "secureDNS": {
+            "$ref": "#/components/schemas/SecureDNS"
+          },
+          "lastUpdateOfRdapDb": {
+            "type": "string"
+          },
+          "unparsed": {
+            "type": "boolean",
+            "description": "True when no parser exists for the TLD; the response carries the raw WHOIS text in rawText instead of parsed fields."
+          },
+          "rawText": {
+            "type": "string",
+            "description": "Raw WHOIS response (only when unparsed is true)."
+          }
+        }
+      },
+      "SecureDNS": {
+        "type": "object",
+        "description": "DNSSEC information (RFC 9083 section 5.3).",
+        "required": ["delegationSigned"],
+        "properties": {
+          "delegationSigned": {
+            "type": "boolean"
+          },
+          "dsData": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DSData"
+            }
+          }
+        }
+      },
+      "DSData": {
+        "type": "object",
+        "description": "Delegation signer record.",
+        "required": ["keyTag", "algorithm", "digestType", "digest"],
+        "properties": {
+          "keyTag": {
+            "type": "integer"
+          },
+          "algorithm": {
+            "type": "integer"
+          },
+          "digestType": {
+            "type": "integer"
+          },
+          "digest": {
+            "type": "string"
+          }
+        }
+      },
+      "IPNetwork": {
+        "type": "object",
+        "description": "IP network registration data; field names follow the RDAP ip network object (RFC 9083 section 5.4).",
+        "required": ["objectClassName", "handle", "status"],
+        "properties": {
+          "objectClassName": {
+            "type": "string",
+            "const": "ip network"
+          },
+          "handle": {
+            "type": "string"
+          },
+          "startAddress": {
+            "type": "string"
+          },
+          "endAddress": {
+            "type": "string"
+          },
+          "cidr": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "status": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "registrationDate": {
+            "type": "string"
+          },
+          "lastChangedDate": {
+            "type": "string"
+          },
+          "remarks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Remark"
+            }
+          }
+        }
+      },
+      "Autnum": {
+        "type": "object",
+        "description": "Autonomous system registration data; field names follow the RDAP autnum object (RFC 9083 section 5.5).",
+        "required": ["objectClassName", "handle", "status"],
+        "properties": {
+          "objectClassName": {
+            "type": "string",
+            "const": "autnum"
+          },
+          "handle": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "registrationDate": {
+            "type": "string"
+          },
+          "lastChangedDate": {
+            "type": "string"
+          },
+          "remarks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Remark"
+            }
+          }
+        }
+      },
+      "Remark": {
+        "type": "object",
+        "description": "Registry-provided remark (RFC 9083 section 4.3).",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"net"
 	"net/http"
 	"strings"
 
@@ -69,7 +68,7 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	rc := newResponseCapture()
 	const cacheKeyPrefix = handlers.CacheKeyPrefix
 
-	if net.ParseIP(query) != nil {
+	if utils.IsIP(query) || utils.IsCIDR(query) {
 		handlers.HandleIP(ctx, rc, query, cacheKeyPrefix)
 	} else if utils.IsASN(query) {
 		handlers.HandleASN(ctx, rc, query, cacheKeyPrefix)
@@ -101,7 +100,7 @@ func NewHandler(version string) http.Handler {
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "whois_lookup",
-		Description: "Query WHOIS/RDAP information for a domain name, IP address (v4 or v6), or ASN",
+		Description: "Query WHOIS/RDAP information for a domain name, IP address or CIDR prefix (v4 or v6), or ASN",
 	}, whoisLookup)
 
 	return mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {

--- a/internal/rdap/rdap_query.go
+++ b/internal/rdap/rdap_query.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -137,7 +138,14 @@ func RDAPQueryIP(ctx context.Context, ip, serverURL string) (string, error) {
 	defer func() {
 		metrics.UpstreamDuration.WithLabelValues("rdap", "_ip").Observe(time.Since(start).Seconds())
 	}()
-	return doRDAPRequest(ctx, config.HttpClient, serverURL+"ip/"+url.PathEscape(ip))
+	// CIDR input ("192.0.2.0/24") maps to the RFC 9082 ip/<prefix>/<length>
+	// form, so the slash must survive as a path separator: escape each
+	// segment individually.
+	segments := strings.Split(ip, "/")
+	for i := range segments {
+		segments[i] = url.PathEscape(segments[i])
+	}
+	return doRDAPRequest(ctx, config.HttpClient, serverURL+"ip/"+strings.Join(segments, "/"))
 }
 
 // RDAPQueryASN queries the RDAP information for a given ASN.

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"net"
 	"regexp"
 
 	"golang.org/x/net/idna"
@@ -19,6 +20,18 @@ var (
 // IsASN reports whether the given resource is an Autonomous System Number (ASN).
 func IsASN(resource string) bool {
 	return asnRegex.MatchString(resource)
+}
+
+// IsIP reports whether the given resource is a bare IPv4 or IPv6 address.
+func IsIP(resource string) bool {
+	return net.ParseIP(resource) != nil
+}
+
+// IsCIDR reports whether the given resource is an IP prefix in CIDR notation
+// (e.g. "192.0.2.0/24", "2001:db8::/32").
+func IsCIDR(resource string) bool {
+	_, _, err := net.ParseCIDR(resource)
+	return err == nil
 }
 
 // IsDomain reports whether the given resource is a valid domain name.

--- a/internal/utils/validate_test.go
+++ b/internal/utils/validate_test.go
@@ -25,6 +25,49 @@ func TestIsASN(t *testing.T) {
 	}
 }
 
+func TestIsIP(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"192.0.2.1", true},
+		{"2001:db8::", true},
+		{"192.0.2.0/24", false}, // CIDR is not a bare IP
+		{"example.com", false},
+		{"", false},
+	}
+
+	for _, test := range tests {
+		result := IsIP(test.input)
+		if result != test.expected {
+			t.Errorf("IsIP(%q) = %v; want %v", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestIsCIDR(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"192.0.2.0/24", true},
+		{"192.0.2.5/24", true}, // host bits set is still a valid prefix query
+		{"2001:db8::/32", true},
+		{"192.0.2.0/33", false}, // mask too long for IPv4
+		{"192.0.2.0/", false},
+		{"192.0.2.1", false}, // bare IP is not CIDR
+		{"example.com/24", false},
+		{"", false},
+	}
+
+	for _, test := range tests {
+		result := IsCIDR(test.input)
+		if result != test.expected {
+			t.Errorf("IsCIDR(%q) = %v; want %v", test.input, result, test.expected)
+		}
+	}
+}
+
 func TestIsDomain(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -77,12 +76,16 @@ func registerRoutes(mux *http.ServeMux) {
 	// Prometheus metrics endpoint
 	mux.Handle("/metrics", promhttp.Handler())
 
+	// OpenAPI 3.1 service description
+	mux.HandleFunc("/openapi.json", handlers.HandleOpenAPI)
+
 	// MCP Streamable HTTP endpoint
 	mux.Handle("/mcp", mcp.NewHandler(config.Version))
 
-	// RFC 9082-style typed query paths
+	// RFC 9082-style typed query paths. The ip path uses a rest wildcard so
+	// CIDR prefixes ("/ip/192.0.2.0/24") keep their slash.
 	mux.HandleFunc("/domain/{resource}", typedHandler("domain"))
-	mux.HandleFunc("/ip/{resource}", typedHandler("ip"))
+	mux.HandleFunc("/ip/{resource...}", typedHandler("ip"))
 	mux.HandleFunc("/autnum/{resource}", typedHandler("asn"))
 
 	// Main query handler (auto-detects the resource type)
@@ -142,7 +145,7 @@ func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 	start := time.Now()
 
 	var resourceType string
-	if net.ParseIP(resource) != nil {
+	if utils.IsIP(resource) || utils.IsCIDR(resource) {
 		resourceType = "ip"
 	} else if utils.IsASN(resource) {
 		resourceType = "asn"

--- a/main_routes_test.go
+++ b/main_routes_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,6 +93,74 @@ func TestTypedPathAutnumCacheHit(t *testing.T) {
 		}
 		if !strings.Contains(w.Body.String(), "AS64511") {
 			t.Errorf("%s: response body missing cached data: %s", path, w.Body.String())
+		}
+	}
+}
+
+// TestCIDRCacheHit verifies CIDR prefixes resolve cache entries on both the
+// root path and the /ip/ typed path (whose rest wildcard keeps the slash).
+func TestCIDRCacheHit(t *testing.T) {
+	cidr := "192.0.2.0/24"
+	key := handlers.CacheKeyPrefix + cidr
+	cached := `{"objectClassName":"ip network","handle":"NET-192-0-2-0-1","cidr":"192.0.2.0/24"}`
+	if err := config.CacheManager.Set(context.Background(), key, cached, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	for _, path := range []string{"/" + cidr, "/ip/" + cidr} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		newTestMux().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: expected 200, got %d", path, w.Code)
+			continue
+		}
+		if !strings.Contains(w.Body.String(), "NET-192-0-2-0-1") {
+			t.Errorf("%s: response body missing cached data: %s", path, w.Body.String())
+		}
+	}
+}
+
+// TestCIDRInvalid verifies malformed prefixes are rejected.
+func TestCIDRInvalid(t *testing.T) {
+	for _, path := range []string{"/ip/192.0.2.0/99", "/ip/192.0.2.0/", "/192.0.2.0/24/extra"} {
+		req := httptest.NewRequest("GET", path, nil)
+		w := httptest.NewRecorder()
+		newTestMux().ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", path, w.Code)
+		}
+	}
+}
+
+// TestOpenAPIEndpoint verifies /openapi.json serves a parseable OpenAPI 3.1
+// document.
+func TestOpenAPIEndpoint(t *testing.T) {
+	req := httptest.NewRequest("GET", "/openapi.json", nil)
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+	var doc struct {
+		OpenAPI string         `json:"openapi"`
+		Paths   map[string]any `json:"paths"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("openapi.json is not valid JSON: %v", err)
+	}
+	if !strings.HasPrefix(doc.OpenAPI, "3.1") {
+		t.Errorf("openapi version: got %q, want 3.1.x", doc.OpenAPI)
+	}
+	for _, p := range []string{"/{resource}", "/domain/{name}", "/ip/{address}", "/autnum/{asn}", "/openapi.json"} {
+		if _, ok := doc.Paths[p]; !ok {
+			t.Errorf("openapi.json missing path %q", p)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

v0.8.0 收尾的两个增量功能 + 一个 bug 修复：

- **CIDR 前缀查询**：IP 查询支持 CIDR（根路径 `/192.0.2.0/24` 和类型化路径 `/ip/2001:db8::/32` 均可，MCP 同步支持）。`/ip/` 路由改用 Go 1.22 剩余通配符（`{resource...}`）保留斜杠；RDAP 上游 URL 按 RFC 9082 `ip/<prefix>/<length>` 构造，各段单独转义。非法前缀返回 400 problem。
- **OpenAPI 3.1**：go:embed 嵌入的规范文档在 `/openapi.json` 提供，覆盖全部端点、RDAP 词汇 schema（Domain/IPNetwork/Autnum 带 `objectClassName` discriminator）、RFC 9457 错误、`?raw` 参数与 `X-Cache`/`Cache-Control` 头。这也是 v1.0.0 稳定承诺的契约载体。
- **修复**：`config.docker.yaml` 在 config 重构（#12）时漏迁移，仍是旧格式——Docker 镜像启动会直接报旧键迁移错误退出。已迁移到新分组格式。

## Test plan

- [x] `go test ./...` 全绿（新增 CIDR 路由/缓存命中/非法前缀测试、OpenAPI 文档解析与路径完整性测试、IsIP/IsCIDR 单测）
- [x] `gofmt` / `go vet` 干净，`golangci-lint run` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)