### PR TITLE
feat: ?refresh=1 forces a fresh upstream query (authenticated instances only)

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -39,6 +39,14 @@ config) and the request carried no valid key. Send a configured key as
 `Authorization: Bearer <key>` or `X-API-Key: <key>`. Only `/health` and
 `/ready` are exempt from authentication.
 
+## refresh-requires-auth
+
+**Status: 403.** The `?refresh` parameter (force a fresh upstream query,
+bypassing the cache) was used on an instance that does not have API key
+authentication enabled. Refresh is only honored on authenticated instances,
+because on an open instance it would let anyone bypass the cache and hammer
+upstream registries.
+
 ## rate-limited
 
 **Status: 429.** Either the server's concurrent-request limit

--- a/internal/handlers/asn.go
+++ b/internal/handlers/asn.go
@@ -16,7 +16,9 @@ import (
 )
 
 // HandleASN function is used to handle the HTTP request for querying the RDAP information for a given ASN (Autonomous System Number).
-func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string) {
+// When refresh is true the cache read is skipped: the query goes upstream and
+// its result overwrites the cached entry (X-Cache: REFRESH).
+func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string, refresh bool) {
 	// Parse the ASN
 	asn := strings.TrimPrefix(resource, "asn")
 	if asn == resource {
@@ -30,19 +32,21 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 
 	// Check cache first before doing any lookups
 	key := fmt.Sprintf("%s%s", cacheKeyPrefix, asn)
-	cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-	if err != nil {
-		utils.HandleInternalError(ctx, w, err)
-		return
-	}
-	if cacheResult.Found {
-		w.Header().Set("X-Cache", "HIT")
-		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+	if !refresh {
+		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
+		if err != nil {
+			utils.HandleInternalError(ctx, w, err)
 			return
 		}
-		setCacheControl(w)
-		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
-		return
+		if cacheResult.Found {
+			w.Header().Set("X-Cache", "HIT")
+			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+				return
+			}
+			setCacheControl(w)
+			utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
+			return
+		}
 	}
 
 	// Find the RDAP server URL via pre-built sorted ASN range index
@@ -77,7 +81,7 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 	}
 
 	// Return the RDAP information
-	w.Header().Set("X-Cache", "MISS")
+	w.Header().Set("X-Cache", missLabel(refresh))
 	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -76,7 +76,9 @@ var whoisParsers = map[string]func(string, string) (model.DomainInfo, error){
 // When raw is true, the unparsed WHOIS response is returned as text/plain
 // (RDAP is skipped, since RDAP has no raw-text form), cached under a separate
 // "raw:" key namespace so parsed and raw results never mix.
-func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string, raw bool) {
+// When refresh is true the cache read is skipped: the query goes upstream and
+// its result overwrites the cached entry (X-Cache: REFRESH).
+func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string, raw, refresh bool) {
 	// Convert the domain to Punycode encoding (supports IDN domains)
 	punycodeDomain, err := idna.ToASCII(resource)
 	if err != nil {
@@ -113,24 +115,26 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	}
 
 	// Check if the RDAP or WHOIS information for the domain is cached
-	cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-	if err != nil {
-		utils.HandleInternalError(ctx, w, err)
-		return
-	}
-
-	if cacheResult.Found {
-		w.Header().Set("X-Cache", "HIT")
-		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+	if !refresh {
+		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
+		if err != nil {
+			utils.HandleInternalError(ctx, w, err)
 			return
 		}
-		contentType := "application/json"
-		if len(cacheResult.Data) == 0 || cacheResult.Data[0] != '{' {
-			contentType = "text/plain; charset=utf-8"
+
+		if cacheResult.Found {
+			w.Header().Set("X-Cache", "HIT")
+			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+				return
+			}
+			contentType := "application/json"
+			if len(cacheResult.Data) == 0 || cacheResult.Data[0] != '{' {
+				contentType = "text/plain; charset=utf-8"
+			}
+			setCacheControl(w)
+			utils.HandleCacheResponse(w, cacheResult.Data, contentType)
+			return
 		}
-		setCacheControl(w)
-		utils.HandleCacheResponse(w, cacheResult.Data, contentType)
-		return
 	}
 
 	// Select the query path: RDAP preferred, WHOIS as fallback (raw output
@@ -164,7 +168,7 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 		return
 	}
 
-	w.Header().Set("X-Cache", "MISS")
+	w.Header().Set("X-Cache", missLabel(refresh))
 	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)

--- a/internal/handlers/headers.go
+++ b/internal/handlers/headers.go
@@ -12,3 +12,12 @@ import (
 func setCacheControl(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(config.CacheExpiration.Seconds())))
 }
