### PR TITLE
fix: cap IANA bootstrap reads at 2 MiB + reject negative numeric config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Each breaking change is listed under a **Breaking** heading below. After
 > v1.0.0 the API and configuration format will remain stable.
 
+## [Unreleased]
+
+### Fixed
+- IANA RDAP bootstrap fetches are now capped at 2 MiB, matching the limit
+  already applied to WHOIS/RDAP upstream reads; an oversized response is
+  rejected instead of read without bound.
+- Negative values in numeric configuration settings (`server.port`,
+  `server.rateLimit`, `cache.expiration`, `cache.memoryMaxSize`,
+  `cache.memoryCleanInterval`, `bootstrap.interval`, `batch.maxItems`) are
+  now rejected at startup with a clear error naming the offending key,
+  instead of crashing later or silently misbehaving
+  (`cache.negativeExpiration` keeps its documented negative "disable"
+  semantics).
+
 ## [0.10.0] - 2026-06-12
 
 ### Added

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,6 +184,12 @@ func load() {
 	// Apply default values for anything left unset
 	applyDefaults(&config)
 
+	// Reject negative values that would otherwise fail far from their cause
+	if err := validateConfig(&config); err != nil {
+		slog.Error("invalid configuration", "err", err)
+		os.Exit(1)
+	}
+
 	// Initialize the Redis client with custom options
 	options := &redis.Options{
 		Addr:            config.Redis.Addr,
@@ -345,6 +351,33 @@ func applyDefaults(config *Config) {
 	if config.Batch.MaxItems == 0 {
 		config.Batch.MaxItems = 10
 	}
+}
+
+// validateConfig rejects negative values in numeric settings after defaults
+// are applied: each would otherwise fail far from its cause (a negative
+// server.rateLimit panics creating the concurrency limiter, a negative
+// cache.memoryCleanInterval panics the memory cache's cleanup ticker, a
+// negative batch.maxItems rejects every batch request). cache.negativeExpiration
+// is exempt: negative is its documented "disable" value.
+func validateConfig(config *Config) error {
+	checks := []struct {
+		name  string
+		value int
+	}{
+		{"server.port", config.Server.Port},
+		{"server.rateLimit", config.Server.RateLimit},
+		{"cache.expiration", config.Cache.Expiration},
+		{"cache.memoryMaxSize", config.Cache.MemoryMaxSize},
+		{"cache.memoryCleanInterval", config.Cache.MemoryCleanInterval},
+		{"bootstrap.interval", config.Bootstrap.Interval},
+		{"batch.maxItems", config.Batch.MaxItems},
+	}
+	for _, c := range checks {
+		if c.value < 0 {
+			return fmt.Errorf("%s must not be negative (got %d)", c.name, c.value)
+		}
+	}
+	return nil
 }
 
 // initializeCacheManager sets up the cache with Redis primary and memory fallback

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -252,6 +252,48 @@ func TestParseConfigUnsupportedExt(t *testing.T) {
 	}
 }
 
+func TestValidateConfigNegativeValues(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"server.port", func(c *Config) { c.Server.Port = -1 }},
+		{"server.rateLimit", func(c *Config) { c.Server.RateLimit = -1 }},
+		{"cache.expiration", func(c *Config) { c.Cache.Expiration = -1 }},
+		{"cache.memoryMaxSize", func(c *Config) { c.Cache.MemoryMaxSize = -1 }},
+		{"cache.memoryCleanInterval", func(c *Config) { c.Cache.MemoryCleanInterval = -1 }},
+		{"bootstrap.interval", func(c *Config) { c.Bootstrap.Interval = -1 }},
+		{"batch.maxItems", func(c *Config) { c.Batch.MaxItems = -1 }},
+	}
+	for _, tc := range cases {
+		var cfg Config
+		applyDefaults(&cfg)
+		tc.mutate(&cfg)
+		err := validateConfig(&cfg)
+		if err == nil {
+			t.Errorf("%s: expected error for negative value", tc.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.name) {
+			t.Errorf("%s: error %q does not name the offending key", tc.name, err)
+		}
+	}
+}
+
+func TestValidateConfigDefaultsPass(t *testing.T) {
+	var cfg Config
+	applyDefaults(&cfg)
+	if err := validateConfig(&cfg); err != nil {
+		t.Errorf("defaults must validate: %v", err)
+	}
+
+	// The documented "disable" value for negative caching must stay accepted.
+	cfg.Cache.NegativeExpiration = -1
+	if err := validateConfig(&cfg); err != nil {
+		t.Errorf("negative cache.negativeExpiration must stay valid: %v", err)
+	}
+}
+
 func TestApplyDefaults(t *testing.T) {
 	var cfg Config
 	applyDefaults(&cfg)

--- a/internal/serverlist/bootstrap.go
+++ b/internal/serverlist/bootstrap.go
@@ -19,6 +19,11 @@ type bootstrapResponse struct {
 	Services [][]json.RawMessage `json:"services"`
 }
 
+// maxBootstrapResponseSize caps how much we read from an IANA bootstrap file,
+// matching the limit on WHOIS/RDAP upstream reads (the dns.json file, the
+// largest of the four, is around 200 KB).
+const maxBootstrapResponseSize = 2 << 20 // 2 MiB
+
 var ianaBootstrapURLs = map[string]string{
 	"dns":  "https://data.iana.org/rdap/dns.json",
 	"ipv4": "https://data.iana.org/rdap/ipv4.json",
@@ -44,9 +49,14 @@ func fetchBootstrap(ctx context.Context, client *http.Client, url string) (map[s
 		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Read one byte past the limit so an oversized response is detected and
+	// rejected rather than silently truncated.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBootstrapResponseSize+1))
 	if err != nil {
 		return nil, err
+	}
+	if len(body) > maxBootstrapResponseSize {
+		return nil, fmt.Errorf("bootstrap response from %s exceeds %d bytes", url, maxBootstrapResponseSize)
 	}
 
 	var bootstrap bootstrapResponse


### PR DESCRIPTION
## Summary

Two low-severity hardening items from a full post-v0.10.0 code review:

- **IANA bootstrap fetches are now capped at 2 MiB.** `fetchBootstrap` used an unbounded `io.ReadAll` while every other upstream read (WHOIS, RDAP) is capped at 2 MiB with read-one-past-the-limit rejection. The bootstrap URLs are hard-coded `https://data.iana.org` endpoints (largest file ~200 KB), so this is defence in depth for MITM/proxy scenarios, applied the same way as in `rdap_query.go`.
- **Negative numeric configuration values are rejected at startup.** Previously they failed far from their cause: `server.rateLimit: -1` panicked at `make(chan struct{}, -1)`, a negative `cache.memoryCleanInterval` panicked the memory cache's cleanup ticker goroutine, and a negative `batch.maxItems` rejected every batch request. `validateConfig` now runs after defaults are applied and reports the offending key. `cache.negativeExpiration` is exempt — negative is its documented "disable" value, covered by a test.

No behavior change for any valid configuration.

## Review notes

Items reviewed and deliberately **not** changed:
- Query paths accept any HTTP method (restricting could break existing callers; behavior is identical to GET and ETag buffering already applies only to GET)
- Batch items that never start before the deadline report 500 rather than 504 (per-item status semantics are self-consistent)

## Test plan

- `go test ./...`, `go vet ./...`, `gofmt -l` all clean
- New tests: `TestValidateConfigNegativeValues` (each key rejected, error names the key), `TestValidateConfigDefaultsPass` (defaults and the negative-expiration disable value stay valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)