### PR TITLE
feat: POST /batch bulk queries + MCP whois_batch_lookup tool

### DIFF
--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -33,8 +33,17 @@ bootstrap:
 auth:
   # API keys accepted for authentication. Empty (the default) leaves the
   # service open; one or more keys protect every endpoint except /health and
-  # /ready. Can also be set via WHOIS_AUTH_KEYS (comma-separated).
+  # /ready. Can also be set via WHOIS_AUTH_KEYS (comma-separated). Entries
+  # are bare strings, or {key, name, rateLimit} objects for per-key naming
+  # and rate limiting (requests/minute).
   keys: []
+
+batch:
+  # POST /batch bulk queries (and the MCP whois_batch_lookup tool). Off by
+  # default; best enabled together with auth.keys. Can also be set via
+  # WHOIS_BATCH_ENABLED / WHOIS_BATCH_MAX_ITEMS.
+  enabled: false
+  maxItems: 10
 
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose

--- a/config.yaml
+++ b/config.yaml
@@ -50,9 +50,24 @@ auth:
   # service open; one or more keys protect every endpoint except /health and
   # /ready. Clients send a key as "Authorization: Bearer <key>" or
   # "X-API-Key: <key>". Can also be set via WHOIS_AUTH_KEYS (comma-separated).
+  # Entries are bare strings, or objects with a display name (shows up in
+  # logs and metrics) and an optional per-key rate limit in requests/minute:
   # keys:
   #   - "your-secret-key"
+  #   - key: "another-secret-key"
+  #     name: "ci"
+  #     rateLimit: 120
   keys: []
+
+batch:
+  # POST /batch answers up to maxItems mixed domain/IP/ASN queries in one
+  # request (also exposed as the MCP whois_batch_lookup tool). Off by
+  # default; best enabled together with auth.keys, since an open instance
+  # offering batch queries multiplies how fast it can be abused against
+  # upstream registries. With a per-key rate limit, a batch of N queries
+  # costs N tokens.
+  enabled: false
+  maxItems: 10
 
 mcp:
   # DNS-rebinding protection for the /mcp endpoint: rejects requests whose

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -47,6 +47,12 @@ authentication enabled. Refresh is only honored on authenticated instances,
 because on an open instance it would let anyone bypass the cache and hammer
 upstream registries.
 
+## batch-disabled
+
+**Status: 403.** The `POST /batch` endpoint (or the MCP batch tool) was used
+on an instance that has not enabled batch queries. The operator can turn them
+on with `batch.enabled` in the configuration.
+
 ## rate-limited
 
 **Status: 429.** Either the server's concurrent-request limit

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,7 +83,29 @@ var (
 	// optional rate limit). Empty leaves the service open; non-empty enables
 	// authentication on every endpoint except /health and /ready.
 	AuthClients []AuthClient
+	// BatchEnabled turns on the POST /batch bulk-query endpoint and the MCP
+	// batch tool (default: false).
+	BatchEnabled bool
+	// BatchMaxItems caps how many queries one batch request may carry.
+	BatchMaxItems int
 )
+
+// authClientKey is the context key under which the authenticated client is
+// stored by the auth middleware, so handlers that charge more than one
+// rate-limit token per request (batch) can reach the client's limiter.
+type authClientKey struct{}
+
+// WithAuthClient returns a copy of ctx carrying the authenticated client.
+func WithAuthClient(ctx context.Context, client *AuthClient) context.Context {
+	return context.WithValue(ctx, authClientKey{}, client)
+}
+
+// AuthClientFromContext returns the authenticated client stored in ctx, or
+// nil on instances without authentication enabled.
+func AuthClientFromContext(ctx context.Context) *AuthClient {
+	client, _ := ctx.Value(authClientKey{}).(*AuthClient)
+	return client
+}
 
 // AuthClient is the runtime form of one auth.keys entry: the secret itself
 // plus the name used to label the caller in logs and metrics.