+
+// missLabel is the X-Cache value for a response that went upstream: REFRESH
+// when the cache was deliberately bypassed (?refresh=1), MISS otherwise.
+func missLabel(refresh bool) string {
+	if refresh {
+		return "REFRESH"
+	}
+	return "MISS"
+}

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -16,22 +16,26 @@ import (
 )
 
 // HandleIP function is used to handle the HTTP request for querying the RDAP information for a given IP.
-func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string) {
+// When refresh is true the cache read is skipped: the query goes upstream and
+// its result overwrites the cached entry (X-Cache: REFRESH).
+func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string, refresh bool) {
 	// Check cache first before doing any lookups
 	key := fmt.Sprintf("%s%s", cacheKeyPrefix, resource)
-	cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-	if err != nil {
-		utils.HandleInternalError(ctx, w, err)
-		return
-	}
-	if cacheResult.Found {
-		w.Header().Set("X-Cache", "HIT")
-		if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+	if !refresh {
+		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
+		if err != nil {
+			utils.HandleInternalError(ctx, w, err)
 			return
 		}
-		setCacheControl(w)
-		utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
-		return
+		if cacheResult.Found {
+			w.Header().Set("X-Cache", "HIT")
+			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
+				return
+			}
+			setCacheControl(w)
+			utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
+			return
+		}
 	}
 
 	// Parse the IP (for CIDR input, the prefix base address) and find the
@@ -72,7 +76,7 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 	}
 
 	// Return the RDAP information
-	w.Header().Set("X-Cache", "MISS")
+	w.Header().Set("X-Cache", missLabel(refresh))
 	setCacheControl(w)
 	w.Header().Set("Content-Type", outcome.contentType)
 	_, _ = fmt.Fprint(w, outcome.body)

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -38,6 +38,9 @@
             "$ref": "#/components/parameters/raw"
           },
           {
+            "$ref": "#/components/parameters/refresh"
+          },
+          {
             "$ref": "#/components/parameters/ifNoneMatch"
           }
         ],
@@ -86,6 +89,9 @@
           },
           {
             "$ref": "#/components/parameters/raw"
+          },
+          {
+            "$ref": "#/components/parameters/refresh"
           },
           {
             "$ref": "#/components/parameters/ifNoneMatch"
@@ -156,6 +162,9 @@
             }
           },
           {
+            "$ref": "#/components/parameters/refresh"
+          },
+          {
             "$ref": "#/components/parameters/ifNoneMatch"
           }
         ],
@@ -216,6 +225,9 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "$ref": "#/components/parameters/refresh"
           },
           {
             "$ref": "#/components/parameters/ifNoneMatch"
@@ -422,6 +434,15 @@
         "schema": {
           "type": "string"
         }
+      },
+      "refresh": {
+        "name": "refresh",
+        "in": "query",
+        "required": false,
+        "description": "Bypass the server-side cache and query the upstream registry, overwriting the cached entry (response carries `X-Cache: REFRESH`). Only honored when API key authentication is enabled; open instances return 403 `refresh-requires-auth`. `refresh=0` and `refresh=false` opt out; any other presence of the parameter opts in.",
+        "schema": {
+          "type": "string"
+        }
       }
     },
     "headers": {
@@ -432,12 +453,13 @@
         }
       },
       "X-Cache": {
-        "description": "Whether the response was served from the server-side cache (HIT) or fetched from the upstream registry (MISS).",
+        "description": "Whether the response was served from the server-side cache (HIT), fetched from the upstream registry (MISS), or forced upstream by `?refresh` (REFRESH).",
         "schema": {
           "type": "string",
           "enum": [
             "HIT",
-            "MISS"
+            "MISS",
+            "REFRESH"
           ]
         }
       },
