### PR TITLE
ci: enable dependabot for gomod and github-actions (weekly)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` with weekly update checks for Go module dependencies and GitHub Actions versions (v0.9.0 plan item 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)