@@ -221,6 +243,10 @@ func load() {
 	// Set MCP endpoint options
 	MCPLocalhostProtection = config.MCP.LocalhostProtection
 
+	// Set batch endpoint options
+	BatchEnabled = config.Batch.Enabled
+	BatchMaxItems = config.Batch.MaxItems
+
 	// Set API authentication clients
 	authClients, err := normalizeAuthClients(config.Auth.Keys)
 	if err != nil {
@@ -314,6 +340,11 @@ func applyDefaults(config *Config) {
 	if config.Server.RateLimit == 0 {
 		config.Server.RateLimit = 100
 	}
+
+	// Default batch size cap: 10 queries per request
+	if config.Batch.MaxItems == 0 {
+		config.Batch.MaxItems = 10
+	}
 }
 
 // initializeCacheManager sets up the cache with Redis primary and memory fallback
@@ -383,6 +414,7 @@ var legacyKeys = map[string]string{
 var groupKeys = map[string]bool{
 	"server": true, "log": true, "cache": true, "redis": true,
 	"proxy": true, "bootstrap": true, "mcp": true, "auth": true,
+	"batch": true,
 }
 
 // detectLegacyKeys returns an error describing every pre-v0.9 key found in
@@ -540,6 +572,16 @@ func overrideConfigWithEnv(config *Config) {
 	}
 	if proxySuffixes := os.Getenv("WHOIS_PROXY_SUFFIXES"); proxySuffixes != "" {
 		config.Proxy.Suffixes = strings.Split(proxySuffixes, ",")
+	}
+
+	// Override batch configuration
+	if batchEnabled := os.Getenv("WHOIS_BATCH_ENABLED"); batchEnabled != "" {
+		config.Batch.Enabled = batchEnabled == "true" || batchEnabled == "1"
+	}
+	if batchMaxItems := os.Getenv("WHOIS_BATCH_MAX_ITEMS"); batchMaxItems != "" {
+		if maxItems, err := strconv.Atoi(batchMaxItems); err == nil {
+			config.Batch.MaxItems = maxItems
+		}
 	}
 
 	if logLevel := os.Getenv("WHOIS_LOG_LEVEL"); logLevel != "" {

--- a/internal/config/struct.go
+++ b/internal/config/struct.go
@@ -140,6 +140,16 @@ type Config struct {
 		// AuthKeySpec.
 		Keys []AuthKeySpec `json:"keys" yaml:"keys"`
 	} `json:"auth" yaml:"auth"`
+	// Batch holds settings for the POST /batch bulk-query endpoint.
+	Batch struct {
+		// Enabled turns the endpoint on (default: false). Best combined with
+		// auth.keys: a public open instance offering batch queries multiplies
+		// how fast it can be abused against upstream registries.
+		Enabled bool `json:"enabled" yaml:"enabled"`
+		// MaxItems is the maximum number of queries accepted in one batch
+		// request (default: 10).
+		MaxItems int `json:"maxItems" yaml:"maxItems"`
+	} `json:"batch" yaml:"batch"`
 	// MCP holds settings for the MCP Streamable HTTP endpoint (/mcp).
 	MCP struct {
 		// LocalhostProtection enables DNS-rebinding protection, which rejects

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
+)
+
+// batchConcurrency caps how many of one batch's queries run upstream at the
+// same time. The whole batch shares one request timeout, so items beyond the
+// first waves of a slow batch may individually time out rather than extend
+// the request.
+const batchConcurrency = 5
+
+// maxBatchBody bounds the /batch request body; batches are short lists of
+// domain names, IPs and ASNs, so anything bigger is a mistake or abuse.
+const maxBatchBody = 64 << 10 // 64 KiB
+
+// ResponseCapture is a minimal http.ResponseWriter that buffers the response
+// instead of sending it, so an http handler can be reused as an in-process
+// query function (the MCP tools and the batch endpoint do this).
+type ResponseCapture struct {
+	header     http.Header
+	statusCode int
+	body       bytes.Buffer
+}
+
+// NewResponseCapture returns an empty capture ready to be written to.
+func NewResponseCapture() *ResponseCapture {
+	return &ResponseCapture{header: make(http.Header)}
+}
+
+func (rc *ResponseCapture) Header() http.Header         { return rc.header }
+func (rc *ResponseCapture) Write(b []byte) (int, error) { return rc.body.Write(b) }
+func (rc *ResponseCapture) WriteHeader(code int)        { rc.statusCode = code }
+
+// StatusCode returns the captured status code, defaulting to 200 when the
+// handler never called WriteHeader.
+func (rc *ResponseCapture) StatusCode() int {
+	if rc.statusCode == 0 {
+		return http.StatusOK
+	}
+	return rc.statusCode
+}
+
+// Body returns the captured response body.
+func (rc *ResponseCapture) Body() []byte { return rc.body.Bytes() }
+
+// BatchRequest is the POST /batch request body.
+type BatchRequest struct {
+	Queries []string `json:"queries"`
+}
+
+// BatchItem is the outcome of one query in a batch: Data carries the regular
+// response object on success, Error the RFC 9457 problem object on failure.
+type BatchItem struct {
+	Query  string          `json:"query"`
+	Status int             `json:"status"`
+	Data   json.RawMessage `json:"data,omitempty"`
+	Error  json.RawMessage `json:"error,omitempty"`
+}
+
+// BatchResponse is the POST /batch response body.
+type BatchResponse struct {
+	Results []BatchItem `json:"results"`
+}
+
+// HandleBatch serves POST /batch: a list of mixed domain/IP/ASN queries
+// answered item by item. The response is always 200 with per-item statuses;
+// request-level failures (disabled, oversized, malformed, over budget) are
+// problem responses.
+func HandleBatch(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	if !config.BatchEnabled {
+		utils.WriteBatchDisabled(w)
+		return
+	}
+
+	var req BatchRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBatchBody))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		utils.HandleHTTPError(w, utils.ErrorTypeBadRequest, "Invalid request body: expected {\"queries\": [\"example.com\", ...]}.")
+		return
+	}
+	if len(req.Queries) == 0 {
+		utils.HandleHTTPError(w, utils.ErrorTypeBadRequest, "The queries list must not be empty.")
+		return
+	}
+	if len(req.Queries) > config.BatchMaxItems {
+		utils.HandleHTTPError(w, utils.ErrorTypeBadRequest,
+			"Too many queries in one batch: the limit on this instance is "+strconv.Itoa(config.BatchMaxItems)+".")
+		return
+	}
+
+	// The auth middleware charged one rate-limit token for the request;
+	// charge the remaining N-1 so a batch costs as many tokens as the same
+	// queries sent one by one, and the per-key limit cannot be bypassed.
+	if client := config.AuthClientFromContext(ctx); client != nil && client.Limiter != nil && len(req.Queries) > 1 {
+		reservation := client.Limiter.ReserveN(time.Now(), len(req.Queries)-1)
+		if !reservation.OK() {
+			utils.WriteRateLimitedBatch(w)
+			return
+		}
+		if delay := reservation.Delay(); delay > 0 {
+			reservation.Cancel()
+			utils.WriteRateLimitedAfter(w, delay)
+			return
+		}
+	}
+
+	results := RunBatch(ctx, req.Queries)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(BatchResponse{Results: results})
+}
+
+// RunBatch answers each query with bounded concurrency. Items share the
+// caller's context: when the request deadline expires, unfinished items
+// report their individual timeout errors. Duplicate in-flight queries are
+// collapsed by the singleflight layer the handlers already use. Shared by
+// the HTTP /batch endpoint and the MCP whois_batch_lookup tool.
+func RunBatch(ctx context.Context, queries []string) []BatchItem {
+	results := make([]BatchItem, len(queries))
+	sem := make(chan struct{}, batchConcurrency)
+	var wg sync.WaitGroup
+	for i, query := range queries {
+		wg.Add(1)
+		go func(i int, query string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i] = runBatchItem(ctx, query)
+		}(i, query)
+	}
+	wg.Wait()
+	return results
+}
+
+// runBatchItem answers one batch query by dispatching to the regular
+// domain/IP/ASN handlers against a capture writer, exactly like a single
+// query (cache, singleflight and negative caching all apply).
+func runBatchItem(ctx context.Context, query string) BatchItem {
+	item := BatchItem{Query: query}
+	normalized := strings.ToLower(strings.TrimSpace(query))
+
+	rc := NewResponseCapture()
+	switch {
+	case utils.IsIP(normalized) || utils.IsCIDR(normalized):
+		HandleIP(ctx, rc, normalized, CacheKeyPrefix, false)
+	case utils.IsASN(normalized):
+		HandleASN(ctx, rc, normalized, CacheKeyPrefix, false)
+	case utils.IsDomain(normalized):
+		HandleDomain(ctx, rc, normalized, CacheKeyPrefix, false, false)
+	default:
+		utils.HandleHTTPError(rc, utils.ErrorTypeBadRequest, "Invalid input. Please provide a valid domain, IP, or ASN.")
+	}
+
+	item.Status = rc.StatusCode()
+	body := rc.Body()
+	if !json.Valid(body) {
+		// Defensive: every handler output on these paths is JSON today, but a
+		// non-JSON body must not corrupt the batch response.
+		quoted, _ := json.Marshal(string(body))
+		body = quoted
+	}
+	if item.Status < 400 {
+		item.Data = body
+	} else {
+		item.Error = body
+	}
+	return item
+}

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -134,13 +134,34 @@ func RunBatch(ctx context.Context, queries []string) []BatchItem {
 		wg.Add(1)
 		go func(i int, query string) {
 			defer wg.Done()
-			sem <- struct{}{}
+			// A query still queued when the batch deadline expires must not
+			// start: the handlers' singleflight layer deliberately detaches
+			// upstream flights from the caller's deadline, so a late start
+			// would get a fresh timeout and outlive the response.
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				results[i] = batchDeadlineItem(query)
+				return
+			}
 			defer func() { <-sem }()
+			if ctx.Err() != nil {
+				results[i] = batchDeadlineItem(query)
+				return
+			}
 			results[i] = runBatchItem(ctx, query)
 		}(i, query)
 	}
 	wg.Wait()
 	return results
