### PR TITLE
chore(goreleaser): use archives.formats instead of deprecated format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 release:
   disable: false
 archives:
-  - format: tar.gz
+  - formats: [ tar.gz ]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE


### PR DESCRIPTION
Clears the GoReleaser v2 deprecation warning seen during the v1.0.0 release:

> DEPRECATED: archives.format should not be used anymore

GoReleaser v2 replaced the scalar `archives.format` with the `archives.formats`
list. Switched `format: tar.gz` → `formats: [ tar.gz ]`.

- Produced artifacts are unchanged (still `*_<os>_<arch>.tar.gz`).
- YAML validated locally; `goreleaser` CLI isn't available here, so the config
  is exercised for real by the next tag's release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)