### PR TITLE
fix(ci): use positive allowlist for release attachments, drop broken ! exclusions

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -23,11 +23,10 @@ $:
         - name: release 上传附件
           image: cnbcool/attachments:latest
           settings:
-            attachments:
-              - dist/*
-              - "!dist/config.yaml"
-              - "!dist/artifacts.json"
-              - "!dist/metadata.json"
+            # attachments 插件对每个模式独立匹配，"!" 否定模式实际语义是
+            # "除该文件外的全部文件"，多条否定会互相抵消导致排除失效，
+            # 因此只能用正向白名单匹配 goreleaser 产物（归档 + 校验和）
+            attachments: "dist/*.tar.gz,dist/*_checksums.txt"
     - runner:
         tags: cnb:arch:amd64
       services:


### PR DESCRIPTION
## Problem

Release attachment exclusions in `.cnb.yml` never worked: `dist/config.yaml`, `dist/artifacts.json`, and `dist/metadata.json` were still uploaded, and the empty `dist/digests.txt` caused 400 errors.

## Root cause

Reading the [cnbcool/attachments plugin source](https://cnb.cool/cnb/plugins/cnbcool/attachments), `parseAttachment` resolves **each pattern independently** via `find([path])` and merges the results:

- A standalone `!dist/config.yaml` pattern in micromatch means "every file **except** dist/config.yaml" — so each negation pattern matches nearly the whole workspace, and the excluded files get re-included by sibling patterns. Verified locally with micromatch 4 replicating the plugin's `globFilter` logic.
- The comma-separated string format is parsed into the same per-pattern pipeline as the array format (`parsePluginAttachments` falls back to `split(',')`), so switching `attachments` from array to a comma string — with or without `!dist/digests.txt` — would not fix the exclusions either. The earlier diagnosis that the array-to-`{path, ttl}` wrapping breaks `!` parsing doesn't hold: `parseArrayObjectItem` extracts the path (including the `!` prefix) correctly.

## Fix

Drop negation entirely and use a positive allowlist matching the goreleaser outputs:

```yaml
attachments: "dist/*.tar.gz,dist/*_checksums.txt"
```

Per `.ide/.goreleaser.yml`, archives are all `tar.gz` and the checksum file is `whois_<version>_checksums.txt`, so this uploads exactly the intended files and naturally excludes all four metadata files. Verified with micromatch that the result set is exactly `dist/*.tar.gz` + the checksums file.

## Credits

Thanks to [@bringCool](https://github.com/bringCool) for discovering the issue and sharing the initial analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)