+}
+
+// batchDeadlineItem reports a query that never ran because the batch's
+// request deadline expired while it was queued behind slower items.
+func batchDeadlineItem(query string) BatchItem {
+	rc := NewResponseCapture()
+	utils.HandleHTTPError(rc, utils.ErrorTypeInternalServer, "The batch deadline expired before this query started; retry it separately.")
+	return BatchItem{Query: query, Status: rc.StatusCode(), Error: rc.Body()}
 }
 
 // runBatchItem answers one batch query by dispatching to the regular

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -276,6 +276,69 @@
         }
       }
     },
+    "/batch": {
+      "post": {
+        "operationId": "batchQuery",
+        "summary": "Query multiple domains, IPs/CIDR prefixes, or ASNs in one request",
+        "description": "Answers each query independently and always returns 200 with per-item statuses: successful items carry the regular response object in `data`, failed items an RFC 9457 problem object in `error`. Disabled by default; the operator enables it with `batch.enabled`, and the number of queries per request is capped by `batch.maxItems` (default 10). When the API key has a per-key rate limit, a batch of N queries costs N tokens — the same as N single queries.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "queries"
+                ],
+                "properties": {
+                  "queries": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Domain names (IDN accepted), IP addresses, CIDR prefixes, or ASNs, freely mixed."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Per-item results in request order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "description": "Batch queries are disabled on this instance (problem type `batch-disabled`).",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "operationId": "health",
@@ -601,6 +664,56 @@
       }
     },
     "schemas": {
+      "BatchResponse": {
+        "type": "object",
+        "required": [
+          "results"
+        ],
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BatchItem"
+            },
+            "description": "One entry per query, in request order."
+          }
+        }
+      },
+      "BatchItem": {
+        "type": "object",
+        "required": [
+          "query",
+          "status"
+        ],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The query exactly as submitted."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status this query would have received as a single request."
+          },
+          "data": {
+            "description": "The regular response object; present when status < 400.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/Domain"
+              },
+              {
+                "$ref": "#/components/schemas/IPNetwork"
+              },
+              {
+                "$ref": "#/components/schemas/Autnum"
+              }
+            ]
+          },
+          "error": {
+            "$ref": "#/components/schemas/Problem",
+            "description": "The problem object; present when status >= 400."
+          }
+        }
+      },
       "Problem": {
         "type": "object",
         "description": "RFC 9457 Problem Details. `type` and `title` are stable identifiers; `detail` is human-readable and may change between releases. See https://github.com/KincaidYang/whois/blob/main/docs/errors.md",

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -1,11 +1,13 @@
 package mcp
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/handlers"
@@ -13,24 +15,14 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// responseCapture is a minimal http.ResponseWriter that captures the response body and status code.
-type responseCapture struct {
-	header     http.Header
-	statusCode int
-	body       bytes.Buffer
-}
-
-func newResponseCapture() *responseCapture {
-	return &responseCapture{header: make(http.Header)}
-}
-
-func (rc *responseCapture) Header() http.Header         { return rc.header }
-func (rc *responseCapture) Write(b []byte) (int, error) { return rc.body.Write(b) }
-func (rc *responseCapture) WriteHeader(code int)        { rc.statusCode = code }
-
 // WhoisInput defines the input schema for the whois_lookup tool.
 type WhoisInput struct {
 	Query string `json:"query" jsonschema:"Domain name, IP address (v4/v6), or ASN (e.g. AS12345) to look up"`
+}
+
+// BatchInput defines the input schema for the whois_batch_lookup tool.
+type BatchInput struct {
+	Queries []string `json:"queries" jsonschema:"Domain names, IP addresses (v4/v6), or ASNs (e.g. AS12345) to look up"`
 }
 
 // errorResult builds a tool result carrying an error message.
@@ -65,7 +57,7 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 
 	query := strings.TrimSpace(strings.ToLower(input.Query))
 
-	rc := newResponseCapture()
+	rc := handlers.NewResponseCapture()
 	const cacheKeyPrefix = handlers.CacheKeyPrefix
 
 	if utils.IsIP(query) || utils.IsCIDR(query) {
@@ -78,15 +70,73 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 		return errorResult("Invalid input: please provide a valid domain, IP address, or ASN"), nil, nil
 	}
 
-	statusCode := rc.statusCode
-	if statusCode == 0 {
-		statusCode = http.StatusOK
+	return &mcp.CallToolResult{
+		IsError: rc.StatusCode() >= 400,
+		Content: []mcp.Content{
+			&mcp.TextContent{Text: string(rc.Body())},
+		},
+	}, nil, nil
+}
+
+// whoisBatchLookup answers the whois_batch_lookup tool: the MCP face of the
+// /batch endpoint, under the same enablement flag, size cap and rate-limit
+// accounting (the HTTP layer charged one token; the rest are charged here).
+func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchInput) (*mcp.CallToolResult, any, error) {
+	if !config.BatchEnabled {
+		return errorResult("Batch queries are disabled on this instance (batch.enabled)"), nil, nil
+	}
+	if len(input.Queries) == 0 {
+		return errorResult("The queries list must not be empty"), nil, nil
+	}
+	if len(input.Queries) > config.BatchMaxItems {
+		return errorResult("Too many queries in one batch: the limit on this instance is " + strconv.Itoa(config.BatchMaxItems)), nil, nil
+	}
+
+	config.Wg.Add(1)
+	select {
+	case config.ConcurrencyLimiter <- struct{}{}:
+	default:
+		config.Wg.Done()
+		slog.WarnContext(ctx, "rate limit reached", "path", "/mcp")
+		return errorResult("too many concurrent requests"), nil, nil
+	}
+	defer func() {
+		config.Wg.Done()
+		<-config.ConcurrencyLimiter
+	}()
+
+	if client := config.AuthClientFromContext(ctx); client != nil && client.Limiter != nil && len(input.Queries) > 1 {
+		reservation := client.Limiter.ReserveN(time.Now(), len(input.Queries)-1)
+		if !reservation.OK() {
+			return errorResult("The batch exceeds the API key's per-minute request budget; reduce the batch size"), nil, nil
+		}
+		if delay := reservation.Delay(); delay > 0 {
+			reservation.Cancel()
+			return errorResult("The API key's request budget is exhausted; retry in " + delay.Round(time.Second).String()), nil, nil
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
+	defer cancel()
+
+	results := handlers.RunBatch(ctx, input.Queries)
+	payload, err := json.Marshal(handlers.BatchResponse{Results: results})
+	if err != nil {
+		return errorResult("failed to encode batch results"), nil, nil
+	}
+
+	isError := true
+	for _, item := range results {
+		if item.Status < 400 {
+			isError = false
+			break
+		}
 	}
 
 	return &mcp.CallToolResult{
-		IsError: statusCode >= 400,
+		IsError: isError,
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: rc.body.String()},
+			&mcp.TextContent{Text: string(payload)},
 		},
 	}, nil, nil
 }