@@ -540,7 +562,7 @@
         }
       },
       "QueryDenied": {
-        "description": "The upstream registry refused to answer the query.",
+        "description": "The upstream registry refused to answer the query (problem type `query-denied`), or `?refresh` was used on an instance without API key authentication enabled (problem type `refresh-requires-auth`).",
         "content": {
           "application/problem+json": {
             "schema": {

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -69,11 +69,11 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	const cacheKeyPrefix = handlers.CacheKeyPrefix
 
 	if utils.IsIP(query) || utils.IsCIDR(query) {
-		handlers.HandleIP(ctx, rc, query, cacheKeyPrefix)
+		handlers.HandleIP(ctx, rc, query, cacheKeyPrefix, false)
 	} else if utils.IsASN(query) {
-		handlers.HandleASN(ctx, rc, query, cacheKeyPrefix)
+		handlers.HandleASN(ctx, rc, query, cacheKeyPrefix, false)
 	} else if utils.IsDomain(query) {
-		handlers.HandleDomain(ctx, rc, query, cacheKeyPrefix, false)
+		handlers.HandleDomain(ctx, rc, query, cacheKeyPrefix, false, false)
 	} else {
 		return errorResult("Invalid input: please provide a valid domain, IP address, or ASN"), nil, nil
 	}

--- a/internal/utils/response.go
+++ b/internal/utils/response.go
@@ -75,6 +75,16 @@ func WriteRateLimitedAfter(w http.ResponseWriter, retryAfter time.Duration) {
 		"The API key's request budget is exhausted. Retry after the delay in the Retry-After header.")
 }
 
+// WriteRefreshRequiresAuth writes the 403 problem response returned when
+// ?refresh is used on an instance without API key authentication: an open
+// instance honoring forced refreshes would let anyone bypass the cache and
+// hammer upstream registries.
+func WriteRefreshRequiresAuth(w http.ResponseWriter) {
+	writeProblem(w, http.StatusForbidden, "refresh-requires-auth",
+		"Refresh requires authentication",
+		"The ?refresh parameter is only honored when API key authentication (auth.keys) is enabled on this instance.")
+}
+
 // HandleQueryError handles common query errors with appropriate HTTP responses.
 // Unexpected errors are logged in full but reported to the client with a
 // generic message, so internal details such as upstream server addresses and

--- a/main.go
+++ b/main.go
@@ -220,6 +220,13 @@ func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 	rawValue := r.URL.Query().Get("raw")
 	raw := r.URL.Query().Has("raw") && rawValue != "0" && rawValue != "false"
 
+	// ?refresh bypasses the cache read and overwrites the cached entry with a
+	// fresh upstream result. Only honored when authentication is enabled: on
+	// an open instance it would let anyone bypass the cache and hammer
+	// upstream registries.
+	refreshValue := r.URL.Query().Get("refresh")
+	refresh := r.URL.Query().Has("refresh") && refreshValue != "0" && refreshValue != "false"
+
 	cacheKeyPrefix := handlers.CacheKeyPrefix
 
 	// GET responses are buffered so a 200 gets an ETag and an If-None-Match
@@ -246,20 +253,22 @@ func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 	switch {
 	case want != "" && resourceType != want:
 		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, typedPathError[want])
+	case refresh && len(config.AuthClients) == 0:
+		utils.WriteRefreshRequiresAuth(sw)
 	case resourceType == "ip":
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
-			handlers.HandleIP(ctx, sw, resource, cacheKeyPrefix)
+			handlers.HandleIP(ctx, sw, resource, cacheKeyPrefix, refresh)
 		}
 	case resourceType == "asn":
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
-			handlers.HandleASN(ctx, sw, resource, cacheKeyPrefix)
+			handlers.HandleASN(ctx, sw, resource, cacheKeyPrefix, refresh)
 		}
 	case resourceType == "domain":
-		handlers.HandleDomain(ctx, sw, resource, cacheKeyPrefix, raw)
+		handlers.HandleDomain(ctx, sw, resource, cacheKeyPrefix, raw, refresh)
 	default:
 		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Invalid input. Please provide a valid domain, IP, or ASN.")
 	}

