### PR TITLE
fix: RDAP parse audit — registrar IANA ID typing, nested entities, DNSSEC inference

### DIFF
--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -646,6 +646,31 @@
             "items": {
               "$ref": "#/components/schemas/DSData"
             }
+          },
+          "keyData": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KeyData"
+            }
+          }
+        }
+      },
+      "KeyData": {
+        "type": "object",
+        "description": "DNSSEC key record; some registries publish DNSKEY material instead of DS records.",
+        "required": ["flags", "protocol", "algorithm", "publicKey"],
+        "properties": {
+          "flags": {
+            "type": "integer"
+          },
+          "protocol": {
+            "type": "integer"
+          },
+          "algorithm": {
+            "type": "integer"
+          },
+          "publicKey": {
+            "type": "string"
           }
         }
       },

--- a/internal/model/domain.go
+++ b/internal/model/domain.go
@@ -16,10 +16,20 @@ type DSData struct {
 	Digest     string `json:"digest"`
 }
 
+// KeyData is a DNSSEC key record (RFC 9083 section 5.3). Some registries
+// (e.g. DENIC) publish DNSKEY material instead of DS records.
+type KeyData struct {
+	Flags     int    `json:"flags"`
+	Protocol  int    `json:"protocol"`
+	Algorithm int    `json:"algorithm"`
+	PublicKey string `json:"publicKey"`
+}
+
 // SecureDNS describes the DNSSEC state of a domain (RFC 9083 section 5.3).
 type SecureDNS struct {
-	DelegationSigned bool     `json:"delegationSigned"`
-	DSData           []DSData `json:"dsData,omitempty"`
+	DelegationSigned bool      `json:"delegationSigned"`
+	DSData           []DSData  `json:"dsData,omitempty"`
+	KeyData          []KeyData `json:"keyData,omitempty"`
 }
 
 // DomainInfo is the API representation of a domain. Field names follow the

