### PR TITLE
feat: WHOIS parsers for .eu (EURid) and .kr/.한국 (KISA)

### DIFF
--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -46,24 +46,27 @@ func finalizeDomainInfo(info *model.DomainInfo, domain string) {
 // whoisParsers is a map from top-level domain (TLD) to a function that can parse
 // the WHOIS response for that TLD into a DomainInfo structure.
 // Currently, it includes parsers for the following TLDs: cn, xn--fiqs8s, xn--fiqz9s,
-// hk, xn--j6w193g, tw, so, sb, sg, mo, ru, su, au, la, jp.
+// hk, xn--j6w193g, tw, so, sb, sg, mo, ru, su, au, la, jp, eu, kr, xn--3e0b707e.
 // You can add parsers for other TLDs by adding them to this map.
 var whoisParsers = map[string]func(string, string) (model.DomainInfo, error){
-	"cn":          whois.ParseWhoisResponseCN,
-	"xn--fiqs8s":  whois.ParseWhoisResponseCN,
-	"xn--fiqz9s":  whois.ParseWhoisResponseCN,
-	"hk":          whois.ParseWhoisResponseHK,
-	"xn--j6w193g": whois.ParseWhoisResponseHK,
-	"tw":          whois.ParseWhoisResponseTW,
-	"so":          whois.ParseWhoisResponseSO,
-	"sb":          whois.ParseWhoisResponseSB,
-	"sg":          whois.ParseWhoisResponseSG,
-	"mo":          whois.ParseWhoisResponseMO,
-	"ru":          whois.ParseWhoisResponseRU,
-	"su":          whois.ParseWhoisResponseRU,
-	"au":          whois.ParseWhoisResponseAU,
-	"la":          whois.ParseWhoisResponseLA,
-	"jp":          whois.ParseWhoisResponseJP,
+	"cn":           whois.ParseWhoisResponseCN,
+	"xn--fiqs8s":   whois.ParseWhoisResponseCN,
+	"xn--fiqz9s":   whois.ParseWhoisResponseCN,
+	"hk":           whois.ParseWhoisResponseHK,
+	"xn--j6w193g":  whois.ParseWhoisResponseHK,
+	"tw":           whois.ParseWhoisResponseTW,
+	"so":           whois.ParseWhoisResponseSO,
+	"sb":           whois.ParseWhoisResponseSB,
+	"sg":           whois.ParseWhoisResponseSG,
+	"mo":           whois.ParseWhoisResponseMO,
+	"ru":           whois.ParseWhoisResponseRU,
+	"su":           whois.ParseWhoisResponseRU,
+	"au":           whois.ParseWhoisResponseAU,
+	"la":           whois.ParseWhoisResponseLA,
+	"jp":           whois.ParseWhoisResponseJP,
+	"eu":           whois.ParseWhoisResponseEU,
+	"kr":           whois.ParseWhoisResponseKR,
+	"xn--3e0b707e": whois.ParseWhoisResponseKR,
 }
 
 // HandleDomain function is used to handle the HTTP request for querying the RDAP (Registration Data Access Protocol) or WHOIS information for a given domain.

--- a/internal/model/normalize.go
+++ b/internal/model/normalize.go
@@ -23,6 +23,7 @@ var dateOnlyLayouts = []string{
 	"02-01-2006", // .hk
 	"2006/01/02", // .jp
 	"02-Jan-2006",
+	"2006. 01. 02.", // .kr
 }
 
 // NormalizeDate parses a registry-provided date string and returns it as

--- a/internal/whois/whois_parsers.go
+++ b/internal/whois/whois_parsers.go
@@ -112,6 +112,21 @@ var (
 	reLADNSSEC             = regexp.MustCompile(`DNSSEC:\s+(.+)`)
 	reLALastUpdateOfRDAPDB = regexp.MustCompile(`>>> Last update of WHOIS database:\s+(.+)`)
 
+	// EU (EURid)。port-43 响应不含任何日期与联系人信息（隐私政策），
+	// 可提取的字段只有注册商、域名服务器与 DNSSEC 公钥。
+	reEURegistrarName = regexp.MustCompile(`Registrar:\s*\n\s*Name:\s*(.*)`)
+	reEUNameServers   = regexp.MustCompile(`(?s)Name servers:\s*\n(.*?)\n\s*\n`)
+	reEUStatus        = regexp.MustCompile(`Status:\s*(.*)`)
+	reEUKeys          = regexp.MustCompile(`\nKeys:\s*\n`)
+
+	// KR (KISA/KRNIC)。响应分韩文/英文两段，只解析 "# ENGLISH" 之后的部分。
+	reKRCreationDate = regexp.MustCompile(`Registered Date\s*:\s*(.*)`)
+	reKRUpdatedDate  = regexp.MustCompile(`Last Updated Date\s*:\s*(.*)`)
+	reKRExpiryDate   = regexp.MustCompile(`Expiration Date\s*:\s*(.*)`)
+	reKRRegistrar    = regexp.MustCompile(`Authorized Agency\s*:\s*(.*)`)
+	reKRNameServer   = regexp.MustCompile(`Host Name\s*:\s*(.*)`)
+	reKRDNSSEC       = regexp.MustCompile(`DNSSEC\s*:\s*(.*)`)
+
 	// JP WHOIS 预编译正则表达式
 	// 格式1：.jp 域名
 	reJPDomainName = regexp.MustCompile(`\[Domain Name\]\s+(.*)`)
@@ -897,6 +912,107 @@ func ParseWhoisResponseJP(response string, domain string) (model.DomainInfo, err
 	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
 
 	// 验证必要字段
+	if domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
+		return model.DomainInfo{}, utils.ErrDomainNotFound
+	}
+
+	return domainInfo, nil
+}
+
+// ParseWhoisResponseEU parses EURid (.eu) WHOIS responses. The port-43
+// service discloses no dates, contacts or EPP status — only the registrar,
+// the name servers (with optional glue addresses) and the DNSSEC public keys.
+func ParseWhoisResponseEU(response string, domain string) (model.DomainInfo, error) {
+	// 未注册域名返回 "Status: AVAILABLE"
+	if status := matchFirstGroup(reEUStatus, response, nil); strings.EqualFold(status, "AVAILABLE") {
+		return model.DomainInfo{}, utils.ErrDomainNotFound
+	}
+
+	domainInfo := newDomainInfo(domain)
+
+	// 解析注册商（Registrar 块内的 Name 行）
+	domainInfo.Registrar = matchFirstGroup(reEURegistrarName, response, nil)
+
+	// 解析域名服务器：块内每行形如 "ns1.eurid.eu (185.36.4.252)"，
+	// 去掉胶水记录地址并去重（同一主机的 v4/v6 各占一行）
+	if m := reEUNameServers.FindStringSubmatch(response); len(m) > 1 {
+		seen := make(map[string]struct{})
+		for _, line := range strings.Split(m[1], "\n") {
+			host := strings.TrimSpace(line)
+			if i := strings.Index(host, " ("); i >= 0 {
+				host = host[:i]
+			}
+			host = strings.ToLower(strings.TrimSpace(host))
+			if host == "" {
+				continue
+			}
+			if _, dup := seen[host]; dup {
+				continue
+			}
+			seen[host] = struct{}{}
+			domainInfo.Nameservers = append(domainInfo.Nameservers, host)
+		}
+	}
+
+	// 解析 DNSSEC：已签名时响应携带 "Keys:" 公钥块，未签名时整块缺失
+	domainInfo.SecureDNS = &model.SecureDNS{DelegationSigned: reEUKeys.MatchString(response)}
+
+	// 设置数据库更新时间为数据处理时间
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
+
+	if domainInfo.Registrar == "" {
+		return model.DomainInfo{}, utils.ErrDomainNotFound
+	}
+
+	return domainInfo, nil
+}
+
+// ParseWhoisResponseKR parses KISA/KRNIC (.kr / .한국) WHOIS responses,
+// reading the "# ENGLISH" half of the bilingual output. Dates are local
+// Korean dates without a time of day ("2007. 02. 28.").
+func ParseWhoisResponseKR(response string, domain string) (model.DomainInfo, error) {
+	// 未注册域名（韩英双语提示）
+	if strings.Contains(response, "The requested domain was not found in the Registry or Registrar") {
+		return model.DomainInfo{}, utils.ErrDomainNotFound
+	}
+
+	// 只解析英文段，避免韩文段的同名字段（如 "DNSSEC : 미서명"）先被匹配
+	if idx := strings.Index(response, "# ENGLISH"); idx >= 0 {
+		response = response[idx:]
+	}
+
+	domainInfo := newDomainInfo(domain)
+
+	// 解析注册/变更/过期日期（日期无时分秒，直接归一为 YYYY-MM-DD）
+	if dateStr := matchFirstGroup(reKRCreationDate, response, nil); dateStr != "" {
+		domainInfo.RegistrationDate = normDate(dateStr, nil)
+	}
+	if dateStr := matchFirstGroup(reKRUpdatedDate, response, nil); dateStr != "" {
+		domainInfo.LastChangedDate = normDate(dateStr, nil)
+	}
+	if dateStr := matchFirstGroup(reKRExpiryDate, response, nil); dateStr != "" {
+		domainInfo.ExpirationDate = normDate(dateStr, nil)
+	}
+
+	// 解析注册商，去掉附带的网址（"Gabia, Inc.(http://www.gabia.co.kr)"）
+	registrar := matchFirstGroup(reKRRegistrar, response, nil)
+	if i := strings.Index(registrar, "(http"); i >= 0 {
+		registrar = strings.TrimSpace(registrar[:i])
+	}
+	domainInfo.Registrar = registrar
+
+	// 解析域名服务器（Primary/Secondary Name Server 块中的 Host Name 行）
+	domainInfo.Nameservers = lowerAll(matchAllFirstGroup(reKRNameServer, response))
+
+	// 解析 DNSSEC（"signed" / "unsigned"）
+	if dnssec := matchFirstGroup(reKRDNSSEC, response, nil); dnssec != "" {
+		domainInfo.SecureDNS = secureDNSFromString(dnssec)
+	}
+
+	// 设置数据库更新时间为数据处理时间
+	domainInfo.LastUpdateOfRdapDb = time.Now().UTC().Format(time.RFC3339)
+
+	// 注册资格受限的域名（如 nic.kr）不返回任何字段，与未注册同样处理
 	if domainInfo.RegistrationDate == "" || domainInfo.ExpirationDate == "" {
 		return model.DomainInfo{}, utils.ErrDomainNotFound
 	}

--- a/internal/whois/whois_parsers_test.go
+++ b/internal/whois/whois_parsers_test.go
@@ -569,3 +569,218 @@ func TestParseWhoisResponseJP_NotFound(t *testing.T) {
 		t.Errorf("expected ErrDomainNotFound, got %v", err)
 	}
 }
+
+func TestParseWhoisResponseEU(t *testing.T) {
+	// 真实 whois.eu 响应节选（前缀的 % 法律声明省略）
+	response := `% WHOIS eurid.eu
+Domain: eurid.eu
+Script: LATIN
+
+Registrant:
+        NOT DISCLOSED!
+        Visit www.eurid.eu for the web-based WHOIS.
+
+Technical:
+        Organisation: EURid vzw
+        Language: en
+        Email: tech@eurid.eu
+
+Registrar:
+        Name: EURid vzw
+        Website: https://www.eurid.eu
+
+Name servers:
+        ns3.eurid.eu (2001:67c:9c:3937::253)
+        ns3.eurid.eu (185.36.4.253)
+        nsp.netnod.se
+        ns1.eurid.eu (2001:67c:9c:3937::252)
+        ns1.eurid.eu (185.36.4.252)
+
+Keys:
+        flags:KSK protocol:3 algorithm:RSA_SHA256 pubKey:AwEAAcOQldGtC33GLx8s335UscKMPlWjDXCqbhR2QyAYcfS4CZS6YHg3A1Zz
+
+Please visit www.eurid.eu for more info.
+`
+
+	domain := "eurid.eu"
+	expected := model.DomainInfo{
+		ObjectClassName: model.ObjectClassDomain,
+		LdhName:         domain,
+		Registrar:       "EURid vzw",
+		Nameservers:     []string{"ns3.eurid.eu", "nsp.netnod.se", "ns1.eurid.eu"},
+		SecureDNS:       &model.SecureDNS{DelegationSigned: true},
+	}
+
+	domainInfo, err := ParseWhoisResponseEU(response, domain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, domainInfo.LastUpdateOfRdapDb); err != nil {
+		t.Errorf("LastUpdateOfRdapDb is not a valid RFC3339 timestamp: %v", domainInfo.LastUpdateOfRdapDb)
+	}
+	domainInfo.LastUpdateOfRdapDb = ""
+	if !reflect.DeepEqual(domainInfo, expected) {
+		t.Errorf("expected %+v, got %+v", expected, domainInfo)
+	}
+}
+
+func TestParseWhoisResponseEU_Unsigned(t *testing.T) {
+	response := `% WHOIS example.eu
+Domain: example.eu
+Script: LATIN
+
+Registrar:
+        Name: Example Registrar BV
+        Website: https://registrar.example
+
+Name servers:
+        ns1.example.net
+        ns2.example.net
+
+Please visit www.eurid.eu for more info.
+`
+
+	domainInfo, err := ParseWhoisResponseEU(response, "example.eu")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if domainInfo.SecureDNS == nil || domainInfo.SecureDNS.DelegationSigned {
+		t.Errorf("expected unsigned secureDNS, got %+v", domainInfo.SecureDNS)
+	}
+	if len(domainInfo.Nameservers) != 2 {
+		t.Errorf("nameservers: %+v", domainInfo.Nameservers)
+	}
+}
+
+func TestParseWhoisResponseEU_NotFound(t *testing.T) {
+	response := `% WHOIS zzz-notexist.eu
+Domain: zzz-notexist.eu
+Script: LATIN
+Status: AVAILABLE
+`
+
+	_, err := ParseWhoisResponseEU(response, "zzz-notexist.eu")
+	if !errors.Is(err, utils.ErrDomainNotFound) {
+		t.Errorf("expected ErrDomainNotFound, got %v", err)
+	}
+}
+
+func TestParseWhoisResponseKR(t *testing.T) {
+	// 真实 whois.kr 响应节选（韩文段在前、英文段在后）
+	response := `query : naver.kr
+
+
+# KOREAN(UTF8)
+
+도메인이름                  : naver.kr
+등록일                      : 2007. 02. 28.
+최근 정보 변경일            : 2018. 02. 28.
+사용 종료일                 : 2027. 02. 28.
+등록대행자                  : (주)가비아(http://www.gabia.co.kr)
+DNSSEC                      : 미서명
+
+1차 네임서버 정보
+   호스트이름               : ns1.naver.com
+
+2차 네임서버 정보
+   호스트이름               : ns2.naver.com
+
+
+# ENGLISH
+
+Domain Name                 : naver.kr
+Registrant                  : NAVER Corp.
+Registrant Address          : 6 Buljung-ro, Bundang-gu, Seongnam-si, Gyeonggi-do, 463-867, Korea, &nbsp;
+Registrant Zip Code         : 463867
+Administrative Contact(AC)  : NAVER Corp.
+AC E-Mail                   : dl_ssl@navercorp.com
+AC Phone Number             : +82.28293528
+Registered Date             : 2007. 02. 28.
+Last Updated Date           : 2018. 02. 28.
+Expiration Date             : 2027. 02. 28.
+Publishes                   : Y
+Authorized Agency           : Gabia, Inc.(http://www.gabia.co.kr)
+DNSSEC                      : unsigned
+
+Primary Name Server
+   Host Name                : ns1.naver.com
+
+Secondary Name Server
+   Host Name                : ns2.naver.com
+
+
+- KISA/KRNIC WHOIS Service -
+`
+
+	domain := "naver.kr"
+	expected := model.DomainInfo{
+		ObjectClassName:  model.ObjectClassDomain,
+		LdhName:          domain,
+		RegistrationDate: "2007-02-28",
+		LastChangedDate:  "2018-02-28",
+		ExpirationDate:   "2027-02-28",
+		Registrar:        "Gabia, Inc.",
+		Nameservers:      []string{"ns1.naver.com", "ns2.naver.com"},
+		SecureDNS:        &model.SecureDNS{DelegationSigned: false},
+	}
+
+	domainInfo, err := ParseWhoisResponseKR(response, domain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := time.Parse(time.RFC3339, domainInfo.LastUpdateOfRdapDb); err != nil {
+		t.Errorf("LastUpdateOfRdapDb is not a valid RFC3339 timestamp: %v", domainInfo.LastUpdateOfRdapDb)
+	}
+	domainInfo.LastUpdateOfRdapDb = ""
+	if !reflect.DeepEqual(domainInfo, expected) {
+		t.Errorf("expected %+v, got %+v", expected, domainInfo)
+	}
+}
+
+func TestParseWhoisResponseKR_NotFound(t *testing.T) {
+	response := `query : zzz-notexist.kr
+
+
+# KOREAN(UTF8)
+
+상기 도메인이름은 등록되어 있지 않습니다.
+
+
+# ENGLISH
+
+The requested domain was not found in the Registry or Registrar’s WHOIS Server.
+
+
+- KISA/KRNIC WHOIS Service -
+`
+
+	_, err := ParseWhoisResponseKR(response, "zzz-notexist.kr")
+	if !errors.Is(err, utils.ErrDomainNotFound) {
+		t.Errorf("expected ErrDomainNotFound, got %v", err)
+	}
+}
+
+func TestParseWhoisResponseKR_Restricted(t *testing.T) {
+	// 注册资格受限的域名（如 nic.kr）不返回任何字段
+	response := `query : nic.kr
+
+
+# KOREAN(UTF8)
+
+상기 도메인이름은 도메인이름의 안정적 관리와 공공의 이익 등을 위하여 
+등록자격이 제한된 도메인이름입니다.
+
+
+# ENGLISH
+
+This request domain name is restricted to specifically qualified registrants for stable management of domain names and public interest.
+
+
+- KISA/KRNIC WHOIS Service -
+`
+
+	_, err := ParseWhoisResponseKR(response, "nic.kr")
+	if !errors.Is(err, utils.ErrDomainNotFound) {
+		t.Errorf("expected ErrDomainNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

v0.9.0 plan item 2 (ccTLD parser expansion). Coverage check against the targets first:

| TLD | Outcome |
|---|---|
| uk, fr, nl, in, th, br | Already have RDAP in the IANA bootstrap — no parser needed |
| de | Already covered by the custom `rdap.denic.de` entry in `rdap_servers_custom.go` |
| **eu** | **New WHOIS parser** (EURid has no RDAP) |
| **kr** | **New WHOIS parser**, also registered for `xn--3e0b707e` (.한국, same KISA server) |
| vn | Skipped — VNNIC runs no public port-43 WHOIS and no RDAP |

Parser details (built and tested against live registry responses):

- **.eu**: EURid's port-43 service discloses no dates, contacts or EPP status by policy. Extracted: registrar name, name servers (glue addresses stripped, v4/v6 duplicate lines deduped), DNSSEC signed-state from the presence of the `Keys:` block. `Status: AVAILABLE` → 404.
- **.kr**: bilingual response; only the `# ENGLISH` half is parsed so Korean field values (e.g. `DNSSEC : 미서명`) can't shadow the English ones. Registered/Last Updated/Expiration dates use a new `2006. 01. 02.` date-only layout in `model.NormalizeDate`; registrar trailing `(http://…)` URL stripped; not-found and restricted-registration responses both → 404.

Live verification: `eurid.eu`, `naver.kr`, `denic.de` (RDAP path) and a nonexistent .kr all return correct results through the full server.

Noticed while verifying (out of scope here, belongs to the RDAP registrar-extraction audit): DENIC RDAP responses come back with no registrar, trailing-dot nameservers, and `delegationSigned: false` for a signed zone.

## Tests

Real-sample table tests for both parsers: full DomainInfo assertions, unsigned-EU variant, EU available→404, KR not-found→404, KR restricted→404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)