--- a/main_refresh_test.go
+++ b/main_refresh_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
+)
+
+// TestRefreshRequiresAuth verifies ?refresh is rejected with the
+// refresh-requires-auth problem when authentication is not enabled.
+func TestRefreshRequiresAuth(t *testing.T) {
+	withTestAuthKeys(t) // auth disabled
+
+	req := httptest.NewRequest("GET", "/example.com?refresh=1", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/problem+json") {
+		t.Errorf("expected problem+json, got %q", ct)
+	}
+	if !strings.Contains(w.Body.String(), "#refresh-requires-auth") {
+		t.Errorf("body missing refresh-requires-auth problem type: %s", w.Body.String())
+	}
+}
+
+// TestRefreshOptOut verifies refresh=0 / refresh=false behave like no refresh
+// at all: served from cache even on an open instance.
+func TestRefreshOptOut(t *testing.T) {
+	withTestAuthKeys(t) // auth disabled
+
+	domain := "refreshoptouttest.cn"
+	key := handlers.CacheKeyPrefix + domain
+	if err := config.CacheManager.Set(context.Background(), key, `{"ldhName":"`+domain+`"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	for _, q := range []string{"?refresh=0", "?refresh=false"} {
+		req := httptest.NewRequest("GET", "/"+domain+q, nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("%s: expected 200, got %d", q, w.Code)
+		}
+		if got := w.Header().Get("X-Cache"); got != "HIT" {
+			t.Errorf("%s: X-Cache: got %q, want HIT", q, got)
+		}
+	}
+}
+
+// TestRefreshBypassesCache verifies an authenticated ?refresh skips the cache
+// read. The domain's TLD has no WHOIS/RDAP server, so the cached entry is the
+// only thing that could serve a 200: without refresh the seeded cache answers
+// (HIT); with refresh the handler must go upstream and fails with the
+// "no server known" 500 — proving the cache was bypassed, without network.
+func TestRefreshBypassesCache(t *testing.T) {
+	withTestAuthKeys(t, "refresh-test-key")
+
+	domain := "refreshbypasstest.zzqqxxnotld"
+	key := handlers.CacheKeyPrefix + domain
+	if err := config.CacheManager.Set(context.Background(), key, `{"ldhName":"`+domain+`"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/"+domain, nil)
+	req.Header.Set("X-API-Key", "refresh-test-key")
+	w := authRequest(req)
+	if w.Code != http.StatusOK || w.Header().Get("X-Cache") != "HIT" {
+		t.Fatalf("without refresh: expected cached 200 HIT, got %d %q", w.Code, w.Header().Get("X-Cache"))
+	}
+
+	req = httptest.NewRequest("GET", "/"+domain+"?refresh=1", nil)
+	req.Header.Set("X-API-Key", "refresh-test-key")
+	w = authRequest(req)
+	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
+		t.Errorf("with refresh: expected the upstream path (500 no server known), got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## 动机 / Motivation

v0.10.0 系列第 4 个 PR。域名转移/续费后,旧缓存要等 TTL(默认 1 小时)过期才能看到新状态。`?refresh=1` 允许强制穿透缓存查注册局并用新结果覆盖缓存。

**为什么仅限鉴权实例**:开放实例上 ?refresh 等于人人可用的缓存击穿器,会被用来刷上游注册局——这正是鉴权落地前一直没做它的原因。未开 `auth.keys` 的实例返回 403 problem+json(新锚点 `refresh-requires-auth`)。

## 行为

- 根路径与类型化路径都支持,取值规则同 `?raw`(`refresh=0/false` 视为未开),可与 `?raw` 叠加
- 跳过缓存读,上游结果照常写缓存;响应 `X-Cache: REFRESH`(区别于 HIT/MISS)
- 并发 refresh 同一资源仍被 singleflight 合并为一次上游请求
- MCP 不暴露 refresh;仍计入按 key 限流的 1 个令牌
- OpenAPI:四条查询路径加 refresh 参数,X-Cache enum 加 REFRESH,QueryDenied 描述覆盖新 problem type

## 测试(全部 network-free)

- 未开鉴权 → 403 + 正确锚点
- `refresh=0/false` → 正常走缓存(HIT)
- **绕过验证**:种缓存 + 无服务器的 TLD——不带 refresh 命中缓存 200,带 refresh 走到服务器选择失败(500 no server known),证明缓存读确实被跳过
- go test / gofmt / vet / golangci-lint 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)