### PR TITLE
feat(config): WHOIS_BOOTSTRAP_INTERVAL env override + complete env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,44 @@ mcp:
   localhostProtection: false   # /mcp 端点的 DNS rebinding 保护：开启后只接受 Host 为 localhost 的请求。反向代理部署保持 false；本机直连部署建议设为 true
 ```
 
-部分配置项可通过环境变量覆盖（优先级高于配置文件），如 `WHOIS_REDIS_ADDR`、`WHOIS_REDIS_TLS`、`WHOIS_PORT`、`WHOIS_RATE_LIMIT`、`WHOIS_CACHE_EXPIRATION`、`WHOIS_NEGATIVE_CACHE_EXPIRATION`、`WHOIS_LOG_LEVEL`、`WHOIS_MCP_LOCALHOST_PROTECTION`、`WHOIS_AUTH_KEYS`（逗号分隔）等。
+### 环境变量
+
+所有配置项均可通过环境变量覆盖（优先级高于配置文件），适合 Docker/Kubernetes 等不便挂载配置文件的部署方式：
+
+| 环境变量 | 对应配置项 | 默认值 | 说明 |
+|---------|-----------|--------|------|
+| `WHOIS_PORT` | `server.port` | `8043` | 服务监听端口 |
+| `WHOIS_RATE_LIMIT` | `server.rateLimit` | `100` | 最大并发请求数 |
+| `WHOIS_LOG_LEVEL` | `log.level` | `info` | 日志级别：debug、info、warn、error |
+| `WHOIS_CACHE_EXPIRATION` | `cache.expiration` | `3600` | 缓存过期时间（秒） |
+| `WHOIS_NEGATIVE_CACHE_EXPIRATION` | `cache.negativeExpiration` | `60` | 负向缓存时间（秒），负数禁用 |
+| `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` 时 Redis 不可用则启动失败 |
+| `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | 内存缓存最大条目数 |
+| `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | 内存缓存清理间隔（秒） |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | 空 | Redis 地址；不可用时自动降级到内存缓存（除非开启 requireRedis） |
+| `WHOIS_REDIS_PASSWORD` | `redis.password` | 空 | Redis 密码 |
+| `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis 数据库编号 |
+| `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` 启用 Redis TLS |
+| `WHOIS_REDIS_TLS_SKIP_VERIFY` | `redis.tlsSkipVerify` | `false` | `true`/`1` 跳过证书校验（不推荐） |
+| `WHOIS_PROXY_SERVER` | `proxy.server` | 空 | 代理服务器地址，空则不使用代理 |
+| `WHOIS_PROXY_USERNAME` | `proxy.username` | 空 | 代理用户名 |
+| `WHOIS_PROXY_PASSWORD` | `proxy.password` | 空 | 代理密码 |
+| `WHOIS_PROXY_SUFFIXES` | `proxy.suffixes` | 空 | 走代理的 TLD 列表，**逗号分隔**（`all` 表示全部） |
+| `WHOIS_BOOTSTRAP_INTERVAL` | `bootstrap.interval` | `0`（禁用） | IANA RDAP 列表刷新间隔（秒）；配置文件示例为 86400 |
+| `WHOIS_AUTH_KEYS` | `auth.keys` | 空 | API 密钥，**逗号分隔** |
+| `WHOIS_MCP_LOCALHOST_PROTECTION` | `mcp.localhostProtection` | `false` | `true`/`1` 启用 /mcp 的 DNS rebinding 保护 |
+
+布尔型变量只认 `true` 和 `1`，其余值视为 `false`。数值型变量解析失败时静默忽略并沿用配置文件/默认值。
+
+纯环境变量部署示例（不挂载配置文件）：
+
+```bash
+docker run -d --name whois -p 8043:8043 \
+  -e WHOIS_REDIS_ADDR=redis:6379 \
+  -e WHOIS_BOOTSTRAP_INTERVAL=86400 \
+  -e WHOIS_AUTH_KEYS=secret1,secret2 \
+  --link redis:redis jinzeyang/whois
+```
 
 **配置说明：**
 - **Redis配置**：建议使用Redis以获得更好的性能和多实例缓存共享能力

