### PR TITLE
docs: v0.10.0 release docs (README zh/en, CHANGELOG, OpenAPI version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Each breaking change is listed under a **Breaking** heading below. After
 > v1.0.0 the API and configuration format will remain stable.
 
+## [0.10.0] - 2026-06-12
+
+### Added
+- **Named API keys with per-key rate limits.** `auth.keys` entries now also
+  accept an object form `{key, name, rateLimit}` alongside bare strings
+  (fully backward compatible). The name labels the caller in request logs
+  (`client` field) and in the new
+  `whois_client_requests_total{client, status_code}` Prometheus counter;
+  `rateLimit` (requests per minute, token bucket with a full minute's burst)
+  answers over-budget requests with an RFC 9457 `429` problem and a
+  `Retry-After` header.
+- **`POST /batch` bulk queries** (and an MCP `whois_batch_lookup` tool):
+  up to `batch.maxItems` (default 10) mixed domain/IP/ASN queries per
+  request, each answered independently with per-item status, the regular
+  response object in `data` on success and a problem object in `error` on
+  failure. Disabled by default (`batch.enabled` / `WHOIS_BATCH_ENABLED`);
+  best enabled together with authentication. A batch of N queries costs N
+  rate-limit tokens, so batching cannot bypass per-key limits.
+- **`?refresh=1` forces a fresh upstream query**, bypassing the cache read
+  and overwriting the cached entry (response carries `X-Cache: REFRESH`).
+  Only honored on instances with authentication enabled; open instances
+  answer `403` (`#refresh-requires-auth`).
+- **`WHOIS_BOOTSTRAP_INTERVAL`** environment override (previously the only
+  option without one) and a complete environment variable reference table in
+  the README (both languages), including an env-only `docker run` example.
+
 ## [0.9.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ bootstrap:
 
 auth:
   keys: []                     # API 密钥列表。留空（默认）则服务完全开放；配置一个或多个密钥后，除 /health 和 /ready 外的所有端点都需要认证，请求时通过 "Authorization: Bearer <key>" 或 "X-API-Key: <key>" 携带密钥
+  # 列表项支持纯字符串，也支持对象形式（可命名、可按 key 限流）：
+  # keys:
+  #   - "plain-secret"         # 匿名 key，自动命名 key1/key2/…
+  #   - key: "another-secret"
+  #     name: "ci"             # 显示名：出现在日志 client 字段和 Prometheus 指标中
+  #     rateLimit: 120         # 该 key 的速率限制（次/分钟）；0 或缺省=不限
+
+batch:
+  enabled: false               # POST /batch 批量查询端点（含 MCP 批量 tool），默认关闭；建议与 auth.keys 一起开启
+  maxItems: 10                 # 单批最多查询条数
 
 mcp:
   localhostProtection: false   # /mcp 端点的 DNS rebinding 保护：开启后只接受 Host 为 localhost 的请求。反向代理部署保持 false；本机直连部署建议设为 true
@@ -101,7 +111,9 @@ mcp:
 | `WHOIS_PROXY_PASSWORD` | `proxy.password` | 空 | 代理密码 |
 | `WHOIS_PROXY_SUFFIXES` | `proxy.suffixes` | 空 | 走代理的 TLD 列表，**逗号分隔**（`all` 表示全部） |
 | `WHOIS_BOOTSTRAP_INTERVAL` | `bootstrap.interval` | `0`（禁用） | IANA RDAP 列表刷新间隔（秒）；配置文件示例为 86400 |
-| `WHOIS_AUTH_KEYS` | `auth.keys` | 空 | API 密钥，**逗号分隔** |
+| `WHOIS_AUTH_KEYS` | `auth.keys` | 空 | API 密钥，**逗号分隔**（仅纯 key 形式；命名/按 key 限流需配置文件） |
+| `WHOIS_BATCH_ENABLED` | `batch.enabled` | `false` | `true`/`1` 开启批量查询端点 |
+| `WHOIS_BATCH_MAX_ITEMS` | `batch.maxItems` | `10` | 单批最多查询条数 |
 | `WHOIS_MCP_LOCALHOST_PROTECTION` | `mcp.localhostProtection` | `false` | `true`/`1` 启用 /mcp 的 DNS rebinding 保护 |
 
 布尔型变量只认 `true` 和 `1`，其余值视为 `false`。数值型变量解析失败时静默忽略并沿用配置文件/默认值。
@@ -126,9 +138,11 @@ docker run -d --name whois -p 8043:8043 \
 - **日志级别**：`debug` 会输出每次缓存命中和上游查询，流量大时噪声较高；生产环境建议保持 `info`
 - **RDAP 刷新间隔**：服务启动时会立即从 IANA 拉取最新 RDAP 服务器列表，之后按此间隔定期刷新；编译进二进制的数据作为拉取失败时的兜底
 - **API 认证**：默认关闭。配置 `auth.keys` 后即启用，未携带有效密钥的请求返回 401（RFC 9457 problem+json）；仅 `/health` 和 `/ready` 豁免，便于存活/就绪探针工作
+- **key 命名与按 key 限流**：`auth.keys` 的对象形式可为每个 key 设置显示名和速率限制。显示名出现在请求日志的 `client` 字段和 Prometheus 指标 `whois_client_requests_total{client,status_code}` 中，便于区分调用方；速率限制为 token bucket（次/分钟，**允许一次性用完整分钟额度**），超限返回 429 + `Retry-After` 头。批量查询按条数计费：一批 N 条消耗 N 个令牌
+- **批量查询**：默认关闭。建议与 `auth.keys` 一起开启——开放实例提供批量查询等于放大被滥用打上游注册局的能力
 
 
-> ⚠️ **Warning:** 限频针对的是程序向 whois 服务器发起的请求，而非用户向本程序发起的请求。例如，您将限频设置为 50，那么程序向注册局 whois 服务器发起的请求将不会超过 50 次/秒，但是用户向本程序发起的请求不受限制。请您通过 Nginx 等工具对本程序进行限流，以防止恶意请求。
+> ⚠️ **Warning:** 限频针对的是程序向 whois 服务器发起的请求，而非用户向本程序发起的请求。例如，您将限频设置为 50，那么程序向注册局 whois 服务器发起的请求将不会超过 50 次/秒，但是用户向本程序发起的请求不受限制。请您通过 Nginx 等工具对本程序进行限流，或为每个 API key 配置 `rateLimit`，以防止恶意请求。
 
 ### 运行
 ```bash
@@ -148,6 +162,7 @@ docker run -d --name whois -p 8043:8043 \
 | `GET /metrics` | Prometheus 指标 - 请求计数、延迟、缓存命中率、上游查询耗时 |
 | `GET /openapi.json` | OpenAPI 3.1 规范 - 全部端点与响应 schema 的机器可读描述 |
 | `POST /mcp` | MCP Streamable HTTP 端点 - 供 AI 助手集成使用 |
+| `POST /batch` | 批量查询 - 一次提交多个域名/IP/ASN（默认关闭，见 `batch.enabled`） |
 
 **示例：**
 ```bash
@@ -213,7 +228,7 @@ curl http://localhost:8043/2001:db8::/32
 服务在 `/openapi.json` 提供 OpenAPI 3.1 描述文档，包含全部端点、响应 schema（RDAP 词汇）和错误格式，可直接导入 Postman/Swagger UI 等工具。
 
 #### 缓存与跨域
-- 成功响应带 `X-Cache: HIT/MISS` 头标识是否命中服务端缓存，以及 `Cache-Control: public, max-age=<缓存秒数>` 供客户端/CDN 缓存。
+- 成功响应带 `X-Cache` 头标识缓存状态：`HIT`（命中服务端缓存）、`MISS`（回源注册局）、`REFRESH`（`?refresh` 强制回源），以及 `Cache-Control: public, max-age=<缓存秒数>` 供客户端/CDN 缓存。
 - 成功响应（200）带强 `ETag` 头；请求时携带 `If-None-Match: <etag>` 可做条件重验证，内容未变化时返回 `304 Not Modified`（无响应体），`/openapi.json` 同样支持。
 - 所有响应带 `Access-Control-Allow-Origin: *`，可直接在浏览器前端跨域调用。
 
@@ -263,6 +278,35 @@ curl http://localhost:8043/example.com
 ```bash
 curl "http://localhost:8043/example.com?raw=1"
 ```
+
+#### 强制刷新缓存
+添加 `?refresh=1` 参数可跳过服务端缓存、强制向注册局查询并用新结果覆盖缓存（响应带 `X-Cache: REFRESH`），适合域名转移/续费后立即查看新状态。**仅在开启 API 认证的实例上可用**：未配置 `auth.keys` 的实例返回 403（`refresh-requires-auth`）——否则任何人都能借此击穿缓存刷上游注册局。可与 `?raw` 叠加使用。
+
+```bash
+curl -H "X-API-Key: your-secret-key" "http://localhost:8043/example.com?refresh=1"
+```
+
+#### 批量查询
+`POST /batch` 一次提交多个查询（域名/IP/CIDR/ASN 可混排，自动识别类型），逐项返回结果。默认关闭，需配置 `batch.enabled: true`；单批条数上限 `batch.maxItems`（默认 10）。
+
+```bash
+curl -X POST -H "X-API-Key: your-secret-key" -H "Content-Type: application/json" \
+  -d '{"queries": ["example.com", "8.8.8.8", "AS15169"]}' \
+  http://localhost:8043/batch
+```
+
+响应恒为 200，逐项给出状态：成功项的 `data` 是常规响应对象，失败项的 `error` 是 problem+json 对象：
+
+```json
+{
+  "results": [
+    {"query": "example.com", "status": 200, "data": {"objectClassName": "domain", "ldhName": "example.com"}},
+    {"query": "nx.invalid", "status": 404, "error": {"type": "...#not-found", "title": "Resource not found", "status": 404}}
+  ]
+}
+```
+
+配置了按 key 限流时，一批 N 条按 N 个请求计费，无法借批量绕过限流。批内重复查询会被合并为一次上游请求。
 
 #### 请求追踪
 每个响应都带有 `X-Request-ID` 头，服务端日志中的 `request_id` 字段与之对应，便于排查问题。客户端也可自带 `X-Request-ID` 请求头（≤64 字符，仅限字母、数字、`.`、`_`、`-`），服务端将原样使用。
@@ -389,6 +433,15 @@ curl http://localhost:8043/205794
 ```
 
 支持域名、IPv4/v6 地址或 CIDR 前缀、ASN（如 `AS12345`），返回结果与 REST API 完全一致。
+
+**工具名：** `whois_batch_lookup`（需开启 `batch.enabled`）
+
+**输入：**
+```json
+{ "queries": ["example.com", "8.8.8.8", "AS15169"] }
+```
+
+逐项返回结果，与 `POST /batch` 行为一致（同样受 `batch.maxItems` 与按 key 限流约束）。
 
 **MCP 服务器地址：** `http://ip:端口/mcp`
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -82,6 +82,16 @@ bootstrap:
 
 auth:
   keys: []                     # Accepted API keys. Empty (the default) leaves the service open; one or more keys protect every endpoint except /health and /ready. Clients send a key as "Authorization: Bearer <key>" or "X-API-Key: <key>"
+  # Entries are bare strings or objects (named, optionally rate-limited):
+  # keys:
+  #   - "plain-secret"         # anonymous key, auto-named key1/key2/...
+  #   - key: "another-secret"
+  #     name: "ci"             # display name: appears in the log "client" field and Prometheus metrics
+  #     rateLimit: 120         # per-key rate limit (requests/minute); 0 or omitted = unlimited
+
+batch:
+  enabled: false               # POST /batch bulk-query endpoint (and the MCP batch tool); off by default, best enabled together with auth.keys
+  maxItems: 10                 # maximum queries per batch request
 
 mcp:
   localhostProtection: false   # DNS-rebinding protection for /mcp: only accept requests whose Host header is localhost. Keep false behind a reverse proxy; set true for direct localhost deployments
@@ -111,7 +121,9 @@ Every configuration option can be overridden via environment variables (which ta
 | `WHOIS_PROXY_PASSWORD` | `proxy.password` | empty | Proxy password |
 | `WHOIS_PROXY_SUFFIXES` | `proxy.suffixes` | empty | TLDs queried through the proxy, **comma-separated** (`all` proxies everything) |
 | `WHOIS_BOOTSTRAP_INTERVAL` | `bootstrap.interval` | `0` (disabled) | IANA RDAP list refresh interval in seconds; the sample config ships 86400 |
-| `WHOIS_AUTH_KEYS` | `auth.keys` | empty | API keys, **comma-separated** |
+| `WHOIS_AUTH_KEYS` | `auth.keys` | empty | API keys, **comma-separated** (bare keys only; naming / per-key limits need the config file) |
+| `WHOIS_BATCH_ENABLED` | `batch.enabled` | `false` | `true`/`1` enables the bulk-query endpoint |
+| `WHOIS_BATCH_MAX_ITEMS` | `batch.maxItems` | `10` | Maximum queries per batch request |
 | `WHOIS_MCP_LOCALHOST_PROTECTION` | `mcp.localhostProtection` | `false` | `true`/`1` enables DNS-rebinding protection for /mcp |
 
 Boolean variables accept only `true` and `1`; anything else is treated as `false`. Numeric variables that fail to parse are silently ignored, leaving the config-file/default value in place.
@@ -136,8 +148,10 @@ docker run -d --name whois -p 8043:8043 \
 - **Log Level**: `debug` logs every cache hit and upstream query dispatch — noisy under load; `info` is recommended for production
 - **Bootstrap Interval**: On startup the service immediately fetches the latest RDAP server list from IANA, then refreshes on this interval; compiled-in data serves as fallback if the fetch fails
 - **API Authentication**: Disabled by default. Configuring `auth.keys` enables it; requests without a valid key get a 401 (RFC 9457 problem+json). Only `/health` and `/ready` are exempt so liveness/readiness probes keep working
+- **Key naming and per-key rate limits**: The object form of `auth.keys` gives each key a display name and a rate limit. The name labels the caller in the request logs (`client` field) and in the `whois_client_requests_total{client,status_code}` Prometheus metric; the limit is a token bucket (requests/minute, **a full minute's budget may be spent at once**) answering over-budget requests with 429 + `Retry-After`. Batches are charged per item: a batch of N queries costs N tokens
+- **Batch queries**: Off by default. Best enabled together with `auth.keys` — an open instance offering bulk queries multiplies how fast it can be abused against upstream registries
 
-> ⚠️ **Warning:** The rate limit applies to requests from this program to WHOIS servers, not requests from users to this program. For example, if you set the limit to 50, the program will not exceed 50 requests/second to registry WHOIS servers, but user requests to this program are unlimited. Please use Nginx or other tools to rate-limit this program to prevent malicious requests.
+> ⚠️ **Warning:** The rate limit applies to requests from this program to WHOIS servers, not requests from users to this program. For example, if you set the limit to 50, the program will not exceed 50 requests/second to registry WHOIS servers, but user requests to this program are unlimited. Please use Nginx or other tools to rate-limit this program, or configure a per-key `rateLimit`, to prevent malicious requests.
 
 ### Run
 
@@ -159,6 +173,7 @@ The service provides the following health check endpoints:
 | `GET /metrics` | Prometheus metrics - request count, latency, cache hit rate, upstream query duration |
 | `GET /openapi.json` | OpenAPI 3.1 specification - machine-readable description of all endpoints and response schemas |
 | `POST /mcp` | MCP Streamable HTTP endpoint - for AI assistant integration |
+| `POST /batch` | Bulk queries - multiple domains/IPs/ASNs in one request (off by default, see `batch.enabled`) |
 
 ### Process Daemon (Optional)
 
@@ -216,7 +231,7 @@ An OpenAPI 3.1 description of the service is available at `/openapi.json`, cover
 
 #### Caching and CORS
 
-- Successful responses carry `X-Cache: HIT/MISS` indicating whether the server cache was hit, plus `Cache-Control: public, max-age=<cache seconds>` for client/CDN caching.
+- Successful responses carry an `X-Cache` header describing the cache outcome: `HIT` (served from the server cache), `MISS` (fetched upstream), or `REFRESH` (forced upstream by `?refresh`), plus `Cache-Control: public, max-age=<cache seconds>` for client/CDN caching.
 - Successful (200) responses carry a strong `ETag`; send it back as `If-None-Match: <etag>` for conditional revalidation — unchanged content is answered with `304 Not Modified` and no body. `/openapi.json` supports this too.
 - Every response carries `Access-Control-Allow-Origin: *`, so the API can be called cross-origin from browser frontends directly.
 
@@ -271,6 +286,37 @@ Add `?raw=1` to get the unparsed WHOIS response as `text/plain`. Raw output is o
 ```bash
 curl "http://localhost:8043/example.com?raw=1"
 ```
+
+#### Force a Cache Refresh
+
+Add `?refresh=1` to bypass the server cache, query the registry directly and overwrite the cached entry with the result (the response carries `X-Cache: REFRESH`) — useful right after a domain transfer or renewal. **Only available on instances with API key authentication enabled**: open instances answer 403 (`refresh-requires-auth`), since otherwise anyone could use it to hammer upstream registries through the cache. Can be combined with `?raw`.
+
+```bash
+curl -H "X-API-Key: your-secret-key" "http://localhost:8043/example.com?refresh=1"
+```
+
+#### Batch Queries
+
+`POST /batch` answers several queries in one request (domains, IPs/CIDR prefixes and ASNs freely mixed; types are auto-detected). Off by default — enable with `batch.enabled: true`; the per-request cap is `batch.maxItems` (default 10).
+
+```bash
+curl -X POST -H "X-API-Key: your-secret-key" -H "Content-Type: application/json" \
+  -d '{"queries": ["example.com", "8.8.8.8", "AS15169"]}' \
+  http://localhost:8043/batch
+```
+
+The response is always 200 with per-item statuses: successful items carry the regular response object in `data`, failed items a problem+json object in `error`:
+
+```json
+{
+  "results": [
+    {"query": "example.com", "status": 200, "data": {"objectClassName": "domain", "ldhName": "example.com"}},
+    {"query": "nx.invalid", "status": 404, "error": {"type": "...#not-found", "title": "Resource not found", "status": 404}}
+  ]
+}
+```
+
+With per-key rate limits configured, a batch of N queries is charged as N requests, so batching cannot bypass the limit. Duplicate queries within a batch collapse into a single upstream request.
 
 #### Request Tracing
 
@@ -380,6 +426,15 @@ The service exposes an [MCP (Model Context Protocol)](https://modelcontextprotoc
 ```
 
 Accepts a domain name, IPv4/v6 address or CIDR prefix, or ASN (e.g. `AS12345`). Returns the same JSON as the REST API.
+
+**Tool:** `whois_batch_lookup` (requires `batch.enabled`)
+
+**Input:**
+```json
+{ "queries": ["example.com", "8.8.8.8", "AS15169"] }
+```
+
+Returns per-query results, matching the behavior of `POST /batch` (subject to the same `batch.maxItems` cap and per-key rate limiting).
 
 **MCP server URL:** `http://ip:port/mcp`
 

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "whois",
     "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details. API key authentication is disabled by default; when the operator configures `auth.keys`, every endpoint except /health and /ready requires a key sent as `Authorization: Bearer <key>` or `X-API-Key: <key>`.",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "license": {
       "name": "MIT",
       "identifier": "MIT"


### PR DESCRIPTION
## 内容

v0.10.0 发布前的文档收尾(功能代码已全部在 #26-#30 合并):

- **README / README_EN**:`auth.keys` 对象写法与 batch 组配置示例;env 对照表补 `WHOIS_BATCH_ENABLED`/`WHOIS_BATCH_MAX_ITEMS`;配置说明补 key 命名/按 key 限流/批量;新增 **批量查询** 与 **强制刷新缓存(?refresh)** 章节;X-Cache 增加 REFRESH 取值;端点表加 POST /batch;MCP 章节加 `whois_batch_lookup`
- **CHANGELOG**:0.10.0 落版(2026-06-12,全部 Added,零破坏)
- **openapi.json**:info.version → 0.10.0

## 端到端验证(本地真实服务,开 auth+batch)

- ✅ 批量混排 domain/IP/ASN/非法输入,逐项 200/400,真实注册局数据
- ✅ 按 key 限流:额度 5 的 key 跑 1 批 3 条 + 2 单查后第 6 个请求 429,`Retry-After: 12`,CORS 暴露 Retry-After
- ✅ ?refresh:HIT → REFRESH → HIT(缓存被覆盖)
- ✅ `whois_client_requests_total` 按 client(含自动命名 key1/unauthenticated)分桶;日志带 client 字段
- ✅ MCP 完整握手后 `whois_batch_lookup` 正常返回逐项结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)