### PR TITLE
fix: route .ею/.ευ (EURid IDN ccTLDs) through the .eu WHOIS parser

### DIFF
--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -46,7 +46,8 @@ func finalizeDomainInfo(info *model.DomainInfo, domain string) {
 // whoisParsers is a map from top-level domain (TLD) to a function that can parse
 // the WHOIS response for that TLD into a DomainInfo structure.
 // Currently, it includes parsers for the following TLDs: cn, xn--fiqs8s, xn--fiqz9s,
-// hk, xn--j6w193g, tw, so, sb, sg, mo, ru, su, au, la, jp, eu, kr, xn--3e0b707e.
+// hk, xn--j6w193g, tw, so, sb, sg, mo, ru, su, au, la, jp, eu, xn--e1a4c,
+// xn--qxa6a, kr, xn--3e0b707e.
 // You can add parsers for other TLDs by adding them to this map.
 var whoisParsers = map[string]func(string, string) (model.DomainInfo, error){
 	"cn":           whois.ParseWhoisResponseCN,
@@ -65,6 +66,8 @@ var whoisParsers = map[string]func(string, string) (model.DomainInfo, error){
 	"la":           whois.ParseWhoisResponseLA,
 	"jp":           whois.ParseWhoisResponseJP,
 	"eu":           whois.ParseWhoisResponseEU,
+	"xn--e1a4c":    whois.ParseWhoisResponseEU,
+	"xn--qxa6a":    whois.ParseWhoisResponseEU,
 	"kr":           whois.ParseWhoisResponseKR,
 	"xn--3e0b707e": whois.ParseWhoisResponseKR,
 }


### PR DESCRIPTION
Follow-up to Codex's P2 on #19: `whois_servers.go` already maps `xn--e1a4c` (.ею) and `xn--qxa6a` (.ευ) to `whois.eu`, but the parser map only registered `eu`, so those domains came back as unparsed raw text. Verified live that whois.eu answers `xn--e1a4c` queries in the identical EURid format before adding the aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)