--- a/internal/rdap/rdap_parse.go
+++ b/internal/rdap/rdap_parse.go
@@ -27,6 +27,7 @@ type rdapEntity struct {
 	Roles      []string          `json:"roles"`
 	VcardArray []json.RawMessage `json:"vcardArray"`
 	PublicIds  []rdapPublicId    `json:"publicIds"`
+	Entities   []rdapEntity      `json:"entities"`
 }
 
 type rdapNameserver struct {
@@ -40,9 +41,17 @@ type rdapDsData struct {
 	Digest     string `json:"digest"`
 }
 
+type rdapKeyData struct {
+	Flags     int    `json:"flags"`
+	Protocol  int    `json:"protocol"`
+	Algorithm int    `json:"algorithm"`
+	PublicKey string `json:"publicKey"`
+}
+
 type rdapSecureDNS struct {
-	DelegationSigned bool         `json:"delegationSigned"`
-	DsData           []rdapDsData `json:"dsData"`
+	DelegationSigned bool          `json:"delegationSigned"`
+	DsData           []rdapDsData  `json:"dsData"`
+	KeyData          []rdapKeyData `json:"keyData"`
 }
 
 type rdapDomainResponse struct {
@@ -132,14 +141,16 @@ func ParseRDAPResponseforDomain(response string) (model.DomainInfo, error) {
 		Status:          model.CleanStatus(rdap.Status),
 	}
 
-	// Extract registrar info from entities
-	for _, entity := range rdap.Entities {
-		for _, role := range entity.Roles {
-			if role == "registrar" {
-				info.Registrar = extractRegistrarName(entity.VcardArray)
-				if len(entity.PublicIds) > 0 {
-					info.RegistrarIANAID = entity.PublicIds[0].Identifier
-				}
+	// Extract registrar info from entities. The registrar entity is usually
+	// top-level, but some registries nest it inside another entity, so the
+	// search recurses. Only a public ID typed "IANA Registrar ID" is the IANA
+	// ID — registries also attach other IDs (e.g. Nominet's
+	// "Registry Identifier: NOMINET") that must not be mistaken for it.
+	if registrar := findRegistrarEntity(rdap.Entities); registrar != nil {
+		info.Registrar = extractRegistrarName(registrar.VcardArray)
+		for _, id := range registrar.PublicIds {
+			if strings.EqualFold(id.Type, "IANA Registrar ID") {
+				info.RegistrarIANAID = id.Identifier
 				break
 			}
 		}
@@ -161,16 +172,21 @@ func ParseRDAPResponseforDomain(response string) (model.DomainInfo, error) {
 		}
 	}
 
-	// Extract nameservers
+	// Extract nameservers. Some registries (DENIC, Nominet) return ldhName
+	// as an FQDN with a trailing dot; strip it so hostnames are uniform
+	// across registries.
 	info.Nameservers = make([]string, 0, len(rdap.Nameservers))
 	for _, ns := range rdap.Nameservers {
-		info.Nameservers = append(info.Nameservers, strings.ToLower(ns.LdhName))
+		info.Nameservers = append(info.Nameservers, strings.TrimSuffix(strings.ToLower(ns.LdhName), "."))
 	}
 
-	// Extract DNSSEC info
+	// Extract DNSSEC info. Published DS or DNSKEY records imply a signed
+	// delegation even when the registry omits the delegationSigned boolean
+	// (DENIC sends only keyData).
 	info.SecureDNS = &model.SecureDNS{}
-	if rdap.SecureDNS != nil && rdap.SecureDNS.DelegationSigned {
-		info.SecureDNS.DelegationSigned = true
+	if rdap.SecureDNS != nil {
+		info.SecureDNS.DelegationSigned = rdap.SecureDNS.DelegationSigned ||
+			len(rdap.SecureDNS.DsData) > 0 || len(rdap.SecureDNS.KeyData) > 0
 		for _, ds := range rdap.SecureDNS.DsData {
 			info.SecureDNS.DSData = append(info.SecureDNS.DSData, model.DSData{
 				KeyTag:     ds.KeyTag,
@@ -179,9 +195,35 @@ func ParseRDAPResponseforDomain(response string) (model.DomainInfo, error) {
 				Digest:     ds.Digest,
 			})
 		}
+		for _, kd := range rdap.SecureDNS.KeyData {
+			info.SecureDNS.KeyData = append(info.SecureDNS.KeyData, model.KeyData{
+				Flags:     kd.Flags,
+				Protocol:  kd.Protocol,
+				Algorithm: kd.Algorithm,
+				PublicKey: kd.PublicKey,
+			})
+		}
 	}
 
 	return info, nil
+}
+
+// findRegistrarEntity returns the first entity whose roles include
+// "registrar", searching nested entities depth-first. Returns nil when the
+// response has none (registry-operated TLDs like .br carry no registrar
+// entity at all).
+func findRegistrarEntity(entities []rdapEntity) *rdapEntity {
+	for i := range entities {
+		for _, role := range entities[i].Roles {
+			if role == "registrar" {
+				return &entities[i]
+			}
+		}
+		if nested := findRegistrarEntity(entities[i].Entities); nested != nil {
+			return nested
+		}
+	}
+	return nil
 }
 
 // ParseRDAPResponseforIP parses the RDAP response for an IP address.

--- a/internal/rdap/rdap_parse_test.go
+++ b/internal/rdap/rdap_parse_test.go
@@ -1,0 +1,182 @@
+package rdap
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/model"
+)
+
+// TestParseRDAPDomainRegistrar covers the common gTLD shape (modeled on
+// Verisign .com): top-level registrar entity with an IANA Registrar ID.
+func TestParseRDAPDomainRegistrar(t *testing.T) {
+	response := `{
+		"objectClassName": "domain",
+		"ldhName": "EXAMPLE.COM",
+		"status": ["client delete prohibited"],
+		"entities": [{
+			"objectClassName": "entity",
+			"roles": ["registrar"],
+			"publicIds": [{"type": "IANA Registrar ID", "identifier": "376"}],
+			"vcardArray": ["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "RESERVED-Internet Assigned Numbers Authority"]]]
+		}],
+		"events": [
+			{"eventAction": "registration", "eventDate": "1995-08-14T04:00:00Z"},
+			{"eventAction": "expiration", "eventDate": "2026-08-13T04:00:00Z"}
+		],
+		"nameservers": [
+			{"ldhName": "A.IANA-SERVERS.NET"},
+			{"ldhName": "B.IANA-SERVERS.NET"}
+		],
+		"secureDNS": {
+			"delegationSigned": true,
+			"dsData": [{"keyTag": 370, "algorithm": 13, "digestType": 2, "digest": "BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C"}]
+		}
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := model.DomainInfo{
+		ObjectClassName:  model.ObjectClassDomain,
+		LdhName:          "example.com",
+		Registrar:        "RESERVED-Internet Assigned Numbers Authority",
+		RegistrarIANAID:  "376",
+		Status:           []string{"client delete prohibited"},
+		RegistrationDate: "1995-08-14T04:00:00Z",
+		ExpirationDate:   "2026-08-13T04:00:00Z",
+		Nameservers:      []string{"a.iana-servers.net", "b.iana-servers.net"},
+		SecureDNS: &model.SecureDNS{
+			DelegationSigned: true,
+			DSData: []model.DSData{{
+				KeyTag: 370, Algorithm: 13, DigestType: 2,
+				Digest: "BE74359954660069D5C63D200C39F5603827D7DD02B56F120EE9F3A86764247C",
+			}},
+		},
+	}
+	if !reflect.DeepEqual(info, expected) {
+		t.Errorf("expected %+v, got %+v", expected, info)
+	}
+}
+
+// TestParseRDAPDomainNonIANAPublicId verifies a public ID of another type
+// (Nominet's "Registry Identifier: NOMINET") is not mistaken for the IANA
+// registrar ID, and trailing-dot nameservers are normalized.
+func TestParseRDAPDomainNonIANAPublicId(t *testing.T) {
+	response := `{
+		"ldhName": "nominet.uk",
+		"entities": [{
+			"roles": ["registrar"],
+			"publicIds": [{"type": "Registry Identifier", "identifier": "NOMINET"}],
+			"vcardArray": ["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "Nominet UK"]]]
+		}],
+		"nameservers": [
+			{"ldhName": "dns1.nominetdns.uk."},
+			{"ldhName": "dns2.nominetdns.uk."}
+		]
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Registrar != "Nominet UK" {
+		t.Errorf("registrar: %q", info.Registrar)
+	}
+	if info.RegistrarIANAID != "" {
+		t.Errorf("registrarIanaId should be empty for non-IANA public IDs, got %q", info.RegistrarIANAID)
+	}
+	if !reflect.DeepEqual(info.Nameservers, []string{"dns1.nominetdns.uk", "dns2.nominetdns.uk"}) {
+		t.Errorf("nameservers not normalized: %+v", info.Nameservers)
+	}
+}
+
+// TestParseRDAPDomainKeyDataOnly verifies a DENIC-style secureDNS object —
+// keyData with no delegationSigned boolean — is reported as signed and the
+// key material is surfaced.
+func TestParseRDAPDomainKeyDataOnly(t *testing.T) {
+	response := `{
+		"ldhName": "denic.de",
+		"status": ["active"],
+		"nameservers": [{"ldhName": "ns1.denic.de."}],
+		"secureDNS": {
+			"keyData": [{"algorithm": 8, "flags": 257, "protocol": 3, "publicKey": "AwEAAZ4e0YL"}]
+		}
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !info.SecureDNS.DelegationSigned {
+		t.Error("keyData-only secureDNS should report delegationSigned=true")
+	}
+	expected := []model.KeyData{{Flags: 257, Protocol: 3, Algorithm: 8, PublicKey: "AwEAAZ4e0YL"}}
+	if !reflect.DeepEqual(info.SecureDNS.KeyData, expected) {
+		t.Errorf("keyData: %+v", info.SecureDNS.KeyData)
+	}
+}
+
+// TestParseRDAPDomainNestedRegistrar verifies the registrar entity is found
+// when nested inside another entity.
+func TestParseRDAPDomainNestedRegistrar(t *testing.T) {
+	response := `{
+		"ldhName": "example.org",
+		"entities": [{
+			"roles": ["registrant"],
+			"entities": [{
+				"roles": ["registrar"],
+				"publicIds": [{"type": "IANA Registrar ID", "identifier": "292"}],
+				"vcardArray": ["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "MarkMonitor Inc."]]]
+			}]
+		}]
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Registrar != "MarkMonitor Inc." || info.RegistrarIANAID != "292" {
+		t.Errorf("nested registrar not found: registrar=%q ianaId=%q", info.Registrar, info.RegistrarIANAID)
+	}
+}
+
+// TestParseRDAPDomainNoRegistrar verifies registry-operated TLDs (.br) that
+// carry no registrar entity parse cleanly with the field absent.
+func TestParseRDAPDomainNoRegistrar(t *testing.T) {
+	response := `{
+		"ldhName": "registro.br",
+		"entities": [{"roles": ["registrant"], "vcardArray": ["vcard", [["version", {}, "text", "4.0"], ["fn", {}, "text", "Owner"]]]}],
+		"secureDNS": {"delegationSigned": true, "dsData": [{"keyTag": 1, "algorithm": 13, "digestType": 2, "digest": "AB"}]}
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.Registrar != "" || info.RegistrarIANAID != "" {
+		t.Errorf("expected no registrar, got %q / %q", info.Registrar, info.RegistrarIANAID)
+	}
+	if !info.SecureDNS.DelegationSigned || len(info.SecureDNS.DSData) != 1 {
+		t.Errorf("secureDNS: %+v", info.SecureDNS)
+	}
+}
+
+// TestParseRDAPDomainDsDataWithoutBoolean verifies dsData is kept (and the
+// delegation reported signed) when the registry omits delegationSigned.
+func TestParseRDAPDomainDsDataWithoutBoolean(t *testing.T) {
+	response := `{
+		"ldhName": "example.fr",
+		"secureDNS": {"dsData": [{"keyTag": 5, "algorithm": 8, "digestType": 2, "digest": "CD"}]}
+	}`
+
+	info, err := ParseRDAPResponseforDomain(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !info.SecureDNS.DelegationSigned || len(info.SecureDNS.DSData) != 1 {
+		t.Errorf("secureDNS: %+v", info.SecureDNS)
+	}
+}


### PR DESCRIPTION
v0.9.0 plan item 3: audited `rdap_parse.go` against live responses from Verisign (.com), PIR (.org), DENIC (.de), Nominet (.uk), SIDN (.nl), Afnic (.fr), registro.br and Identity Digital (.me). Findings and fixes:

- **Wrong IANA ID for .uk**: `publicIds[0]` was taken blindly, so Nominet's `{"type": "Registry Identifier", "identifier": "NOMINET"}` came back as `registrarIanaId: "NOMINET"`. Now only entries typed `IANA Registrar ID` (case-insensitive) qualify.
- **Nested registrar entities**: the search now recurses (`findRegistrarEntity`), per the audit plan — all eight sampled registries keep it top-level today, but nesting is legal and seen in the wild.
- **Trailing-dot nameservers**: DENIC and Nominet return `ldhName` as FQDNs (`ns1.denic.de.`); dots are stripped for uniformity.
- **DNSSEC false negatives**: `dsData` was only copied when `delegationSigned: true`, and DENIC sends **only `keyData`** with no boolean at all — signed zones were reported `delegationSigned: false`. Published DS/DNSKEY records now imply a signed delegation, and keyData is surfaced as `secureDNS.keyData` (additive RFC 9083 §5.3 field, added to the OpenAPI schema; .br/.fr style dsData-without-boolean also covered).
- `.br` carrying no registrar entity at all is the registry-direct model — correctly yields no registrar field.

Live verification after the fix: `denic.de` → clean nameservers + `delegationSigned: true` + keyData; `nominet.uk` → `registrar: Nominet UK`, no bogus IANA ID.

## Tests

First tests for the `rdap` package: gTLD happy path (full DomainInfo), non-IANA publicId filtering + dot-stripping, keyData-only secureDNS, nested registrar, no-registrar (.br), dsData-without-boolean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)