### PR TITLE
fix: address code-review findings (redis health, bool env, parsers, mcp cap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > land in a future major release. The 0.x history below includes the breaking
 > changes made on the way to 1.0.0 (each under a **Breaking** heading).
 
+## [Unreleased]
+
+### Fixed
+- Redis cache no longer treats a caller's cancelled/expired request context as a
+  Redis failure. Previously a single client disconnecting mid-request could flip
+  the shared connection to "unhealthy", forcing every other in-flight request onto
+  the memory-only fallback until the next 30s health check. Genuine Redis command
+  errors are now also logged and counted (`whois_cache_requests_total{result="error"}`).
+- Boolean environment overrides (`WHOIS_REDIS_TLS`, `WHOIS_REDIS_TLS_SKIP_VERIFY`,
+  `WHOIS_REQUIRE_REDIS`, `WHOIS_BATCH_ENABLED`, `WHOIS_MCP_LOCALHOST_PROTECTION`) no
+  longer silently coerce an unrecognized value to `false`. Values are now parsed
+  case-insensitively (`true`/`1`/`false`/`0`); anything else keeps the existing
+  setting and logs a warning, so a typo like `True`/`yes` can't quietly disable a
+  security-relevant flag such as `redis.tls`.
+- The `.la` `Registrar IANA ID` field is now parsed correctly. A stray end-of-input
+  anchor in the regex meant the field was only ever captured when it happened to be
+  the last line of the response, so it was effectively always empty.
+- `.hk`, `.tw` and `.mo` responses now have CRLF line endings normalized before
+  parsing (as `.au` already did), so the nameserver list is no longer silently
+  dropped when the registry uses `\r\n`.
+- The `/mcp` endpoint now caps its request body (256 KiB), matching the existing
+  limit on `/batch`; previously the MCP transport read the whole request into
+  memory without bound.
+
+### Changed
+- A partial IANA RDAP bootstrap refresh (some categories fetched, others failed) is
+  now logged as a partial update and recorded as
+  `whois_bootstrap_refresh_total{result="partial"}` rather than `success`, since the
+  failed categories fall back to the compiled baseline for that cycle.
+
 ## [1.0.0] - 2026-06-13
 
 First stable release. From this version on, the HTTP API, error format,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -542,6 +542,24 @@ func parseConfig(data []byte, ext string) (Config, error) {
 	return config, nil
 }
 
+// parseBoolEnv interprets a boolean environment variable. "true"/"1" mean true
+// and "false"/"0" mean false (case-insensitive, surrounding whitespace ignored).
+// Any other value keeps the current setting and is logged, so a typo like "True"
+// (now accepted) — or "yes"/"on" (rejected) — can't silently flip a
+// security-relevant flag such as redis.tls off.
+func parseBoolEnv(name, val string, current bool) bool {
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "true", "1":
+		return true
+	case "false", "0":
+		return false
+	default:
+		slog.Warn("ignoring unrecognized boolean env var; keeping current value",
+			"env", name, "value", val, "current", current)
+		return current
+	}
+}
+
 func overrideConfigWithEnv(config *Config) {
 	// Override Redis configuration
 	if redisAddr := os.Getenv("WHOIS_REDIS_ADDR"); redisAddr != "" {
@@ -556,10 +574,10 @@ func overrideConfigWithEnv(config *Config) {
 		}
 	}
 	if redisTLS := os.Getenv("WHOIS_REDIS_TLS"); redisTLS != "" {
-		config.Redis.TLS = redisTLS == "true" || redisTLS == "1"
+		config.Redis.TLS = parseBoolEnv("WHOIS_REDIS_TLS", redisTLS, config.Redis.TLS)
 	}
 	if redisTLSSkipVerify := os.Getenv("WHOIS_REDIS_TLS_SKIP_VERIFY"); redisTLSSkipVerify != "" {
-		config.Redis.TLSSkipVerify = redisTLSSkipVerify == "true" || redisTLSSkipVerify == "1"
+		config.Redis.TLSSkipVerify = parseBoolEnv("WHOIS_REDIS_TLS_SKIP_VERIFY", redisTLSSkipVerify, config.Redis.TLSSkipVerify)
 	}
 
 	// Override cache configuration
@@ -569,7 +587,7 @@ func overrideConfigWithEnv(config *Config) {
 		}
 	}
 	if requireRedis := os.Getenv("WHOIS_REQUIRE_REDIS"); requireRedis != "" {
-		config.Cache.RequireRedis = requireRedis == "true" || requireRedis == "1"
+		config.Cache.RequireRedis = parseBoolEnv("WHOIS_REQUIRE_REDIS", requireRedis, config.Cache.RequireRedis)
 	}
 	if memoryMaxSize := os.Getenv("WHOIS_MEMORY_MAX_SIZE"); memoryMaxSize != "" {
 		if maxSize, err := strconv.Atoi(memoryMaxSize); err == nil {
@@ -628,7 +646,7 @@ func overrideConfigWithEnv(config *Config) {
 
 	// Override batch configuration
 	if batchEnabled := os.Getenv("WHOIS_BATCH_ENABLED"); batchEnabled != "" {
-		config.Batch.Enabled = batchEnabled == "true" || batchEnabled == "1"
+		config.Batch.Enabled = parseBoolEnv("WHOIS_BATCH_ENABLED", batchEnabled, config.Batch.Enabled)
 	}
 	if batchMaxItems := os.Getenv("WHOIS_BATCH_MAX_ITEMS"); batchMaxItems != "" {
 		if maxItems, err := strconv.Atoi(batchMaxItems); err == nil {
@@ -640,7 +658,7 @@ func overrideConfigWithEnv(config *Config) {
 		config.Log.Level = logLevel
 	}
 	if mcpProtection := os.Getenv("WHOIS_MCP_LOCALHOST_PROTECTION"); mcpProtection != "" {
-		config.MCP.LocalhostProtection = mcpProtection == "true" || mcpProtection == "1"
+		config.MCP.LocalhostProtection = parseBoolEnv("WHOIS_MCP_LOCALHOST_PROTECTION", mcpProtection, config.MCP.LocalhostProtection)
 	}
 
 	// Override API authentication keys (comma-separated bare keys; the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,30 @@ func TestEnvOverrideBootstrapInterval(t *testing.T) {
 	}
 }
 
+func TestEnvOverrideBoolValues(t *testing.T) {
+	// Recognized true/false values (including mixed case) apply.
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{{"true", true}, {"True", true}, {"1", true}, {"false", false}, {"0", false}, {" TRUE ", true}} {
+		t.Setenv("WHOIS_REDIS_TLS", tc.val)
+		cfg := Config{}
+		overrideConfigWithEnv(&cfg)
+		if cfg.Redis.TLS != tc.want {
+			t.Errorf("WHOIS_REDIS_TLS=%q: got %v, want %v", tc.val, cfg.Redis.TLS, tc.want)
+		}
+	}
+
+	// An unrecognized value must not silently flip a flag that is already on.
+	t.Setenv("WHOIS_REDIS_TLS", "yes")
+	cfg := Config{}
+	cfg.Redis.TLS = true
+	overrideConfigWithEnv(&cfg)
+	if !cfg.Redis.TLS {
+		t.Error("unrecognized WHOIS_REDIS_TLS=yes must keep the existing true value, not force false")
+	}
+}
+
 func TestParseConfigJSON(t *testing.T) {
 	cfg, err := parseConfig([]byte(`{"server": {"port": 8080}, "log": {"level": "warn"}}`), ".json")
 	if err != nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -37,7 +37,7 @@ var (
 		[]string{"client", "status_code"},
 	)
 
-	// CacheRequestsTotal counts cache lookups by backend (memory/redis) and result (hit/miss).
+	// CacheRequestsTotal counts cache lookups by backend (memory/redis) and result (hit/miss/error).
 	CacheRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "whois_cache_requests_total",
@@ -66,7 +66,7 @@ var (
 		[]string{"protocol", "tld"},
 	)
 
-	// BootstrapRefreshTotal counts IANA bootstrap refresh attempts by result (success/failure).
+	// BootstrapRefreshTotal counts IANA bootstrap refresh attempts by result (success/failure/partial).
 	BootstrapRefreshTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "whois_bootstrap_refresh_total",

--- a/internal/serverlist/bootstrap.go
+++ b/internal/serverlist/bootstrap.go
@@ -98,13 +98,16 @@ func fetchBootstrap(ctx context.Context, client *http.Client, url string) (map[s
 }
 
 // FetchIANA fetches all four IANA bootstrap files and merges them into one map.
-// Categories that fail to fetch are omitted from the result (caller uses compiled fallback).
-func FetchIANA(ctx context.Context, client *http.Client) map[string]string {
-	merged := make(map[string]string)
+// Categories that fail to fetch are omitted from the result (caller uses compiled
+// fallback) and their names are returned so the caller can report a partial update
+// rather than a clean success.
+func FetchIANA(ctx context.Context, client *http.Client) (merged map[string]string, failed []string) {
+	merged = make(map[string]string)
 	for category, url := range ianaBootstrapURLs {
 		data, err := fetchBootstrap(ctx, client, url)
 		if err != nil {
 			slog.Warn("RDAP bootstrap fetch failed", "category", category, "err", err)
+			failed = append(failed, category)
 			continue
 		}
 		for k, v := range data {
@@ -112,7 +115,7 @@ func FetchIANA(ctx context.Context, client *http.Client) map[string]string {
 		}
 		slog.Debug("RDAP bootstrap fetched", "category", category, "entries", len(data))
 	}
-	return merged
+	return merged, failed
 }
 
 // StartBootstrapRefresh fetches IANA data immediately on startup, then
@@ -126,15 +129,24 @@ func StartBootstrapRefresh(ctx context.Context, client *http.Client, interval ti
 		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
-		data := FetchIANA(fetchCtx, client)
+		data, failed := FetchIANA(fetchCtx, client)
 		if len(data) == 0 {
 			slog.Warn("RDAP bootstrap: no data fetched, retaining current index")
 			metrics.BootstrapRefreshTotal.WithLabelValues("failure").Inc()
 			return
 		}
 		UpdateFromIANA(data)
-		metrics.BootstrapRefreshTotal.WithLabelValues("success").Inc()
 		metrics.BootstrapLastFetchTimestamp.Set(float64(time.Now().Unix()))
+		if len(failed) > 0 {
+			// The failed categories were not in `data`, so UpdateFromIANA just
+			// reverted them to the compiled baseline. Surface that instead of
+			// reporting a clean success.
+			slog.Warn("RDAP bootstrap partially updated; failed categories reverted to compiled baseline",
+				"failed", failed, "entries", len(data))
+			metrics.BootstrapRefreshTotal.WithLabelValues("partial").Inc()
+			return
+		}
+		metrics.BootstrapRefreshTotal.WithLabelValues("success").Inc()
 		slog.Info("RDAP bootstrap index updated", "entries", len(data))
 	}
 

--- a/internal/utils/redis_cache.go
+++ b/internal/utils/redis_cache.go
@@ -59,7 +59,14 @@ func (rc *RedisCache) Get(ctx context.Context, key string) (CacheResult, error) 
 		metrics.CacheRequestsTotal.WithLabelValues("redis", "miss").Inc()
 		return CacheResult{Found: false}, nil
 	default:
-		// Redis error occurred, mark as unhealthy
+		// A cancelled or expired caller context is not a Redis fault. Don't let
+		// one client's abort mark the shared connection unhealthy for every
+		// other in-flight request.
+		if ctx.Err() != nil {
+			return CacheResult{Found: false}, err
+		}
+		slog.Warn("Redis GET failed", "key", key, "err", err)
+		metrics.CacheRequestsTotal.WithLabelValues("redis", "error").Inc()
 		rc.setHealthy(false)
 		return CacheResult{Found: false}, err
 	}
@@ -73,6 +80,13 @@ func (rc *RedisCache) Set(ctx context.Context, key string, value string, expirat
 
 	err := rc.client.Set(ctx, key, value, expiration).Err()
 	if err != nil {
+		// As in Get: a cancelled/expired caller context must not be attributed
+		// to Redis and flip the shared health flag.
+		if ctx.Err() != nil {
+			return err
+		}
+		slog.Warn("Redis SET failed", "key", key, "err", err)
+		metrics.CacheRequestsTotal.WithLabelValues("redis", "error").Inc()
 		rc.setHealthy(false)
 		return err
 	}

--- a/internal/whois/whois_parsers.go
+++ b/internal/whois/whois_parsers.go
@@ -103,7 +103,7 @@ var (
 
 	// LA
 	reLARegistrar          = regexp.MustCompile(`Registrar:\s+(.+)`)
-	reLARegistrarIANAID    = regexp.MustCompile(`Registrar IANA ID:\s*(.*)$`)
+	reLARegistrarIANAID    = regexp.MustCompile(`Registrar IANA ID:[ \t]*(.*)`)
 	reLADomainStatus       = regexp.MustCompile(`Domain Status:\s+(.+)`)
 	reLACreationDate       = regexp.MustCompile(`Creation Date:\s+(.+)`)
 	reLAExpiryDate         = regexp.MustCompile(`Registry Expiry Date:\s+(.+)`)
@@ -278,6 +278,9 @@ func ParseWhoisResponseCN(response string, domain string) (model.DomainInfo, err
 func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, error) {
 	domainInfo := newDomainInfo(domain)
 
+	// Normalize CRLF so the blank-line-terminated nameserver block regex matches.
+	response = strings.ReplaceAll(response, "\r", "")
+
 	// 解析创建日期（HKIRC 只给日期，保持 RFC 3339 full-date）
 	matchCreationDate := reHKCreationDate.FindStringSubmatch(response)
 	if len(matchCreationDate) > 1 {
@@ -327,6 +330,9 @@ func ParseWhoisResponseHK(response string, domain string) (model.DomainInfo, err
 
 func ParseWhoisResponseTW(response string, domain string) (model.DomainInfo, error) {
 	domainInfo := newDomainInfo(domain)
+
+	// Normalize CRLF so the blank-line-terminated nameserver block regex matches.
+	response = strings.ReplaceAll(response, "\r", "")
 
 	// 解析注册商
 	matchRegistrar := reTWRegistrar.FindStringSubmatch(response)
@@ -591,6 +597,9 @@ func ParseWhoisResponseSB(response string, domain string) (model.DomainInfo, err
 
 func ParseWhoisResponseMO(response string, domain string) (model.DomainInfo, error) {
 	domainInfo := newDomainInfo(domain)
+
+	// Normalize CRLF so the blank-line-terminated nameserver block regex matches.
+	response = strings.ReplaceAll(response, "\r", "")
 
 	// Parse creation date (MONIC local time is UTC+8)
 	matchCreationDate := reMOCreationDate.FindStringSubmatch(response)

--- a/internal/whois/whois_parsers_test.go
+++ b/internal/whois/whois_parsers_test.go
@@ -157,6 +157,29 @@ URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
 	}
 }
 
+// TestParseWhoisResponseLA_RegistrarIANAID guards against the regex regression
+// where a trailing `$` anchor (or a newline-crossing `\s*`) stopped the field
+// from being captured when it is present and followed by more lines.
+func TestParseWhoisResponseLA_RegistrarIANAID(t *testing.T) {
+	response := `Domain Name: EXAMPLE.LA
+Creation Date: 2000-11-20T01:00:00.0Z
+Registry Expiry Date: 2026-11-20T23:59:59.0Z
+Registrar: TLD Registrar Solutions Ltd
+Registrar IANA ID: 1234
+Domain Status: serverTransferProhibited https://icann.org/epp#serverTransferProhibited
+Name Server: ns1.example.la
+DNSSEC: unsigned
+>>> Last update of WHOIS database: 2024-01-01T00:00:00.0Z <<<`
+
+	domainInfo, err := ParseWhoisResponseLA(response, "example.la")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if domainInfo.RegistrarIANAID != "1234" {
+		t.Errorf("Expected Registrar IANA ID 1234, got %q", domainInfo.RegistrarIANAID)
+	}
+}
+
 func TestParseWhoisResponseLA_DomainNotFound(t *testing.T) {
 	response := `Domain Name: NOTFOUND.LA
 Registry Domain ID:

--- a/main.go
+++ b/main.go
@@ -151,6 +151,19 @@ func withCORS(next http.Handler) http.Handler {
 }
 
 // registerRoutes attaches all endpoints to mux.
+// maxMCPBody bounds the /mcp request body. MCP JSON-RPC calls (including
+// whois_batch_lookup) are small; 256 KiB leaves generous headroom while
+// preventing an unbounded read.
+const maxMCPBody = 256 << 10 // 256 KiB
+
+// maxBytes wraps a handler so its request body is capped at n bytes.
+func maxBytes(next http.Handler, n int64) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, n)
+		next.ServeHTTP(w, r)
+	})
+}
+
 func registerRoutes(mux *http.ServeMux) {
 	// Health check endpoints
 	mux.HandleFunc("/health", handlers.HandleHealth)
@@ -163,8 +176,10 @@ func registerRoutes(mux *http.ServeMux) {
 	// OpenAPI 3.1 service description
 	mux.HandleFunc("/openapi.json", handlers.HandleOpenAPI)
 
-	// MCP Streamable HTTP endpoint
-	mux.Handle("/mcp", mcp.NewHandler(config.Version))
+	// MCP Streamable HTTP endpoint. Cap the body like /batch does: the go-sdk
+	// transport reads the whole request into memory, so an unbounded POST would
+	// otherwise be an easy amplification vector.
+	mux.Handle("/mcp", maxBytes(mcp.NewHandler(config.Version), maxMCPBody))
 
 	// Bulk query endpoint (off unless batch.enabled is set)
 	mux.HandleFunc("/batch", batchHandler)


### PR DESCRIPTION
本轮全库代码审查（多角度并行）后处理确认为真的一批发现。均已在 `main` 上无 diff 时对当前代码 fresh review 得出，非旧版本臆测。

## Fixed

- **Redis 把客户端断连误判为故障** (`internal/utils/redis_cache.go`) — `Get`/`Set` 此前把任何非 `redis.Nil` 错误（含调用方自己 `context.Canceled`/`DeadlineExceeded`）都当作 Redis 故障，翻转共享 `healthy` 标志，导致一个短超时客户端断开就能让**其它所有在途请求**降级到内存缓存直到下一次 30s 健康检查。现在 `ctx.Err()!=nil` 时不再翻转；真实 Redis 命令错误现在会 `slog.Warn` 并计入 `whois_cache_requests_total{result="error"}`（此前完全静默）。
- **布尔环境变量静默当 false** (`internal/config/config.go`) — `WHOIS_REDIS_TLS` 等 5 个布尔 env 此前把任何非 `true`/`1` 的值主动置为 `false`，`WHOIS_REDIS_TLS=True` 会悄悄关掉 yaml 里的 `redis.tls`。新增 `parseBoolEnv`：大小写不敏感解析 `true/1/false/0`，无法识别的值**保留原设置并告警**。
- **`.la` Registrar IANA ID 从不解析** (`internal/whois/whois_parsers.go`) — 正则尾部 `$` 在无 `(?m)` 时锚定整串末尾，仅当该字段恰为响应最后一行时才匹配，实际永远为空。改为 `[ \t]*(.*)`（横向空白，避免 `\s*` 跨行误抓下一行）。
- **HK/TW/MO CRLF 下丢失 nameserver** (`internal/whois/whois_parsers.go`) — 这三个 parser 依赖字面 `\n\n` 判定 nameserver 块结束，注册局用 `\r\n` 时静默返回空列表（`.au` 早已 strip `\r`）。三处顶部统一 `strings.ReplaceAll(response, "\r", "")`。
- **`/mcp` 无 body 上限** (`main.go`) — go-sdk transport 无界 `io.ReadAll` 请求体。加 `maxBytes` 包装，256 KiB，与 `/batch` 的 64 KiB 上限对齐。

## Changed

- **bootstrap 部分失败诚实上报** (`internal/serverlist/bootstrap.go`) — 四个 IANA 类别中部分 fetch 失败时，`UpdateFromIANA` 会把失败类别回退到编译基线，但此前仍记为 `success`。现在 `FetchIANA` 返回失败类别，部分失败记 `whois_bootstrap_refresh_total{result="partial"}` + 告警。**未改合并逻辑**（回退到已知基线本身是刻意取舍，避免残留 IANA 已删条目）。

## Tests

新增 `.la` IANA ID 正例、`parseBoolEnv` 正/负例（含 `yes` 不能把 `true` 翻掉）。`gofmt`/`go vet`/`go test ./...`（含 `-race`）全绿。

## 未纳入（记 backlog，非本 PR）

`.sb/.au` 多 DS 记录只取首条、MCP 路径缺 metrics、资源类型分类逻辑三处重复 —— 均为极罕见场景或整洁度问题，非 bug。

🤖 Generated with [Claude Code](https://claude.com/claude-code)