@@ -102,6 +152,11 @@ func NewHandler(version string) http.Handler {
 		Name:        "whois_lookup",
 		Description: "Query WHOIS/RDAP information for a domain name, IP address or CIDR prefix (v4 or v6), or ASN",
 	}, whoisLookup)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "whois_batch_lookup",
+		Description: "Query WHOIS/RDAP information for multiple domain names, IP addresses/CIDR prefixes, or ASNs in one call. Results are returned per query with individual statuses. Disabled unless the operator enables batch queries.",
+	}, whoisBatchLookup)
 
 	return mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return server

--- a/internal/mcp/mcp_server_test.go
+++ b/internal/mcp/mcp_server_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
+	"github.com/KincaidYang/whois/internal/utils"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// setupBatchTest wires up the minimal config state the batch tool needs
+// (cache, concurrency limiter, batch flags) without running config.Load.
+func setupBatchTest(t *testing.T, enabled bool, maxItems int) {
+	t.Helper()
+	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
+	oldEnabled, oldMax := config.BatchEnabled, config.BatchMaxItems
+	config.CacheManager = utils.NewMemoryCache(100, time.Minute)
+	config.ConcurrencyLimiter = make(chan struct{}, 4)
+	config.BatchEnabled, config.BatchMaxItems = enabled, maxItems
+	t.Cleanup(func() {
+		config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter
+		config.BatchEnabled, config.BatchMaxItems = oldEnabled, oldMax
+	})
+}
+
+func toolText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("tool result has no content")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("tool result content is %T, want TextContent", result.Content[0])
+	}
+	return text.Text
+}
+
+// TestBatchToolDisabled verifies the tool refuses when batch.enabled is off.
+func TestBatchToolDisabled(t *testing.T) {
+	setupBatchTest(t, false, 10)
+
+	result, _, err := whoisBatchLookup(context.Background(), nil, &BatchInput{Queries: []string{"example.com"}})
+	if err != nil {
+		t.Fatalf("tool error: %v", err)
+	}
+	if !result.IsError || !strings.Contains(toolText(t, result), "disabled") {
+		t.Errorf("expected disabled error, got: %+v", result)
+	}
+}
+
+// TestBatchToolLimits verifies empty and oversized query lists are rejected.
+func TestBatchToolLimits(t *testing.T) {
+	setupBatchTest(t, true, 2)
+
+	for name, queries := range map[string][]string{
+		"empty":    {},
+		"too many": {"a.com", "b.com", "c.com"},
+	} {
+		result, _, err := whoisBatchLookup(context.Background(), nil, &BatchInput{Queries: queries})
+		if err != nil {
+			t.Fatalf("%s: tool error: %v", name, err)
+		}
+		if !result.IsError {
+			t.Errorf("%s: expected error result", name)
+		}
+	}
+}
+
+// TestBatchToolMixedResults verifies the tool returns per-item results, with
+// a cached domain succeeding and an invalid query failing — network-free.
+func TestBatchToolMixedResults(t *testing.T) {
+	setupBatchTest(t, true, 10)
+
+	domain := "mcpbatchtest.cn"
+	if err := config.CacheManager.Set(context.Background(), handlers.CacheKeyPrefix+domain, `{"ldhName":"`+domain+`"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	result, _, err := whoisBatchLookup(context.Background(), nil, &BatchInput{Queries: []string{domain, "!!invalid!!"}})
+	if err != nil {
+		t.Fatalf("tool error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected success (at least one item succeeded), got error: %s", toolText(t, result))
+	}
+	payload := toolText(t, result)
+	if !strings.Contains(payload, `"status":200`) || !strings.Contains(payload, `"status":400`) {
+		t.Errorf("expected mixed 200/400 statuses in payload: %s", payload)
+	}
+	if !strings.Contains(payload, domain) {
+		t.Errorf("payload missing cached domain data: %s", payload)
+	}
+}

--- a/internal/utils/response.go
+++ b/internal/utils/response.go
@@ -85,6 +85,31 @@ func WriteRefreshRequiresAuth(w http.ResponseWriter) {
 		"The ?refresh parameter is only honored when API key authentication (auth.keys) is enabled on this instance.")
 }
 
+// WriteMethodNotAllowed writes a 405 problem response carrying the Allow
+// header listing the methods the endpoint supports.
+func WriteMethodNotAllowed(w http.ResponseWriter, allow string) {
+	w.Header().Set("Allow", allow)
+	writeProblem(w, http.StatusMethodNotAllowed, "bad-request",
+		"Method not allowed", "This endpoint only accepts "+allow+".")
+}
+
+// WriteBatchDisabled writes the 403 problem response returned when the batch
+// endpoint is requested but batch.enabled is off (the default).
+func WriteBatchDisabled(w http.ResponseWriter) {
+	writeProblem(w, http.StatusForbidden, "batch-disabled",
+		"Batch queries are disabled",
+		"Batch queries are turned off on this instance. The operator can enable them with batch.enabled in the configuration.")
+}
+
+// WriteRateLimitedBatch writes the 429 problem response returned when a batch
+// request asks for more items than the API key's per-minute budget could ever
+// grant, so no Retry-After would make it succeed — the batch must shrink.
+func WriteRateLimitedBatch(w http.ResponseWriter) {
+	writeProblem(w, http.StatusTooManyRequests, "rate-limited",
+		"Rate limit exceeded",
+		"The batch exceeds the API key's per-minute request budget. Reduce the batch size.")
+}
+
 // HandleQueryError handles common query errors with appropriate HTTP responses.
 // Unexpected errors are logged in full but reported to the client with a
 // generic message, so internal details such as upstream server addresses and

--- a/main.go
+++ b/main.go
@@ -123,7 +123,8 @@ func withAuth(next http.Handler) http.Handler {
 			}
 		}
 		sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
-		next.ServeHTTP(sw, r.WithContext(utils.WithClient(r.Context(), client.Name)))
+		ctx := config.WithAuthClient(utils.WithClient(r.Context(), client.Name), client)
+		next.ServeHTTP(sw, r.WithContext(ctx))
 		metrics.ClientRequestsTotal.WithLabelValues(client.Name, strconv.Itoa(sw.code)).Inc()
 	})
 }
@@ -162,6 +163,9 @@ func registerRoutes(mux *http.ServeMux) {
 	// MCP Streamable HTTP endpoint
 	mux.Handle("/mcp", mcp.NewHandler(config.Version))
 
+	// Bulk query endpoint (off unless batch.enabled is set)
+	mux.HandleFunc("/batch", batchHandler)
+
 	// RFC 9082-style typed query paths. The ip path uses a rest wildcard so
 	// CIDR prefixes ("/ip/192.0.2.0/24") keep their slash.
 	mux.HandleFunc("/domain/{resource}", typedHandler("domain"))
@@ -176,6 +180,40 @@ func registerRoutes(mux *http.ServeMux) {
 // domain, IP address, or ASN.
 func handler(w http.ResponseWriter, r *http.Request) {
 	serve(w, r, strings.TrimPrefix(r.URL.Path, "/"), "")
+}
+
+// batchHandler serves POST /batch. Like serve it occupies one concurrency
+// slot and runs under the shared request timeout; the batch's internal
+// fan-out is bounded separately (handlers.HandleBatch).
+func batchHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.WriteMethodNotAllowed(w, http.MethodPost)
+		return
+	}
+
+	config.Wg.Add(1)
+	select {
+	case config.ConcurrencyLimiter <- struct{}{}:
+	default:
+		config.Wg.Done()
+		slog.WarnContext(r.Context(), "rate limit reached", "path", r.URL.Path)
+		utils.WriteRateLimited(w)
+		metrics.HTTPRequestsTotal.WithLabelValues("batch", "429").Inc()
+		return
+	}
+	defer func() {
+		config.Wg.Done()
+		<-config.ConcurrencyLimiter
+	}()
+
+	ctx, cancel := context.WithTimeout(r.Context(), config.RequestTimeout)
+	defer cancel()
+
+	sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
+	start := time.Now()
+	handlers.HandleBatch(ctx, sw, r)
+	metrics.HTTPRequestsTotal.WithLabelValues("batch", strconv.Itoa(sw.code)).Inc()
+	metrics.HTTPRequestDuration.WithLabelValues("batch").Observe(time.Since(start).Seconds())
 }
 
 // typedHandler serves the RFC 9082-style typed paths (/domain/{resource},

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
+)
+
+// withTestBatch enables the batch endpoint for the duration of a test.
+func withTestBatch(t *testing.T, enabled bool, maxItems int) {
+	t.Helper()
+	oldEnabled, oldMax := config.BatchEnabled, config.BatchMaxItems
+	config.BatchEnabled, config.BatchMaxItems = enabled, maxItems
+	t.Cleanup(func() { config.BatchEnabled, config.BatchMaxItems = oldEnabled, oldMax })
+}
+
+func postBatch(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/batch", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	batchHandler(w, req)
+	return w
+}
+
+// TestBatchDisabled verifies the endpoint is off by default and answers with
+// the batch-disabled problem.
+func TestBatchDisabled(t *testing.T) {
+	withTestBatch(t, false, 10)
+
+	w := postBatch(t, `{"queries": ["example.com"]}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "#batch-disabled") {
+		t.Errorf("body missing batch-disabled problem type: %s", w.Body.String())
+	}
+}
+
+// TestBatchMethodNotAllowed verifies non-POST requests get a 405 with Allow.
+func TestBatchMethodNotAllowed(t *testing.T) {
+	withTestBatch(t, true, 10)
+
+	req := httptest.NewRequest("GET", "/batch", nil)
+	w := httptest.NewRecorder()
+	batchHandler(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+	if got := w.Header().Get("Allow"); got != "POST" {
+		t.Errorf("Allow: got %q, want POST", got)
+	}
+}
+
+// TestBatchBadRequests verifies malformed bodies, empty lists and oversized
+// batches are rejected with 400.
+func TestBatchBadRequests(t *testing.T) {
+	withTestBatch(t, true, 2)
+
+	for name, body := range map[string]string{
+		"not json":      `not json at all`,
+		"unknown field": `{"queris": ["example.com"]}`,
+		"empty list":    `{"queries": []}`,
+		"over maxItems": `{"queries": ["a.com", "b.com", "c.com"]}`,
+	} {
+		w := postBatch(t, body)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("%s: expected 400, got %d", name, w.Code)
+		}
+	}
+}
+
+// TestBatchMixedResults verifies per-item successes and failures coexist in
+// one 200 response: a cached domain answers from cache, an invalid input gets
+// a per-item 400 problem, and an unknown TLD reports its per-item 500 — all
+// network-free.
+func TestBatchMixedResults(t *testing.T) {
+	withTestBatch(t, true, 10)
+
+	domain := "batchcachedtest.cn"
+	key := handlers.CacheKeyPrefix + domain
+	if err := config.CacheManager.Set(context.Background(), key, `{"ldhName":"`+domain+`"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	w := postBatch(t, `{"queries": ["`+domain+`", "!!not-valid!!", "nx.zzqqxxnotld"]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp handlers.BatchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(resp.Results))
+	}
+
+	cached := resp.Results[0]
+	if cached.Query != domain || cached.Status != http.StatusOK || cached.Error != nil {
+		t.Errorf("cached item: %+v", cached)
+	}
+	if !strings.Contains(string(cached.Data), domain) {
+		t.Errorf("cached item data missing domain: %s", cached.Data)
+	}
+
+	invalid := resp.Results[1]
+	if invalid.Status != http.StatusBadRequest || invalid.Data != nil {
+		t.Errorf("invalid item: %+v", invalid)
+	}
+	if !strings.Contains(string(invalid.Error), "#bad-request") {
+		t.Errorf("invalid item error missing problem type: %s", invalid.Error)
+	}
+
+	noServer := resp.Results[2]
+	if noServer.Status != http.StatusInternalServerError || noServer.Data != nil {
+		t.Errorf("no-server item: %+v", noServer)
+	}
+}
+
+// TestBatchChargesRateLimitTokens verifies a batch of N queries consumes N
+// tokens of the key's budget: the middleware charges 1, the handler the
+// remaining N-1, so the next request is rejected.
+func TestBatchChargesRateLimitTokens(t *testing.T) {
+	withTestBatch(t, true, 10)
+	withTestAuthClients(t, []config.AuthClient{limitedClient("batch-key", "batcher", 3)})
+
+	// Seed all three so the batch itself stays network-free.
+	for _, d := range []string{"batchtokena.cn", "batchtokenb.cn", "batchtokenc.cn"} {
+		if err := config.CacheManager.Set(context.Background(), handlers.CacheKeyPrefix+d, `{"ldhName":"`+d+`"}`, time.Minute); err != nil {
+			t.Fatalf("failed to seed cache: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest("POST", "/batch", strings.NewReader(`{"queries": ["batchtokena.cn", "batchtokenb.cn", "batchtokenc.cn"]}`))
+	req.Header.Set("X-API-Key", "batch-key")
+	w := authRequest(req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("batch within budget: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Budget (3/min) is now fully spent: a single follow-up request is 429.
+	follow := httptest.NewRequest("GET", "/info", nil)
+	follow.Header.Set("X-API-Key", "batch-key")
+	if w := authRequest(follow); w.Code != http.StatusTooManyRequests {
+		t.Errorf("after batch: expected 429, got %d", w.Code)
+	}
+}
+
+// TestBatchOverBudget verifies a batch larger than the key's whole budget is
+// rejected outright (no Retry-After could ever make it succeed).
+func TestBatchOverBudget(t *testing.T) {
+	withTestBatch(t, true, 10)
+	withTestAuthClients(t, []config.AuthClient{limitedClient("tiny-key", "tiny", 2)})
+
+	req := httptest.NewRequest("POST", "/batch", strings.NewReader(`{"queries": ["a.cn", "b.cn", "c.cn", "d.cn"]}`))
+	req.Header.Set("X-API-Key", "tiny-key")
+	w := authRequest(req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "Reduce the batch size") {
+		t.Errorf("expected the over-budget detail, got: %s", w.Body.String())
+	}
+}

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -126,6 +126,27 @@ func TestBatchMixedResults(t *testing.T) {
 	}
 }
 
+// TestBatchExpiredDeadline verifies queries still queued when the batch
+// deadline expires are reported as per-item errors instead of starting late —
+// the singleflight layer would otherwise give them a fresh detached timeout
+// that can outlive the HTTP response.
+func TestBatchExpiredDeadline(t *testing.T) {
+	withTestBatch(t, true, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results := handlers.RunBatch(ctx, []string{"a.cn", "b.cn"})
+	for _, item := range results {
+		if item.Status != http.StatusInternalServerError {
+			t.Errorf("%s: expected 500 for expired deadline, got %d", item.Query, item.Status)
+		}
+		if !strings.Contains(string(item.Error), "deadline expired") {
+			t.Errorf("%s: expected deadline detail, got: %s", item.Query, item.Error)
+		}
+	}
+}
+
 // TestBatchChargesRateLimitTokens verifies a batch of N queries consumes N
 // tokens of the key's budget: the middleware charges 1, the handler the
 // remaining N-1, so the next request is rejected.


### PR DESCRIPTION
## 动机 / Motivation

v0.10.0 系列第 5 个 PR,主打功能:批量查询。**一直没做它就是因为没有鉴权**——开放实例上批量端点等于滥用放大器;现在鉴权(#27)+按 key 限流(#28)就位,可以安全提供。

## 行为

`POST /batch`,body `{"queries": ["example.com", "8.8.8.8", "AS15169"]}`(类型自动识别,可混排):

```json
{"results": [
  {"query": "example.com", "status": 200, "data": { …常规响应对象… }},
  {"query": "nx.invalid",  "status": 404, "error": { …problem+json… }}
]}
```

- **默认关闭**:`batch.enabled`(env `WHOIS_BATCH_ENABLED`),未开启返回 403 `batch-disabled`;单批上限 `batch.maxItems`(默认 10,env `WHOIS_BATCH_MAX_ITEMS`),建议与 auth.keys 一起开
- **限流不可被批量绕穿**:中间件已扣 1 个令牌,handler 对 N 条再 ReserveN(N-1)——超预算 429+Retry-After;批量大小超过整个分钟预算时直接告知缩小批量
- 复用:每条走常规 handler + 捕获 writer(`ResponseCapture` 从 mcp 包挪到 handlers 共用),缓存/singleflight/负缓存全部生效,批内重复项合并为一次上游
- 并发:整批占 1 个全局并发槽,批内最多 5 条并行,共享 15s 请求超时(超时条目落为该条目的错误,不拖垮整批)
- MCP 新增 `whois_batch_lookup` tool,同一开关/上限/令牌计费
- OpenAPI 加 /batch + BatchResponse/BatchItem schema;docs/errors.md 加 batch-disabled;config 示例加 batch 组与 auth.keys 对象写法

## 测试(全部 network-free)

- 关闭→403、GET→405+Allow、坏 body/未知字段/空列表/超上限→400
- 混合结果:缓存命中 200 data + 无效输入 400 error + 无服务器 TLD 500 error,顺序保持
- 令牌计费:budget=3 的 key 发 3 条批量后,下一个单查 429;批量超整预算直接拒
- MCP tool:disabled/limits/混合结果(internal/mcp 首批测试)
- go test / gofmt / vet / golangci-lint 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)