### PR TITLE
feat: warn at startup when running open + tighten auth comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- The service now logs a startup warning when no `auth.keys` are configured,
+  noting that the instance accepts requests from anyone who can reach it (and,
+  when `mcp.localhostProtection` is off, that `/mcp` has no DNS-rebinding
+  protection). An open instance behind a trusted reverse proxy or on a private
+  network is unaffected in behavior; only the warning is new.
+
 ### Fixed
 - IANA RDAP bootstrap fetches are now capped at 2 MiB, matching the limit
   already applied to WHOIS/RDAP upstream reads; an oversized response is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -266,6 +266,19 @@ func load() {
 			names[i] = c.Name
 		}
 		slog.Info("API key authentication enabled", "clients", names)
+	} else {
+		// No keys configured: the instance answers queries from anyone who can
+		// reach it. That is fine behind a trusted reverse proxy or on a private
+		// network, but a publicly exposed open instance can be used as a free
+		// WHOIS/RDAP proxy against upstream registries.
+		if MCPLocalhostProtection {
+			slog.Warn("no API key authentication configured: this instance accepts requests from anyone who can reach it; set auth.keys (with rateLimit) for public deployments")
+		} else {
+			// Without localhost protection the /mcp endpoint has no
+			// DNS-rebinding guard, so a browser that can reach the address can
+			// drive it — only safe behind a trusted proxy or on a private net.
+			slog.Warn("no API key authentication configured and /mcp DNS-rebinding protection is off: this instance accepts requests from anyone who can reach it; set auth.keys (with rateLimit) for public deployments, or enable mcp.localhostprotection when not behind a trusted reverse proxy")
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -75,9 +75,12 @@ func requestClient(r *http.Request) *config.AuthClient {
 }
 
 // clientForKey returns the configured client whose key matches, comparing
-// every entry in constant time so the comparison itself leaks nothing about
-// the configured keys. The empty key never matches: it is what a request with
-// no credentials presents.
+// every entry with subtle.ConstantTimeCompare so the match outcome leaks
+// nothing about a key's contents through timing. The length of a configured
+// key is not constant-time-protected (ConstantTimeCompare returns early when
+// the lengths differ), which is acceptable: key length is not a useful secret.
+// The empty key never matches: it is what a request with no credentials
+// presents.
 func clientForKey(key string) *config.AuthClient {
 	if key == "" {
 		return nil


### PR DESCRIPTION
## What

Two small changes from working through an external security review (most of whose findings turned out not to apply to the current code):

1. **Open-instance startup warning** (`internal/config/config.go`). When `auth.keys` is empty the service answers queries from anyone who can reach it, but `config.Load` was silent about it — it only logged when keys *were* configured. Now it emits a `slog.Warn` recommending `auth.keys` for public deployments, and when `mcp.localhostProtection` is off (the default) it additionally notes that `/mcp` has no DNS-rebinding protection. **Log-only:** no behavior change, no new config; an open instance behind a trusted reverse proxy or on a private network is unaffected.

2. **Tightened the `clientForKey` comment** (`main.go`). `subtle.ConstantTimeCompare` returns early when lengths differ, so the configured key *length* is not constant-time-protected. The old "leaks nothing about the configured keys" wording was overstated; the comment now states this (length isn't a useful secret). No code change — and notably there is **no** SHA-256 here, so the reviewer's per-request-hashing performance concern never applied.

## Why these two only

The other review items were checked against the code and don't warrant changes:

- **env-proxy leak** — `config.HttpClient` builds its own `http.Transport` with no `Proxy` func, so `HTTP_PROXY`/`HTTPS_PROXY` are not honored; only the explicit `proxy.server` config proxies.
- **HEAD/405** — `serve()` doesn't restrict methods.
- **batch goroutine-per-item** — bounded by the 64 KiB body cap (~16k items worst case) plus concurrency-5; not a DoS.
- **wildcard CORS** — deliberate; configurable origins is already on the v1.0.0 roadmap.
- **405 metrics blind spot** — covered by access/proxy logs.
- **shutdown 5s vs request 15s** — `Wg.Wait()` drains in-flight requests *before* `srv.Shutdown`, so the described race doesn't exist.

## Verification

- `gofmt`, `go vet ./...`, `go build ./...`, `go test ./...` all clean/passing.
- Smoke-ran the binary: empty `auth.keys` → the new warning fires (with the MCP note since `localhostProtection` defaults off); `auth.keys` set → only the existing "authentication enabled" info log, no spurious warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)