### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> ⚠️ **Heads-up:** the 0.x releases leading up to v1.0.0 will include
-> **breaking changes** to the API response format and the configuration file.
-> Each breaking change is listed under a **Breaking** heading below. After
-> v1.0.0 the API and configuration format will remain stable.
+> ✅ **v1.0.0 is the first stable release.** The HTTP API, error format,
+> configuration file layout and `WHOIS_*` environment variables now follow
+> [Semantic Versioning](https://semver.org/): incompatible changes will only
+> land in a future major release. The 0.x history below includes the breaking
+> changes made on the way to 1.0.0 (each under a **Breaking** heading).
 
-## [Unreleased]
+## [1.0.0] - 2026-06-13
+
+First stable release. From this version on, the HTTP API, error format,
+configuration file layout and `WHOIS_*` environment variables are covered by
+[Semantic Versioning](https://semver.org/) — see "Versioning & Stability" in
+the README. There are no API or configuration-format changes since 0.10.0; the
+entries below are operational hardening.
 
 ### Security
 - The service now logs a startup warning when no `auth.keys` are configured,
@@ -230,6 +237,8 @@ See the [release notes](https://github.com/KincaidYang/whois/releases/tag/v0.6.0
 See the [GitHub releases page](https://github.com/KincaidYang/whois/releases)
 for 0.5.x and earlier.
 
+[1.0.0]: https://github.com/KincaidYang/whois/compare/v0.10.0...v1.0.0
+[0.10.0]: https://github.com/KincaidYang/whois/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/KincaidYang/whois/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/KincaidYang/whois/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/KincaidYang/whois/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -445,6 +445,18 @@ curl http://localhost:8043/205794
 
 **MCP 服务器地址：** `http://ip:端口/mcp`
 
+## 版本与稳定性
+
+自 v1.0.0 起，本项目遵循[语义化版本](https://semver.org/lang/zh-CN/)。以下面向用户的契约在 1.x 内保持稳定，不兼容变更只会出现在下一个主版本（2.0.0）：
+
+- **HTTP API**：端点路径与语义、成功响应的 JSON 字段（RDAP 词汇，RFC 9083）、错误格式（RFC 9457 problem+json），以及缓存与条件请求相关的响应头（`X-Cache`、`Cache-Control`、`ETag`）。
+- **配置文件**：`config.yaml` 的分组结构与键名，以及 `WHOIS_*` 环境变量。
+- **MCP 工具**：`whois_lookup` / `whois_batch_lookup` 的名称与输入参数。
+
+不在稳定承诺范围内：注册局上游数据本身的内容与可用字段（随各注册局而变）、Prometheus 指标名称、日志格式，以及 Go 包的内部结构（本模块不对外暴露可导入的 API）。
+
+0.x 阶段的破坏性变更已结束，完整历史见 [CHANGELOG](CHANGELOG.md)。
+
 ## 已知问题
 程序向注册局查询 Whois 信息主要依靠 RDAP 协议查询，但由于大部分 ccTLD 不支持 RDAP 协议，程序会对其原始的 Whois 信息格式化后返回 JSON 数据。由于本人精力有限，未对所有的 ccTLD 后缀进行适配，未适配的后缀会返回 `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`，如您常用的后缀没有被覆盖，可以提交 Issue 或者贡献匹配规则至 `internal/whois/whois_parsers.go` 文件中，在此表示感谢！
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -438,6 +438,18 @@ Returns per-query results, matching the behavior of `POST /batch` (subject to th
 
 **MCP server URL:** `http://ip:port/mcp`
 
+## Versioning & Stability
+
+From v1.0.0 on, this project follows [Semantic Versioning](https://semver.org/). The following user-facing contract is stable within the 1.x line and may only change incompatibly in the next major release (2.0.0):
+
+- **HTTP API**: endpoint paths and semantics, the JSON fields of successful responses (RDAP vocabulary, RFC 9083), the error format (RFC 9457 problem+json), and the caching / conditional-request headers (`X-Cache`, `Cache-Control`, `ETag`).
+- **Configuration**: the grouped structure and key names of `config.yaml`, and the `WHOIS_*` environment variables.
+- **MCP tools**: the names and input parameters of `whois_lookup` / `whois_batch_lookup`.
+
+Not covered by the stability promise: the content and available fields of upstream registry data (which vary by registry), Prometheus metric names, the log format, and the internal structure of the Go packages (the module exposes no importable API).
+
+The 0.x breaking-change period is over; see the [CHANGELOG](CHANGELOG.md) for the full history.
+
 ## Known Issues
 
 The program queries WHOIS information from registries primarily using the RDAP protocol. However, since most ccTLDs do not support RDAP, the program will format and return the original WHOIS information as JSON data. Due to limited resources, not all ccTLD suffixes have been adapted; unadapted suffixes return `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`. If your commonly used suffix is not covered, please submit an Issue or contribute matching rules to `internal/whois/whois_parsers.go`. Thank you!

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "whois",
     "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details. API key authentication is disabled by default; when the operator configures `auth.keys`, every endpoint except /health and /ready requires a key sent as `Authorization: Bearer <key>` or `X-API-Key: <key>`.",
-    "version": "0.10.0",
+    "version": "1.0.0",
     "license": {
       "name": "MIT",
       "identifier": "MIT"


### PR DESCRIPTION
First stable release — **documentation and metadata only, no code change.**

## Changes
- **OpenAPI**: `info.version` `0.10.0` → `1.0.0`.
- **CHANGELOG**: `[Unreleased]` → `[1.0.0] - 2026-06-13`; heads-up banner now
  declares stability; added `v1.0.0` / `v0.10.0` compare links.
- **README.md / README_EN.md**: new **Versioning & Stability** section stating
  the SemVer contract — HTTP API, error format, `config.yaml` layout and
  `WHOIS_*` env vars are stable within 1.x; breaking changes only in a future
  major.

## Notes
- No API or configuration-format change since v0.10.0.
- The git tag `v1.0.0` and the GitHub release are **held** pending sign-off on
  the release-notes draft (per project process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)