--- a/README_EN.md
+++ b/README_EN.md
@@ -87,7 +87,44 @@ mcp:
   localhostProtection: false   # DNS-rebinding protection for /mcp: only accept requests whose Host header is localhost. Keep false behind a reverse proxy; set true for direct localhost deployments
 ```
 
-Selected options can be overridden via environment variables (which take precedence over the config file), e.g. `WHOIS_REDIS_ADDR`, `WHOIS_REDIS_TLS`, `WHOIS_PORT`, `WHOIS_RATE_LIMIT`, `WHOIS_CACHE_EXPIRATION`, `WHOIS_NEGATIVE_CACHE_EXPIRATION`, `WHOIS_LOG_LEVEL`, `WHOIS_MCP_LOCALHOST_PROTECTION`, `WHOIS_AUTH_KEYS` (comma-separated).
+### Environment Variables
+
+Every configuration option can be overridden via environment variables (which take precedence over the config file) — handy for Docker/Kubernetes deployments where mounting a config file is inconvenient:
+
+| Variable | Config key | Default | Description |
+|----------|-----------|---------|-------------|
+| `WHOIS_PORT` | `server.port` | `8043` | HTTP listen port |
+| `WHOIS_RATE_LIMIT` | `server.rateLimit` | `100` | Maximum concurrent requests |
+| `WHOIS_LOG_LEVEL` | `log.level` | `info` | Log level: debug, info, warn, error |
+| `WHOIS_CACHE_EXPIRATION` | `cache.expiration` | `3600` | Cache TTL in seconds |
+| `WHOIS_NEGATIVE_CACHE_EXPIRATION` | `cache.negativeExpiration` | `60` | Negative-cache TTL in seconds; negative value disables |
+| `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` makes startup fail when Redis is unavailable |
+| `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | Max entries in the in-memory cache |
+| `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | In-memory cache cleanup interval in seconds |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | empty | Redis address; the service falls back to the in-memory cache when unreachable (unless requireRedis) |
+| `WHOIS_REDIS_PASSWORD` | `redis.password` | empty | Redis password |
+| `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis database number |
+| `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` enables TLS for Redis |
+| `WHOIS_REDIS_TLS_SKIP_VERIFY` | `redis.tlsSkipVerify` | `false` | `true`/`1` skips certificate verification (not recommended) |
+| `WHOIS_PROXY_SERVER` | `proxy.server` | empty | Proxy URL; empty disables proxying |
+| `WHOIS_PROXY_USERNAME` | `proxy.username` | empty | Proxy username |
+| `WHOIS_PROXY_PASSWORD` | `proxy.password` | empty | Proxy password |
+| `WHOIS_PROXY_SUFFIXES` | `proxy.suffixes` | empty | TLDs queried through the proxy, **comma-separated** (`all` proxies everything) |
+| `WHOIS_BOOTSTRAP_INTERVAL` | `bootstrap.interval` | `0` (disabled) | IANA RDAP list refresh interval in seconds; the sample config ships 86400 |
+| `WHOIS_AUTH_KEYS` | `auth.keys` | empty | API keys, **comma-separated** |
+| `WHOIS_MCP_LOCALHOST_PROTECTION` | `mcp.localhostProtection` | `false` | `true`/`1` enables DNS-rebinding protection for /mcp |
+
+Boolean variables accept only `true` and `1`; anything else is treated as `false`. Numeric variables that fail to parse are silently ignored, leaving the config-file/default value in place.
+
+Environment-only deployment example (no config file mounted):
+
+```bash
+docker run -d --name whois -p 8043:8043 \
+  -e WHOIS_REDIS_ADDR=redis:6379 \
+  -e WHOIS_BOOTSTRAP_INTERVAL=86400 \
+  -e WHOIS_AUTH_KEYS=secret1,secret2 \
+  --link redis:redis jinzeyang/whois
+```
 
 **Configuration Notes:**
 - **Redis Configuration**: Redis is recommended for better performance and multi-instance cache sharing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -472,6 +472,13 @@ func overrideConfigWithEnv(config *Config) {
 		}
 	}
 
+	// Override bootstrap configuration
+	if bootstrapInterval := os.Getenv("WHOIS_BOOTSTRAP_INTERVAL"); bootstrapInterval != "" {
+		if intervalInt, err := strconv.Atoi(bootstrapInterval); err == nil {
+			config.Bootstrap.Interval = intervalInt
+		}
+	}
+
 	// Override proxy configuration
 	if proxyServer := os.Getenv("WHOIS_PROXY_SERVER"); proxyServer != "" {
 		config.Proxy.Server = proxyServer

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -97,6 +97,23 @@ func TestEnvOverrideAuthKeys(t *testing.T) {
 	}
 }
 
+func TestEnvOverrideBootstrapInterval(t *testing.T) {
+	t.Setenv("WHOIS_BOOTSTRAP_INTERVAL", "3600")
+	var cfg Config
+	overrideConfigWithEnv(&cfg)
+	if cfg.Bootstrap.Interval != 3600 {
+		t.Errorf("bootstrap.interval from env: %d, want 3600", cfg.Bootstrap.Interval)
+	}
+
+	t.Setenv("WHOIS_BOOTSTRAP_INTERVAL", "not-a-number")
+	cfg = Config{}
+	cfg.Bootstrap.Interval = 86400
+	overrideConfigWithEnv(&cfg)
+	if cfg.Bootstrap.Interval != 86400 {
+		t.Errorf("invalid env should keep existing value: %d, want 86400", cfg.Bootstrap.Interval)
+	}
+}
+
 func TestParseConfigJSON(t *testing.T) {
 	cfg, err := parseConfig([]byte(`{"server": {"port": 8080}, "log": {"level": "warn"}}`), ".json")
 	if err != nil {


### PR DESCRIPTION
## 动机 / Motivation

v0.10.0 系列第 1 个 PR(env 缺口与文档)。

- `bootstrap.interval` 是唯一没有环境变量覆盖的配置项——纯 env 配置的 Docker/K8s 部署无法开启 IANA bootstrap 刷新。补上 `WHOIS_BOOTSTRAP_INTERVAL`。
- README 此前只有一行不完整的 env 列举("如 …等")。中英 README 各加完整对照表(变量 | 配置项 | 默认值 | 说明)+ 纯 env 的 docker run 示例,并写明布尔解析规则(true/1)与数值解析失败静默忽略的行为。
- 明确 `WHOIS_AUTH_KEYS` 仅支持逗号分隔纯 key(后续 PR 的 name/rateLimit 对象形式需配置文件)。

## 测试

- 新增 `TestEnvOverrideBootstrapInterval`(含非法值不覆盖的断言)
- `go test ./...` / gofmt / vet / golangci-lint 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)