### PR TITLE
feat(auth): named API keys with per-client logging and metrics

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,11 +78,20 @@ var (
 	// MCPLocalhostProtection enables DNS-rebinding protection on the /mcp
 	// endpoint. Defaults to false for reverse proxy deployments.
 	MCPLocalhostProtection bool
-	// AuthKeys is the list of accepted API keys. Empty leaves the service
-	// open; non-empty enables authentication on every endpoint except
-	// /health and /ready.
-	AuthKeys []string
+	// AuthClients is the list of accepted API clients (key + display name +
+	// optional rate limit). Empty leaves the service open; non-empty enables
+	// authentication on every endpoint except /health and /ready.
+	AuthClients []AuthClient
 )
+
+// AuthClient is the runtime form of one auth.keys entry: the secret itself
+// plus the name used to label the caller in logs and metrics.
+type AuthClient struct {
+	Key  string
+	Name string
+	// RateLimit is the per-key budget in requests per minute; 0 = unlimited.
+	RateLimit int
+}
 
 // RequestTimeout bounds how long a single query may take, so a slow upstream
 // WHOIS/RDAP server cannot hold a concurrency slot indefinitely. It must stay
@@ -206,31 +215,62 @@ func load() {
 	// Set MCP endpoint options
 	MCPLocalhostProtection = config.MCP.LocalhostProtection
 
-	// Set API authentication keys
-	authKeys, err := normalizeAuthKeys(config.Auth.Keys)
+	// Set API authentication clients
+	authClients, err := normalizeAuthClients(config.Auth.Keys)
 	if err != nil {
 		slog.Error("invalid configuration", "err", err)
 		os.Exit(1)
 	}
-	AuthKeys = authKeys
-	if len(AuthKeys) > 0 {
-		slog.Info("API key authentication enabled", "keys", len(AuthKeys))
+	AuthClients = authClients
+	if len(AuthClients) > 0 {
+		names := make([]string, len(AuthClients))
+		for i, c := range AuthClients {
+			names[i] = c.Name
+		}
+		slog.Info("API key authentication enabled", "clients", names)
 	}
 }
 
-// normalizeAuthKeys trims surrounding whitespace from the configured API keys
-// and rejects empty entries: a request with no credentials presents the empty
-// key, so an accidental "" in auth.keys would turn authentication on while
-// accepting every request.
-func normalizeAuthKeys(keys []string) ([]string, error) {
-	normalized := make([]string, len(keys))
-	for i, key := range keys {
-		normalized[i] = strings.TrimSpace(key)
-		if normalized[i] == "" {
+// normalizeAuthClients turns the configured auth.keys entries into runtime
+// clients. Keys are trimmed and must be non-empty: a request with no
+// credentials presents the empty key, so an accidental "" in auth.keys would
+// turn authentication on while accepting every request. Names default to
+// key1, key2, … by position; they end up in logs and Prometheus label values,
+// so they are held to the same charset/length rule as request IDs. Duplicate
+// keys or names are rejected — duplicate keys would make the matched client
+// ambiguous, duplicate names would silently merge two callers' metrics.
+func normalizeAuthClients(specs []AuthKeySpec) ([]AuthClient, error) {
+	clients := make([]AuthClient, len(specs))
+	seenKeys := make(map[string]bool, len(specs))
+	seenNames := make(map[string]bool, len(specs))
+	for i, spec := range specs {
+		key := strings.TrimSpace(spec.Key)
+		if key == "" {
 			return nil, fmt.Errorf("auth.keys must not contain empty keys")
 		}
+		if seenKeys[key] {
+			return nil, fmt.Errorf("auth.keys entry %d: duplicate key", i+1)
+		}
+		seenKeys[key] = true
+
+		name := strings.TrimSpace(spec.Name)
+		if name == "" {
+			name = fmt.Sprintf("key%d", i+1)
+		} else if !utils.IsValidRequestID(name) {
+			return nil, fmt.Errorf("auth.keys entry %d: name %q must be 1-64 characters of [A-Za-z0-9._-]", i+1, spec.Name)
+		}
+		if seenNames[name] {
+			return nil, fmt.Errorf("auth.keys entry %d: duplicate name %q", i+1, name)
+		}
+		seenNames[name] = true
+
+		if spec.RateLimit < 0 {
+			return nil, fmt.Errorf("auth.keys entry %d (%s): rateLimit must not be negative", i+1, name)
+		}
+
+		clients[i] = AuthClient{Key: key, Name: name, RateLimit: spec.RateLimit}
 	}
-	return normalized, nil
+	return clients, nil
 }
 
 // applyDefaults sets default values for configuration left unset
@@ -500,12 +540,13 @@ func overrideConfigWithEnv(config *Config) {
 		config.MCP.LocalhostProtection = mcpProtection == "true" || mcpProtection == "1"
 	}
 
-	// Override API authentication keys (comma-separated)
+	// Override API authentication keys (comma-separated bare keys; the
+	// name/rateLimit object form is config-file only)
 	if authKeys := os.Getenv("WHOIS_AUTH_KEYS"); authKeys != "" {
-		keys := []string{}
+		keys := []AuthKeySpec{}
 		for _, key := range strings.Split(authKeys, ",") {
 			if key = strings.TrimSpace(key); key != "" {
-				keys = append(keys, key)
+				keys = append(keys, AuthKeySpec{Key: key})
 			}
 		}
 		config.Auth.Keys = keys

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,28 +63,86 @@ func TestParseConfigYAML(t *testing.T) {
 	if !cfg.MCP.LocalhostProtection {
 		t.Errorf("mcp.localhostProtection: false")
 	}
-	if len(cfg.Auth.Keys) != 2 || cfg.Auth.Keys[0] != "key-one" {
+	if len(cfg.Auth.Keys) != 2 || cfg.Auth.Keys[0].Key != "key-one" {
 		t.Errorf("auth.keys: %+v", cfg.Auth.Keys)
 	}
 }
 
-func TestNormalizeAuthKeys(t *testing.T) {
-	keys, err := normalizeAuthKeys([]string{" padded ", "plain"})
+func TestParseConfigAuthKeyObjects(t *testing.T) {
+	cfg, err := parseConfig([]byte(`
+auth:
+  keys:
+    - "bare-secret"
+    - key: "named-secret"
+      name: "ci"
+      rateLimit: 120
+`), ".yaml")
 	if err != nil {
-		t.Fatalf("normalizeAuthKeys: %v", err)
+		t.Fatalf("parseConfig: %v", err)
 	}
-	if keys[0] != "padded" || keys[1] != "plain" {
-		t.Errorf("got %+v", keys)
+	if len(cfg.Auth.Keys) != 2 {
+		t.Fatalf("auth.keys: %+v", cfg.Auth.Keys)
+	}
+	if cfg.Auth.Keys[0] != (AuthKeySpec{Key: "bare-secret"}) {
+		t.Errorf("bare entry: %+v", cfg.Auth.Keys[0])
+	}
+	if cfg.Auth.Keys[1] != (AuthKeySpec{Key: "named-secret", Name: "ci", RateLimit: 120}) {
+		t.Errorf("object entry: %+v", cfg.Auth.Keys[1])
+	}
+}
+
+func TestParseConfigAuthKeyObjectUnknownField(t *testing.T) {
+	_, err := parseConfig([]byte("auth:\n  keys:\n    - key: \"k\"\n      limit: 5\n"), ".yaml")
+	if err == nil || !strings.Contains(err.Error(), `unknown field "limit"`) {
+		t.Errorf("expected unknown-field error, got %v", err)
+	}
+}
+
+func TestParseConfigAuthKeyObjectsJSON(t *testing.T) {
+	cfg, err := parseConfig([]byte(`{"auth": {"keys": ["bare", {"key": "k2", "name": "ci", "rateLimit": 60}]}}`), ".json")
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+	if cfg.Auth.Keys[0].Key != "bare" || cfg.Auth.Keys[1] != (AuthKeySpec{Key: "k2", Name: "ci", RateLimit: 60}) {
+		t.Errorf("auth.keys from json: %+v", cfg.Auth.Keys)
 	}
 
-	for _, bad := range [][]string{{""}, {"   "}, {"ok", ""}} {
-		if _, err := normalizeAuthKeys(bad); err == nil {
-			t.Errorf("normalizeAuthKeys(%q): expected error", bad)
+	if _, err := parseConfig([]byte(`{"auth": {"keys": [{"key": "k", "limit": 5}]}}`), ".json"); err == nil {
+		t.Error("expected unknown-field error for json object entry")
+	}
+}
+
+func TestNormalizeAuthClients(t *testing.T) {
+	clients, err := normalizeAuthClients([]AuthKeySpec{
+		{Key: " padded "},
+		{Key: "plain", Name: "ci", RateLimit: 60},
+	})
+	if err != nil {
+		t.Fatalf("normalizeAuthClients: %v", err)
+	}
+	if clients[0] != (AuthClient{Key: "padded", Name: "key1"}) {
+		t.Errorf("auto-named client: %+v", clients[0])
+	}
+	if clients[1] != (AuthClient{Key: "plain", Name: "ci", RateLimit: 60}) {
+		t.Errorf("named client: %+v", clients[1])
+	}
+
+	for name, bad := range map[string][]AuthKeySpec{
+		"empty key":          {{Key: ""}},
+		"blank key":          {{Key: "   "}},
+		"empty among ok":     {{Key: "ok"}, {Key: ""}},
+		"duplicate key":      {{Key: "same"}, {Key: "same"}},
+		"duplicate name":     {{Key: "a", Name: "ci"}, {Key: "b", Name: "ci"}},
+		"name with space":    {{Key: "a", Name: "my ci"}},
+		"negative rateLimit": {{Key: "a", RateLimit: -1}},
+	} {
+		if _, err := normalizeAuthClients(bad); err == nil {
+			t.Errorf("%s: expected error", name)
 		}
 	}
 
-	if keys, err := normalizeAuthKeys(nil); err != nil || len(keys) != 0 {
-		t.Errorf("nil keys: got %+v, %v", keys, err)
+	if clients, err := normalizeAuthClients(nil); err != nil || len(clients) != 0 {
+		t.Errorf("nil specs: got %+v, %v", clients, err)
 	}
 }
 
@@ -92,7 +150,7 @@ func TestEnvOverrideAuthKeys(t *testing.T) {
 	t.Setenv("WHOIS_AUTH_KEYS", "k1, k2 ,,k3")
 	var cfg Config
 	overrideConfigWithEnv(&cfg)
-	if len(cfg.Auth.Keys) != 3 || cfg.Auth.Keys[0] != "k1" || cfg.Auth.Keys[1] != "k2" || cfg.Auth.Keys[2] != "k3" {
+	if len(cfg.Auth.Keys) != 3 || cfg.Auth.Keys[0].Key != "k1" || cfg.Auth.Keys[1].Key != "k2" || cfg.Auth.Keys[2].Key != "k3" {
 		t.Errorf("auth.keys from env: %+v", cfg.Auth.Keys)
 	}
 }

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -1,5 +1,72 @@
 package config
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AuthKeySpec is one entry of auth.keys. It accepts two forms:
+//
+//   - "secret"                       # bare string: anonymous key, no per-key limit
+//   - {key: "secret", name: "ci", rateLimit: 120}
+//
+// Name labels the caller in logs and metrics (auto-named key1, key2, … when
+// omitted); RateLimit is the per-key request budget in requests per minute
+// (0 or omitted = unlimited).
+type AuthKeySpec struct {
+	Key       string `json:"key" yaml:"key"`
+	Name      string `json:"name" yaml:"name"`
+	RateLimit int    `json:"rateLimit" yaml:"rateLimit"`
+}
+
+// UnmarshalYAML accepts either a bare string or a mapping. Unknown fields in
+// the mapping are rejected, preserving the strict parsing the rest of the
+// config gets from yaml.Decoder.KnownFields (which does not reach inside
+// custom unmarshalers).
+func (s *AuthKeySpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		return value.Decode(&s.Key)
+	}
+	var fields map[string]yaml.Node
+	if err := value.Decode(&fields); err != nil {
+		return err
+	}
+	for name := range fields {
+		switch name {
+		case "key", "name", "rateLimit":
+		default:
+			return fmt.Errorf("unknown field %q in auth.keys entry", name)
+		}
+	}
+	type plain AuthKeySpec
+	var p plain
+	if err := value.Decode(&p); err != nil {
+		return err
+	}
+	*s = AuthKeySpec(p)
+	return nil
+}
+
+// UnmarshalJSON accepts either a bare string or an object, mirroring
+// UnmarshalYAML.
+func (s *AuthKeySpec) UnmarshalJSON(data []byte) error {
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, &s.Key)
+	}
+	type plain AuthKeySpec
+	var p plain
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&p); err != nil {
+		return err
+	}
+	*s = AuthKeySpec(p)
+	return nil
+}
+
 // Config represents the configuration for the application. YAML and JSON tags
 // are identical camelCase; keys from the pre-v0.9 flat layout are rejected at
 // load time with a migration hint (see legacyKeys in config.go).
@@ -69,7 +136,9 @@ type Config struct {
 		// the service open; one or more keys protect every endpoint except
 		// /health and /ready, which stay open for liveness probes. Clients
 		// send a key as "Authorization: Bearer <key>" or "X-API-Key: <key>".
-		Keys []string `json:"keys" yaml:"keys"`
+		// Entries are bare strings or {key, name, rateLimit} objects; see
+		// AuthKeySpec.
+		Keys []AuthKeySpec `json:"keys" yaml:"keys"`
 	} `json:"auth" yaml:"auth"`
 	// MCP holds settings for the MCP Streamable HTTP endpoint (/mcp).
 	MCP struct {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -25,6 +25,18 @@ var (
 		[]string{"type"},
 	)
 
+	// ClientRequestsTotal counts completed HTTP requests by authenticated
+	// client name and status code. Only populated when API key authentication
+	// is enabled; requests that fail authentication are counted under the
+	// client label "unauthenticated".
+	ClientRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "whois_client_requests_total",
+			Help: "Total HTTP requests by authenticated client and status code (auth enabled only).",
+		},
+		[]string{"client", "status_code"},
+	)
+
 	// CacheRequestsTotal counts cache lookups by backend (memory/redis) and result (hit/miss).
 	CacheRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{

--- a/internal/utils/client.go
+++ b/internal/utils/client.go
@@ -1,0 +1,19 @@
+package utils
+
+import "context"
+
+// clientKey is the context key under which the authenticated client's name is
+// stored (see config.AuthClient).
+type clientKey struct{}
+
+// WithClient returns a copy of ctx carrying the authenticated client's name.
+func WithClient(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, clientKey{}, name)
+}
+
+// ClientFromContext returns the authenticated client name stored in ctx, if
+// any. Requests on an instance without auth enabled carry none.
+func ClientFromContext(ctx context.Context) (string, bool) {
+	name, ok := ctx.Value(clientKey{}).(string)
+	return name, ok && name != ""
+}

--- a/internal/utils/log_handler.go
+++ b/internal/utils/log_handler.go
@@ -5,15 +5,16 @@ import (
 	"log/slog"
 )
 
-// ContextHandler wraps a slog.Handler and appends a request_id attribute to
-// records whose context carries one (see WithRequestID), so all logs emitted
-// on a request path can be correlated. Log calls must use the *Context slog
-// variants for the ID to flow through.
+// ContextHandler wraps a slog.Handler and appends request_id and client
+// attributes to records whose context carries them (see WithRequestID and
+// WithClient), so all logs emitted on a request path can be correlated and
+// attributed to a caller. Log calls must use the *Context slog variants for
+// the attributes to flow through.
 type ContextHandler struct {
 	slog.Handler
 }
 
-// NewContextHandler wraps h with request-id extraction.
+// NewContextHandler wraps h with request-id and client extraction.
 func NewContextHandler(h slog.Handler) *ContextHandler {
 	return &ContextHandler{Handler: h}
 }
@@ -21,6 +22,9 @@ func NewContextHandler(h slog.Handler) *ContextHandler {
 func (h *ContextHandler) Handle(ctx context.Context, r slog.Record) error {
 	if id, ok := RequestIDFromContext(ctx); ok {
 		r.AddAttrs(slog.String("request_id", id))
+	}
+	if name, ok := ClientFromContext(ctx); ok {
+		r.AddAttrs(slog.String("client", name))
 	}
 	return h.Handler.Handle(ctx, r)
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,13 @@ func (sw *statusWriter) WriteHeader(code int) {
 	sw.ResponseWriter.WriteHeader(code)
 }
 
+// Unwrap exposes the underlying writer to http.ResponseController, so
+// optional interfaces like http.Flusher keep working through the wrapper —
+// the MCP endpoint's SSE stream needs Flush to deliver its initial response.
+func (sw *statusWriter) Unwrap() http.ResponseWriter {
+	return sw.ResponseWriter
+}
+
 // withRequestID attaches a request ID to every request: an inbound
 // X-Request-ID header is reused when it passes validation, otherwise a fresh
 // ID is generated. The ID is echoed on the response and stored in the request

--- a/main.go
+++ b/main.go
@@ -53,33 +53,35 @@ func withRequestID(next http.Handler) http.Handler {
 // compared case-insensitively (RFC 9110 section 11.1).
 const bearerPrefix = "Bearer "
 
-// requestAuthorized reports whether the request presents a configured API
-// key as "Authorization: Bearer <key>" or "X-API-Key: <key>". Both headers
-// are checked, so a stale bearer token does not mask a valid X-API-Key.
-func requestAuthorized(r *http.Request) bool {
+// requestClient returns the configured client whose API key the request
+// presents as "Authorization: Bearer <key>" or "X-API-Key: <key>", or nil.
+// Both headers are checked, so a stale bearer token does not mask a valid
+// X-API-Key.
+func requestClient(r *http.Request) *config.AuthClient {
 	if auth := r.Header.Get("Authorization"); len(auth) > len(bearerPrefix) &&
-		strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) &&
-		keyAllowed(auth[len(bearerPrefix):]) {
-		return true
-	}
-	return keyAllowed(r.Header.Get("X-API-Key"))
-}
-
-// keyAllowed reports whether key matches one of the configured API keys,
-// comparing in constant time so the comparison itself leaks nothing about the
-// configured keys. The empty key never matches: it is what a request with no
-// credentials presents.
-func keyAllowed(key string) bool {
-	if key == "" {
-		return false
-	}
-	allowed := false
-	for _, k := range config.AuthKeys {
-		if subtle.ConstantTimeCompare([]byte(key), []byte(k)) == 1 {
-			allowed = true
+		strings.EqualFold(auth[:len(bearerPrefix)], bearerPrefix) {
+		if client := clientForKey(auth[len(bearerPrefix):]); client != nil {
+			return client
 		}
 	}
-	return allowed
+	return clientForKey(r.Header.Get("X-API-Key"))
+}
+
+// clientForKey returns the configured client whose key matches, comparing
+// every entry in constant time so the comparison itself leaks nothing about
+// the configured keys. The empty key never matches: it is what a request with
+// no credentials presents.
+func clientForKey(key string) *config.AuthClient {
+	if key == "" {
+		return nil
+	}
+	var matched *config.AuthClient
+	for i := range config.AuthClients {
+		if subtle.ConstantTimeCompare([]byte(key), []byte(config.AuthClients[i].Key)) == 1 {
+			matched = &config.AuthClients[i]
+		}
+	}
+	return matched
 }
 
 // withAuth enforces API key authentication when auth.keys is configured
@@ -87,17 +89,25 @@ func keyAllowed(key string) bool {
 // liveness probes keep working; everything else — queries, /mcp, /metrics,
 // /info, /openapi.json — requires a key: an instance that enables auth is not
 // meant to be publicly enumerable at all.
+//
+// Authenticated requests carry the client name in the request context, so
+// request-path logs name the caller, and are counted per client in
+// whois_client_requests_total.
 func withAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if len(config.AuthKeys) == 0 || r.URL.Path == "/health" || r.URL.Path == "/ready" {
+		if len(config.AuthClients) == 0 || r.URL.Path == "/health" || r.URL.Path == "/ready" {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if !requestAuthorized(r) {
+		client := requestClient(r)
+		if client == nil {
 			utils.WriteUnauthorized(w)
+			metrics.ClientRequestsTotal.WithLabelValues("unauthenticated", "401").Inc()
 			return
 		}
-		next.ServeHTTP(w, r)
+		sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
+		next.ServeHTTP(sw, r.WithContext(utils.WithClient(r.Context(), client.Name)))
+		metrics.ClientRequestsTotal.WithLabelValues(client.Name, strconv.Itoa(sw.code)).Inc()
 	})
 }
 

--- a/main_auth_test.go
+++ b/main_auth_test.go
@@ -177,6 +177,26 @@ func TestAuthClientInContext(t *testing.T) {
 	}
 }
 
+// TestAuthStatusWriterFlush verifies http.ResponseController can reach the
+// underlying writer's Flush through the metrics statusWriter wrapper — the
+// MCP endpoint's SSE stream relies on it to deliver the initial response.
+func TestAuthStatusWriterFlush(t *testing.T) {
+	withTestAuthKeys(t, "test-key-1")
+
+	var flushErr error
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flushErr = http.NewResponseController(w).Flush()
+	})
+
+	req := httptest.NewRequest("GET", "/mcp", nil)
+	req.Header.Set("X-API-Key", "test-key-1")
+	withAuth(inner).ServeHTTP(httptest.NewRecorder(), req)
+
+	if flushErr != nil {
+		t.Errorf("Flush through statusWriter: %v", flushErr)
+	}
+}
+
 // TestAuthPreflightExempt verifies CORS preflight requests are answered
 // before authentication, so browsers can complete preflight without a key.
 func TestAuthPreflightExempt(t *testing.T) {

--- a/main_auth_test.go
+++ b/main_auth_test.go
@@ -1,20 +1,32 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
 )
 
-// withTestAuthKeys configures API keys for the duration of a test.
+// withTestAuthKeys configures anonymous API keys for the duration of a test.
 func withTestAuthKeys(t *testing.T, keys ...string) {
 	t.Helper()
-	old := config.AuthKeys
-	config.AuthKeys = keys
-	t.Cleanup(func() { config.AuthKeys = old })
+	clients := make([]config.AuthClient, len(keys))
+	for i, key := range keys {
+		clients[i] = config.AuthClient{Key: key, Name: fmt.Sprintf("key%d", i+1)}
+	}
+	withTestAuthClients(t, clients)
+}
+
+// withTestAuthClients configures full auth clients for the duration of a test.
+func withTestAuthClients(t *testing.T, clients []config.AuthClient) {
+	t.Helper()
+	old := config.AuthClients
+	config.AuthClients = clients
+	t.Cleanup(func() { config.AuthClients = old })
 }
 
 // authRequest runs a request through the full production middleware chain.
@@ -139,6 +151,29 @@ func TestAuthProbesExempt(t *testing.T) {
 	w = authRequest(httptest.NewRequest("GET", "/ready", nil))
 	if w.Code != http.StatusOK && w.Code != http.StatusServiceUnavailable {
 		t.Errorf("/ready: expected 200 or 503, got %d", w.Code)
+	}
+}
+
+// TestAuthClientInContext verifies the matched client's name reaches the
+// request context, where logs (and later per-key rate limiting) pick it up.
+func TestAuthClientInContext(t *testing.T) {
+	withTestAuthClients(t, []config.AuthClient{
+		{Key: "test-key-1", Name: "ci"},
+		{Key: "test-key-2", Name: "monitor"},
+	})
+
+	var gotName string
+	var gotOK bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotName, gotOK = utils.ClientFromContext(r.Context())
+	})
+
+	req := httptest.NewRequest("GET", "/info", nil)
+	req.Header.Set("X-API-Key", "test-key-2")
+	withAuth(inner).ServeHTTP(httptest.NewRecorder(), req)
+
+	if !gotOK || gotName != "monitor" {
+		t.Errorf("client in context: got %q (ok=%v), want \"monitor\"", gotName, gotOK)
 	}
 }
 


### PR DESCRIPTION
## 动机 / Motivation

v0.10.0 系列第 2 个 PR("鉴权解锁的功能"):给 key 起名字、按调用方观测。为下一个 PR 的按 key 限流打地基(rateLimit 字段本 PR 只解析校验、不生效)。

`auth.keys` 现在同时接受字符串和对象两种条目(**完全向后兼容**):

```yaml
auth:
  keys:
    - "plain-secret"            # 旧写法:匿名 key,自动命名 key1/key2/…
    - key: "another-secret"
      name: "ci"                # 进日志 client 字段和 Prometheus client label
      rateLimit: 120            # 次/分钟;0 或缺省=不限(下一个 PR 生效)
```

## 实现

- `AuthKeySpec` 自定义 YAML/JSON 解码,**对象内未知字段报错**(与全局严格解析一致,自定义 unmarshaler 不在 yaml KnownFields 覆盖范围内,手动补齐)
- 运行时 `config.AuthClients []AuthClient` 取代 `AuthKeys []string`;校验:空 key 报错(保留)、name 限 `[A-Za-z0-9._-]{1,64}`(可安全进 Prometheus label/日志,复用 IsValidRequestID 同一规则)、key/name 重复报错、rateLimit 负数报错
- `withAuth` 解析出匹配 client(仍恒定时间遍历全部条目)、把 name 注入请求 ctx;`ContextHandler` 日志增 `client` 字段
- 新增 `whois_client_requests_total{client, status_code}`:独立计数器,不动现有 HTTPRequestsTotal 的 label(不破坏既有 dashboard);仅鉴权开启时打点,鉴权失败计入 client="unauthenticated"
- `WHOIS_AUTH_KEYS` env 不变(逗号分隔纯 key,对象形式仅配置文件)

## 测试

- config:字符串/对象混排(YAML+JSON)、未知字段报错、name 校验/重复/负 rateLimit、env 解析
- main:新增 TestAuthClientInContext;既有 auth 测试全部保持通过(行为零变化)
- go test / gofmt / vet / golangci-lint 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)