### PR TITLE
feat: optional API key authentication (auth.keys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ proxy:
 bootstrap:
   interval: 86400              # RDAP 服务器列表从 IANA 刷新间隔，单位：秒；0 则禁用（推荐：86400）
 
+auth:
+  keys: []                     # API 密钥列表。留空（默认）则服务完全开放；配置一个或多个密钥后，除 /health 和 /ready 外的所有端点都需要认证，请求时通过 "Authorization: Bearer <key>" 或 "X-API-Key: <key>" 携带密钥
+
 mcp:
   localhostProtection: false   # /mcp 端点的 DNS rebinding 保护：开启后只接受 Host 为 localhost 的请求。反向代理部署保持 false；本机直连部署建议设为 true
 ```
 
-部分配置项可通过环境变量覆盖（优先级高于配置文件），如 `WHOIS_REDIS_ADDR`、`WHOIS_REDIS_TLS`、`WHOIS_PORT`、`WHOIS_RATE_LIMIT`、`WHOIS_CACHE_EXPIRATION`、`WHOIS_NEGATIVE_CACHE_EXPIRATION`、`WHOIS_LOG_LEVEL`、`WHOIS_MCP_LOCALHOST_PROTECTION` 等。
+部分配置项可通过环境变量覆盖（优先级高于配置文件），如 `WHOIS_REDIS_ADDR`、`WHOIS_REDIS_TLS`、`WHOIS_PORT`、`WHOIS_RATE_LIMIT`、`WHOIS_CACHE_EXPIRATION`、`WHOIS_NEGATIVE_CACHE_EXPIRATION`、`WHOIS_LOG_LEVEL`、`WHOIS_MCP_LOCALHOST_PROTECTION`、`WHOIS_AUTH_KEYS`（逗号分隔）等。
 
 **配置说明：**
 - **Redis配置**：建议使用Redis以获得更好的性能和多实例缓存共享能力
@@ -85,6 +88,7 @@ mcp:
 - **代理配置**：某些TLD可能需要代理访问，可配置特定后缀使用代理
 - **日志级别**：`debug` 会输出每次缓存命中和上游查询，流量大时噪声较高；生产环境建议保持 `info`
 - **RDAP 刷新间隔**：服务启动时会立即从 IANA 拉取最新 RDAP 服务器列表，之后按此间隔定期刷新；编译进二进制的数据作为拉取失败时的兜底
+- **API 认证**：默认关闭。配置 `auth.keys` 后即启用，未携带有效密钥的请求返回 401（RFC 9457 problem+json）；仅 `/health` 和 `/ready` 豁免，便于存活/就绪探针工作
 
 
 > ⚠️ **Warning:** 限频针对的是程序向 whois 服务器发起的请求，而非用户向本程序发起的请求。例如，您将限频设置为 50，那么程序向注册局 whois 服务器发起的请求将不会超过 50 次/秒，但是用户向本程序发起的请求不受限制。请您通过 Nginx 等工具对本程序进行限流，以防止恶意请求。

--- a/README_EN.md
+++ b/README_EN.md
@@ -80,11 +80,14 @@ proxy:
 bootstrap:
   interval: 86400              # RDAP server list refresh interval in seconds; 0 disables fetching (recommended: 86400)
 
+auth:
+  keys: []                     # Accepted API keys. Empty (the default) leaves the service open; one or more keys protect every endpoint except /health and /ready. Clients send a key as "Authorization: Bearer <key>" or "X-API-Key: <key>"
+
 mcp:
   localhostProtection: false   # DNS-rebinding protection for /mcp: only accept requests whose Host header is localhost. Keep false behind a reverse proxy; set true for direct localhost deployments
 ```
 
-Selected options can be overridden via environment variables (which take precedence over the config file), e.g. `WHOIS_REDIS_ADDR`, `WHOIS_REDIS_TLS`, `WHOIS_PORT`, `WHOIS_RATE_LIMIT`, `WHOIS_CACHE_EXPIRATION`, `WHOIS_NEGATIVE_CACHE_EXPIRATION`, `WHOIS_LOG_LEVEL`, `WHOIS_MCP_LOCALHOST_PROTECTION`.
+Selected options can be overridden via environment variables (which take precedence over the config file), e.g. `WHOIS_REDIS_ADDR`, `WHOIS_REDIS_TLS`, `WHOIS_PORT`, `WHOIS_RATE_LIMIT`, `WHOIS_CACHE_EXPIRATION`, `WHOIS_NEGATIVE_CACHE_EXPIRATION`, `WHOIS_LOG_LEVEL`, `WHOIS_MCP_LOCALHOST_PROTECTION`, `WHOIS_AUTH_KEYS` (comma-separated).
 
 **Configuration Notes:**
 - **Redis Configuration**: Redis is recommended for better performance and multi-instance cache sharing
@@ -95,6 +98,7 @@ Selected options can be overridden via environment variables (which take precede
 - **Proxy Configuration**: Some TLDs may require proxy access
 - **Log Level**: `debug` logs every cache hit and upstream query dispatch — noisy under load; `info` is recommended for production
 - **Bootstrap Interval**: On startup the service immediately fetches the latest RDAP server list from IANA, then refreshes on this interval; compiled-in data serves as fallback if the fetch fails
+- **API Authentication**: Disabled by default. Configuring `auth.keys` enables it; requests without a valid key get a 401 (RFC 9457 problem+json). Only `/health` and `/ready` are exempt so liveness/readiness probes keep working
 
 > ⚠️ **Warning:** The rate limit applies to requests from this program to WHOIS servers, not requests from users to this program. For example, if you set the limit to 50, the program will not exceed 50 requests/second to registry WHOIS servers, but user requests to this program are unlimited. Please use Nginx or other tools to rate-limit this program to prevent malicious requests.
 

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -30,6 +30,12 @@ proxy:
 bootstrap:
   interval: 86400
 
+auth:
+  # API keys accepted for authentication. Empty (the default) leaves the
+  # service open; one or more keys protect every endpoint except /health and
+  # /ready. Can also be set via WHOIS_AUTH_KEYS (comma-separated).
+  keys: []
+
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose
   # Host header is not localhost. Keep false behind a reverse proxy; set true

--- a/config.yaml
+++ b/config.yaml
@@ -45,6 +45,15 @@ bootstrap:
   # 0 disables refreshing.
   interval: 86400
 
+auth:
+  # API keys accepted for authentication. Empty (the default) leaves the
+  # service open; one or more keys protect every endpoint except /health and
+  # /ready. Clients send a key as "Authorization: Bearer <key>" or
+  # "X-API-Key: <key>". Can also be set via WHOIS_AUTH_KEYS (comma-separated).
+  # keys:
+  #   - "your-secret-key"
+  keys: []
+
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose
   # Host header is not localhost. Keep false behind a reverse proxy; set true

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -32,6 +32,13 @@ results are negatively cached like not-found.
 query parameter combination is unsupported (e.g. `?raw=1` on an IP/ASN query,
 which has no raw WHOIS form).
 
+## unauthorized
+
+**Status: 401.** The server has API key authentication enabled (`auth.keys` in
+config) and the request carried no valid key. Send a configured key as
+`Authorization: Bearer <key>` or `X-API-Key: <key>`. Only `/health` and
+`/ready` are exempt from authentication.
+
 ## rate-limited
 
 **Status: 429.** The server's concurrent-request limit (`server.rateLimit` in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,10 @@ var (
 	// MCPLocalhostProtection enables DNS-rebinding protection on the /mcp
 	// endpoint. Defaults to false for reverse proxy deployments.
 	MCPLocalhostProtection bool
+	// AuthKeys is the list of accepted API keys. Empty leaves the service
+	// open; non-empty enables authentication on every endpoint except
+	// /health and /ready.
+	AuthKeys []string
 )
 
 // RequestTimeout bounds how long a single query may take, so a slow upstream
@@ -201,6 +205,12 @@ func load() {
 
 	// Set MCP endpoint options
 	MCPLocalhostProtection = config.MCP.LocalhostProtection
+
+	// Set API authentication keys
+	AuthKeys = config.Auth.Keys
+	if len(AuthKeys) > 0 {
+		slog.Info("API key authentication enabled", "keys", len(AuthKeys))
+	}
 }
 
 // applyDefaults sets default values for configuration left unset
@@ -303,7 +313,7 @@ var legacyKeys = map[string]string{
 // groupKeys are the only keys allowed at the top level of the configuration.
 var groupKeys = map[string]bool{
 	"server": true, "log": true, "cache": true, "redis": true,
-	"proxy": true, "bootstrap": true, "mcp": true,
+	"proxy": true, "bootstrap": true, "mcp": true, "auth": true,
 }
 
 // detectLegacyKeys returns an error describing every pre-v0.9 key found in
@@ -461,6 +471,17 @@ func overrideConfigWithEnv(config *Config) {
 	}
 	if mcpProtection := os.Getenv("WHOIS_MCP_LOCALHOST_PROTECTION"); mcpProtection != "" {
 		config.MCP.LocalhostProtection = mcpProtection == "true" || mcpProtection == "1"
+	}
+
+	// Override API authentication keys (comma-separated)
+	if authKeys := os.Getenv("WHOIS_AUTH_KEYS"); authKeys != "" {
+		keys := []string{}
+		for _, key := range strings.Split(authKeys, ",") {
+			if key = strings.TrimSpace(key); key != "" {
+				keys = append(keys, key)
+			}
+		}
+		config.Auth.Keys = keys
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -207,10 +207,30 @@ func load() {
 	MCPLocalhostProtection = config.MCP.LocalhostProtection
 
 	// Set API authentication keys
-	AuthKeys = config.Auth.Keys
+	authKeys, err := normalizeAuthKeys(config.Auth.Keys)
+	if err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
+	AuthKeys = authKeys
 	if len(AuthKeys) > 0 {
 		slog.Info("API key authentication enabled", "keys", len(AuthKeys))
 	}
+}
+
+// normalizeAuthKeys trims surrounding whitespace from the configured API keys
+// and rejects empty entries: a request with no credentials presents the empty
+// key, so an accidental "" in auth.keys would turn authentication on while
+// accepting every request.
+func normalizeAuthKeys(keys []string) ([]string, error) {
+	normalized := make([]string, len(keys))
+	for i, key := range keys {
+		normalized[i] = strings.TrimSpace(key)
+		if normalized[i] == "" {
+			return nil, fmt.Errorf("auth.keys must not contain empty keys")
+		}
+	}
+	return normalized, nil
 }
 
 // applyDefaults sets default values for configuration left unset

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,6 +30,8 @@ proxy:
   suffixes: ["cn", "jp"]
 bootstrap:
   interval: 3600
+auth:
+  keys: ["key-one", "key-two"]
 mcp:
   localhostProtection: true
 `
@@ -60,6 +62,18 @@ func TestParseConfigYAML(t *testing.T) {
 	}
 	if !cfg.MCP.LocalhostProtection {
 		t.Errorf("mcp.localhostProtection: false")
+	}
+	if len(cfg.Auth.Keys) != 2 || cfg.Auth.Keys[0] != "key-one" {
+		t.Errorf("auth.keys: %+v", cfg.Auth.Keys)
+	}
+}
+
+func TestEnvOverrideAuthKeys(t *testing.T) {
+	t.Setenv("WHOIS_AUTH_KEYS", "k1, k2 ,,k3")
+	var cfg Config
+	overrideConfigWithEnv(&cfg)
+	if len(cfg.Auth.Keys) != 3 || cfg.Auth.Keys[0] != "k1" || cfg.Auth.Keys[1] != "k2" || cfg.Auth.Keys[2] != "k3" {
+		t.Errorf("auth.keys from env: %+v", cfg.Auth.Keys)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -68,6 +68,26 @@ func TestParseConfigYAML(t *testing.T) {
 	}
 }
 
+func TestNormalizeAuthKeys(t *testing.T) {
+	keys, err := normalizeAuthKeys([]string{" padded ", "plain"})
+	if err != nil {
+		t.Fatalf("normalizeAuthKeys: %v", err)
+	}
+	if keys[0] != "padded" || keys[1] != "plain" {
+		t.Errorf("got %+v", keys)
+	}
+
+	for _, bad := range [][]string{{""}, {"   "}, {"ok", ""}} {
+		if _, err := normalizeAuthKeys(bad); err == nil {
+			t.Errorf("normalizeAuthKeys(%q): expected error", bad)
+		}
+	}
+
+	if keys, err := normalizeAuthKeys(nil); err != nil || len(keys) != 0 {
+		t.Errorf("nil keys: got %+v, %v", keys, err)
+	}
+}
+
 func TestEnvOverrideAuthKeys(t *testing.T) {
 	t.Setenv("WHOIS_AUTH_KEYS", "k1, k2 ,,k3")
 	var cfg Config

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -63,6 +63,14 @@ type Config struct {
 		// all fetching; the default config.yaml sets 86400 (24 hours).
 		Interval int `json:"interval" yaml:"interval"`
 	} `json:"bootstrap" yaml:"bootstrap"`
+	// Auth holds API authentication settings.
+	Auth struct {
+		// Keys is the list of accepted API keys. Empty (the default) leaves
+		// the service open; one or more keys protect every endpoint except
+		// /health and /ready, which stay open for liveness probes. Clients
+		// send a key as "Authorization: Bearer <key>" or "X-API-Key: <key>".
+		Keys []string `json:"keys" yaml:"keys"`
+	} `json:"auth" yaml:"auth"`
 	// MCP holds settings for the MCP Streamable HTTP endpoint (/mcp).
 	MCP struct {
 		// LocalhostProtection enables DNS-rebinding protection, which rejects

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "whois",
-    "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details.",
+    "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details. API key authentication is disabled by default; when the operator configures `auth.keys`, every endpoint except /health and /ready requires a key sent as `Authorization: Bearer <key>` or `X-API-Key: <key>`.",
     "version": "0.8.0",
     "license": {
       "name": "MIT",
@@ -44,6 +44,9 @@
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/QueryDenied"
@@ -107,6 +110,9 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/QueryDenied"
           },
@@ -160,6 +166,9 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/QueryDenied"
           },
@@ -212,6 +221,9 @@
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "$ref": "#/components/responses/QueryDenied"
@@ -276,6 +288,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -294,6 +309,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -313,6 +331,9 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -329,12 +350,28 @@
         "responses": {
           "200": {
             "description": "MCP protocol response."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
     }
   },
   "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key sent as `Authorization: Bearer <key>`. Only enforced when the server is configured with `auth.keys`; authentication is disabled by default."
+      },
+      "apiKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API key sent as `X-API-Key: <key>`. Only enforced when the server is configured with `auth.keys`; authentication is disabled by default."
+      }
+    },
     "parameters": {
       "raw": {
         "name": "raw",
@@ -400,6 +437,23 @@
             "schema": {
               "type": "string",
               "description": "Unparsed WHOIS response (only with `?raw=1` on a domain query)."
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "API key authentication is enabled on this server and the request carried no valid key. Only returned when the operator configures `auth.keys`; authentication is disabled by default.",
+        "headers": {
+          "WWW-Authenticate": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "#/components/schemas/Problem"
             }
           }
         }

--- a/internal/utils/response.go
+++ b/internal/utils/response.go
@@ -43,6 +43,14 @@ func writeProblem(w http.ResponseWriter, statusCode int, typeAnchor, title, deta
 	})
 }
 
+// WriteUnauthorized writes the 401 problem response used when API key
+// authentication is enabled and the request carries no valid key.
+func WriteUnauthorized(w http.ResponseWriter) {
+	w.Header().Set("WWW-Authenticate", `Bearer realm="whois"`)
+	writeProblem(w, http.StatusUnauthorized, "unauthorized", "Authentication required",
+		"Provide a valid API key via \"Authorization: Bearer <key>\" or \"X-API-Key: <key>\".")
+}
+
 // WriteRateLimited writes the 429 problem response used when the concurrency
 // limiter rejects a request.
 func WriteRateLimited(w http.ResponseWriter) {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"log/slog"
@@ -48,6 +49,52 @@ func withRequestID(next http.Handler) http.Handler {
 	})
 }
 
+// bearerPrefix is the Authorization header scheme prefix; the scheme name is
+// compared case-insensitively (RFC 9110 section 11.1).
+const bearerPrefix = "Bearer "
+
+// requestAPIKey extracts the API key a request presents, from either an
+// "Authorization: Bearer <key>" or an "X-API-Key: <key>" header.
+func requestAPIKey(r *http.Request) string {
+	if auth := r.Header.Get("Authorization"); len(auth) > len(bearerPrefix) &&
+		strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) {
+		return auth[len(bearerPrefix):]
+	}
+	return r.Header.Get("X-API-Key")
+}
+
+// keyAllowed reports whether key matches one of the configured API keys,
+// comparing in constant time so the comparison itself leaks nothing about the
+// configured keys.
+func keyAllowed(key string) bool {
+	allowed := false
+	for _, k := range config.AuthKeys {
+		if subtle.ConstantTimeCompare([]byte(key), []byte(k)) == 1 {
+			allowed = true
+		}
+	}
+	return allowed
+}
+
+// withAuth enforces API key authentication when auth.keys is configured
+// (empty keys leave the service open). Only /health and /ready are exempt so
+// liveness probes keep working; everything else — queries, /mcp, /metrics,
+// /info, /openapi.json — requires a key: an instance that enables auth is not
+// meant to be publicly enumerable at all.
+func withAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(config.AuthKeys) == 0 || r.URL.Path == "/health" || r.URL.Path == "/ready" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !keyAllowed(requestAPIKey(r)) {
+			utils.WriteUnauthorized(w)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // withCORS allows cross-origin browser access: every response carries
 // Access-Control-Allow-Origin and preflight OPTIONS requests are answered
 // directly.
@@ -57,7 +104,7 @@ func withCORS(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Expose-Headers", "X-Request-ID, X-Cache")
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-Request-ID, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key, X-Request-ID, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
 			w.Header().Set("Access-Control-Max-Age", "86400")
 			w.WriteHeader(http.StatusNoContent)
 			return
@@ -197,7 +244,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),
-		Handler: withRequestID(withCORS(http.DefaultServeMux)),
+		Handler: withRequestID(withCORS(withAuth(http.DefaultServeMux))),
 		// WriteTimeout must exceed the upstream query timeout (WHOIS/RDAP
 		// each allow up to 10s), since the handler queries upstream
 		// synchronously before writing the response.

--- a/main.go
+++ b/main.go
@@ -53,20 +53,26 @@ func withRequestID(next http.Handler) http.Handler {
 // compared case-insensitively (RFC 9110 section 11.1).
 const bearerPrefix = "Bearer "
 
-// requestAPIKey extracts the API key a request presents, from either an
-// "Authorization: Bearer <key>" or an "X-API-Key: <key>" header.
-func requestAPIKey(r *http.Request) string {
+// requestAuthorized reports whether the request presents a configured API
+// key as "Authorization: Bearer <key>" or "X-API-Key: <key>". Both headers
+// are checked, so a stale bearer token does not mask a valid X-API-Key.
+func requestAuthorized(r *http.Request) bool {
 	if auth := r.Header.Get("Authorization"); len(auth) > len(bearerPrefix) &&
-		strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) {
-		return auth[len(bearerPrefix):]
+		strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) &&
+		keyAllowed(auth[len(bearerPrefix):]) {
+		return true
 	}
-	return r.Header.Get("X-API-Key")
+	return keyAllowed(r.Header.Get("X-API-Key"))
 }
 
 // keyAllowed reports whether key matches one of the configured API keys,
 // comparing in constant time so the comparison itself leaks nothing about the
-// configured keys.
+// configured keys. The empty key never matches: it is what a request with no
+// credentials presents.
 func keyAllowed(key string) bool {
+	if key == "" {
+		return false
+	}
 	allowed := false
 	for _, k := range config.AuthKeys {
 		if subtle.ConstantTimeCompare([]byte(key), []byte(k)) == 1 {
@@ -87,7 +93,7 @@ func withAuth(next http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if !keyAllowed(requestAPIKey(r)) {
+		if !requestAuthorized(r) {
 			utils.WriteUnauthorized(w)
 			return
 		}

--- a/main_auth_test.go
+++ b/main_auth_test.go
@@ -85,6 +85,30 @@ func TestAuthAPIKeyHeader(t *testing.T) {
 	}
 }
 
+// TestAuthInvalidBearerFallsBackToAPIKey verifies a stale bearer token does
+// not mask a valid X-API-Key sent on the same request.
+func TestAuthInvalidBearerFallsBackToAPIKey(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	req := httptest.NewRequest("GET", "/info", nil)
+	req.Header.Set("Authorization", "Bearer stale-token")
+	req.Header.Set("X-API-Key", "test-key-1")
+	if w := authRequest(req); w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// TestAuthEmptyKeyNeverMatches verifies a request with no credentials is
+// rejected even if an empty string somehow ends up in the configured keys.
+func TestAuthEmptyKeyNeverMatches(t *testing.T) {
+	withTestAuthKeys(t, "")
+
+	w := authRequest(httptest.NewRequest("GET", "/info", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
 // TestAuthWrongKey verifies unknown keys are rejected on both headers.
 func TestAuthWrongKey(t *testing.T) {
 	withTestAuthKeys(t, "test-key-1")

--- a/main_auth_test.go
+++ b/main_auth_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/config"
+)
+
+// withTestAuthKeys configures API keys for the duration of a test.
+func withTestAuthKeys(t *testing.T, keys ...string) {
+	t.Helper()
+	old := config.AuthKeys
+	config.AuthKeys = keys
+	t.Cleanup(func() { config.AuthKeys = old })
+}
+
+// authRequest runs a request through the full production middleware chain.
+func authRequest(req *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	withRequestID(withCORS(withAuth(newTestMux()))).ServeHTTP(w, req)
+	return w
+}
+
+// TestAuthDisabledAllOpen verifies that with no keys configured (the default)
+// every endpoint stays open.
+func TestAuthDisabledAllOpen(t *testing.T) {
+	withTestAuthKeys(t) // empty
+
+	for _, path := range []string{"/info", "/openapi.json", "/health"} {
+		w := authRequest(httptest.NewRequest("GET", path, nil))
+		if w.Code != http.StatusOK {
+			t.Errorf("%s: expected 200 with auth disabled, got %d", path, w.Code)
+		}
+	}
+}
+
+// TestAuthMissingKey verifies protected endpoints return a 401 problem
+// response when auth is enabled and no key is sent.
+func TestAuthMissingKey(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	for _, path := range []string{"/example.com", "/domain/example.com", "/info", "/metrics", "/openapi.json", "/mcp"} {
+		w := authRequest(httptest.NewRequest("GET", path, nil))
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("%s: expected 401, got %d", path, w.Code)
+			continue
+		}
+		if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+			t.Errorf("%s: expected problem+json, got %q", path, ct)
+		}
+		if got := w.Header().Get("WWW-Authenticate"); !strings.HasPrefix(got, "Bearer") {
+			t.Errorf("%s: WWW-Authenticate: got %q", path, got)
+		}
+		if !strings.Contains(w.Body.String(), "#unauthorized") {
+			t.Errorf("%s: body missing unauthorized problem type: %s", path, w.Body.String())
+		}
+	}
+}
+
+// TestAuthBearerKey verifies a configured key sent as Authorization: Bearer
+// is accepted, including case-insensitive scheme matching.
+func TestAuthBearerKey(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1", "test-key-2")
+
+	for _, scheme := range []string{"Bearer", "bearer", "BEARER"} {
+		req := httptest.NewRequest("GET", "/info", nil)
+		req.Header.Set("Authorization", scheme+" test-key-2")
+		if w := authRequest(req); w.Code != http.StatusOK {
+			t.Errorf("scheme %q: expected 200, got %d", scheme, w.Code)
+		}
+	}
+}
+
+// TestAuthAPIKeyHeader verifies a configured key sent as X-API-Key is accepted.
+func TestAuthAPIKeyHeader(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	req := httptest.NewRequest("GET", "/info", nil)
+	req.Header.Set("X-API-Key", "test-key-1")
+	if w := authRequest(req); w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+// TestAuthWrongKey verifies unknown keys are rejected on both headers.
+func TestAuthWrongKey(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	req := httptest.NewRequest("GET", "/info", nil)
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	if w := authRequest(req); w.Code != http.StatusUnauthorized {
+		t.Errorf("Bearer wrong key: expected 401, got %d", w.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/info", nil)
+	req.Header.Set("X-API-Key", "wrong-key")
+	if w := authRequest(req); w.Code != http.StatusUnauthorized {
+		t.Errorf("X-API-Key wrong key: expected 401, got %d", w.Code)
+	}
+}
+
+// TestAuthProbesExempt verifies /health and /ready stay open with auth
+// enabled, so liveness probes keep working without credentials.
+func TestAuthProbesExempt(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	w := authRequest(httptest.NewRequest("GET", "/health", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/health: expected 200, got %d", w.Code)
+	}
+
+	w = authRequest(httptest.NewRequest("GET", "/ready", nil))
+	if w.Code != http.StatusOK && w.Code != http.StatusServiceUnavailable {
+		t.Errorf("/ready: expected 200 or 503, got %d", w.Code)
+	}
+}
+
+// TestAuthPreflightExempt verifies CORS preflight requests are answered
+// before authentication, so browsers can complete preflight without a key.
+func TestAuthPreflightExempt(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	req := httptest.NewRequest("OPTIONS", "/example.com", nil)
+	req.Header.Set("Origin", "https://example.org")
+	w := authRequest(req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, "Authorization") || !strings.Contains(got, "X-API-Key") {
+		t.Errorf("Access-Control-Allow-Headers missing auth headers: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds optional API key authentication, designed per the v0.9.0 plan:

- **`auth.keys` config (non-empty = enabled)** — no separate `enabled` switch. Also settable via `WHOIS_AUTH_KEYS` (comma-separated, whitespace-trimmed). The legacy-key detector's `groupKeys` now includes `auth`.
- **Keys accepted on either header**: `Authorization: Bearer <key>` (scheme matched case-insensitively per RFC 9110) or `X-API-Key: <key>`; compared with `crypto/subtle.ConstantTimeCompare` against every configured key.
- **Middleware chain** `withRequestID(withCORS(withAuth(mux)))` — only `/health` and `/ready` are exempt (liveness probes). Queries, `/mcp`, `/metrics`, `/info` and `/openapi.json` are all protected: an instance that enables auth is not meant to be publicly enumerable.
- **401 as RFC 9457 problem+json** with `WWW-Authenticate: Bearer` and a new `#unauthorized` anchor in docs/errors.md.
- **CORS**: preflight is answered before auth (browsers can complete OPTIONS without a key); `Access-Control-Allow-Headers` now includes `Authorization, X-API-Key`.
- **OpenAPI**: `securitySchemes` (bearerAuth + apiKeyHeader, documented as disabled by default) and 401 responses on all protected operations.
- Docs: config.yaml / config.docker.yaml examples, README zh+en.

Out of scope (per plan): per-key rate limits/quotas/expiry, configurable exempt list.

## Tests

- 401 without key (all protected endpoint kinds, problem+json + WWW-Authenticate asserted)
- Bearer (case-insensitive scheme) and X-API-Key accepted; wrong key rejected on both headers
- /health and /ready exempt; CORS preflight exempt
- Empty keys = fully open; YAML parse + env override parsing

`go test ./...`, `go vet`, golangci-lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)