### PR TITLE
fix: address round-6 external audit findings

### DIFF
--- a/.ide/.goreleaser.yml
+++ b/.ide/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 release:
   disable: true
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE

--- a/.ide/Dockerfile
+++ b/.ide/Dockerfile
@@ -1,7 +1,7 @@
 # 此文件为远程开发环境配置文件
 FROM debian:bookworm
 
-ENV GO_VERSION=1.24.1
+ENV GO_VERSION=1.26.5
 
 RUN apt update &&\
     apt install -y wget rsync unzip openssh-server vim lsof git git-lfs locales locales-all libgit2-1.5 libgit2-dev net-tools jq curl &&\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   still admitting requests, so under sustained traffic shutdown could hang
   indefinitely; both waits are now bounded.
 - A request whose client disconnects (or whose batch item deadline passes) while
-  waiting on a deduplicated upstream query now releases its concurrency slot
-  immediately instead of blocking for the full query timeout. The shared upstream
-  query still runs to completion and populates the cache.
+  waiting on a deduplicated upstream query now returns immediately instead of
+  blocking for the full query timeout. The shared upstream query still runs to
+  completion and populates the cache, and keeps a concurrency slot occupied until
+  it finishes, so `server.rateLimit` remains a true cap on concurrent upstream
+  work.
 - `/batch` rejects request bodies with trailing data after the JSON object;
   previously a valid object followed by a second JSON document was accepted with
   the remainder silently ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Builds now require Go 1.26.5, picking up the upstream `crypto/tls` fix for
+  [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856), which was reachable from
+  this binary.
+- Responses carry `Cache-Control: private` (instead of `public`) when API key
+  authentication is enabled, so a shared cache such as a CDN in front of an
+  authenticated instance cannot serve cached results to clients that never
+  presented a key. Open instances keep `public`.
+- An invalid `proxy.server` URL now fails startup instead of being silently
+  dropped at first use, which sent traffic the operator meant to route through
+  the proxy over the direct connection instead. `proxy.suffixes` entries are
+  lowercased on load to match the lookup side; an uppercase suffix could never
+  match before.
+
 ### Fixed
 - Redis cache no longer treats a caller's cancelled/expired request context as a
   Redis failure. Previously a single client disconnecting mid-request could flip
@@ -34,12 +48,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `/mcp` endpoint now caps its request body (256 KiB), matching the existing
   limit on `/batch`; previously the MCP transport read the whole request into
   memory without bound.
+- Graceful shutdown now stops accepting new requests before waiting for in-flight
+  ones. The previous order waited on the in-flight counter while the listener was
+  still admitting requests, so under sustained traffic shutdown could hang
+  indefinitely; both waits are now bounded.
+- A request whose client disconnects (or whose batch item deadline passes) while
+  waiting on a deduplicated upstream query now releases its concurrency slot
+  immediately instead of blocking for the full query timeout. The shared upstream
+  query still runs to completion and populates the cache.
+- `/batch` rejects request bodies with trailing data after the JSON object;
+  previously a valid object followed by a second JSON document was accepted with
+  the remainder silently ignored.
+- The OpenAPI document now declares that every endpoint accepts anonymous, bearer
+  or `X-API-Key` access (enforced only when `auth.keys` is configured) — it
+  previously defined the security schemes without any security requirement — and
+  CIDR queries are described by a dedicated `/ip/{address}/{prefixlen}` entry
+  instead of a path parameter containing a slash, which OpenAPI does not allow.
+  Runtime routing is unchanged.
 
 ### Changed
-- A partial IANA RDAP bootstrap refresh (some categories fetched, others failed) is
-  now logged as a partial update and recorded as
-  `whois_bootstrap_refresh_total{result="partial"}` rather than `success`, since the
-  failed categories fall back to the compiled baseline for that cycle.
+- The `/mcp` endpoint now runs in stateless mode and answers tool calls with plain
+  `application/json` instead of a server-sent-events stream. The endpoint only
+  exposes tools, so sessions carried no state; idle stateful sessions were never
+  cleaned up and could be created without bound, and the SSE responses conflicted
+  with the server's write timeout. MCP clients following the Streamable HTTP
+  specification are unaffected.
+- When an IANA RDAP bootstrap category fails to refresh, it now keeps serving its
+  most recent successful fetch (at most one refresh interval stale) instead of
+  reverting to the compiled-in baseline from build time. A partial refresh (some
+  categories fetched, others failed) is logged as a partial update and recorded as
+  `whois_bootstrap_refresh_total{result="partial"}` rather than `success`, and
+  `whois_bootstrap_last_fetch_timestamp_seconds` is only advanced on a full
+  success.
 
 ## [1.0.0] - 2026-06-13
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KincaidYang/whois
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime/debug"
@@ -237,11 +238,13 @@ func load() {
 	RateLimit = config.Server.RateLimit
 	ConcurrencyLimiter = make(chan struct{}, RateLimit)
 
-	// Set the proxy server
+	// Set the proxy server. Suffixes are lowercased to match the lookup
+	// side, which normalizes every queried resource to lowercase — an
+	// uppercase suffix in the config would otherwise never match.
 	ProxyServer = config.Proxy.Server
 	ProxyUsername = config.Proxy.Username
 	ProxyPassword = config.Proxy.Password
-	ProxySuffixes = config.Proxy.Suffixes
+	ProxySuffixes = lowercaseAll(config.Proxy.Suffixes)
 
 	// Set the bootstrap interval
 	BootstrapInterval = time.Duration(config.Bootstrap.Interval) * time.Second
@@ -372,6 +375,11 @@ func applyDefaults(config *Config) {
 // cache.memoryCleanInterval panics the memory cache's cleanup ticker, a
 // negative batch.maxItems rejects every batch request). cache.negativeExpiration
 // is exempt: negative is its documented "disable" value.
+//
+// A configured proxy.server must be a usable proxy URL. An invalid one used
+// to be dropped silently at first use, quietly sending traffic the operator
+// meant to proxy over the direct route instead; failing startup keeps that
+// traffic from ever leaking.
 func validateConfig(config *Config) error {
 	checks := []struct {
 		name  string
@@ -389,6 +397,38 @@ func validateConfig(config *Config) error {
 		if c.value < 0 {
 			return fmt.Errorf("%s must not be negative (got %d)", c.name, c.value)
 		}
+	}
+	if config.Proxy.Server != "" {
+		if err := validateProxyURL(config.Proxy.Server); err != nil {
+			return fmt.Errorf("proxy.server: %w", err)
+		}
+	}
+	return nil
+}
+
+// lowercaseAll returns a copy of items with every entry lowercased.
+func lowercaseAll(items []string) []string {
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = strings.ToLower(s)
+	}
+	return out
+}
+
+// validateProxyURL checks that s is an absolute URL with a host and a scheme
+// http.Transport's Proxy function supports.
+func validateProxyURL(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("invalid URL %q: %w", s, err)
+	}
+	switch u.Scheme {
+	case "http", "https", "socks5", "socks5h":
+	default:
+		return fmt.Errorf("unsupported scheme %q in %q (use http, https, socks5 or socks5h)", u.Scheme, s)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host in %q", s)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -351,3 +351,58 @@ func TestApplyDefaults(t *testing.T) {
 		t.Errorf("negative NegativeExpiration overwritten: %d", cfg.Cache.NegativeExpiration)
 	}
 }
+
+// TestValidateConfigProxyServer verifies an unusable proxy.server fails
+// validation (it used to be dropped silently at first use, sending traffic
+// meant for the proxy over the direct route), while valid URLs and the
+// empty default pass.
+func TestValidateConfigProxyServer(t *testing.T) {
+	valid := []string{
+		"",
+		"http://proxy.example:8080",
+		"https://proxy.example",
+		"socks5://127.0.0.1:1080",
+		"socks5h://proxy.example:1080",
+	}
+	for _, server := range valid {
+		var cfg Config
+		applyDefaults(&cfg)
+		cfg.Proxy.Server = server
+		if err := validateConfig(&cfg); err != nil {
+			t.Errorf("proxy.server %q: unexpected error: %v", server, err)
+		}
+	}
+
+	invalid := []string{
+		"://missing-scheme",
+		"proxy.example:8080",       // scheme-less: parses as scheme "proxy.example"
+		"ftp://proxy.example:2121", // unsupported scheme
+		"http://",                  // missing host
+	}
+	for _, server := range invalid {
+		var cfg Config
+		applyDefaults(&cfg)
+		cfg.Proxy.Server = server
+		err := validateConfig(&cfg)
+		if err == nil {
+			t.Errorf("proxy.server %q: expected error", server)
+			continue
+		}
+		if !strings.Contains(err.Error(), "proxy.server") {
+			t.Errorf("proxy.server %q: error %q does not name the offending key", server, err)
+		}
+	}
+}
+
+// TestProxySuffixesLowercased verifies configured suffixes are normalized to
+// lowercase: the lookup side lowercases every queried resource, so an
+// uppercase suffix would never match.
+func TestProxySuffixesLowercased(t *testing.T) {
+	got := lowercaseAll([]string{"COM", "Org", "jp"})
+	want := []string{"com", "org", "jp"}
+	for i, s := range got {
+		if s != want[i] {
+			t.Errorf("suffix %d = %q, want %q", i, s, want[i])
+		}
+	}
+}

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -88,6 +89,12 @@ func HandleBatch(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&req); err != nil {
 		utils.HandleHTTPError(w, utils.ErrorTypeBadRequest, "Invalid request body: expected {\"queries\": [\"example.com\", ...]}.")
+		return
+	}
+	// Decode only reads the first JSON value; reject trailing data so a body
+	// like `{"queries":[...]}{"queries":[...]}` is not silently half-read.
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		utils.HandleHTTPError(w, utils.ErrorTypeBadRequest, "Invalid request body: unexpected data after the JSON object.")
 		return
 	}
 	if len(req.Queries) == 0 {

--- a/internal/handlers/headers.go
+++ b/internal/handlers/headers.go
@@ -8,9 +8,15 @@ import (
 )
 
 // setCacheControl tells clients they may cache a successful response for as
-// long as the server itself caches it.
+// long as the server itself caches it. When API key authentication is
+// enabled the response is marked private: a shared cache (CDN) serving it
+// to other clients would bypass the key check and the per-key rate limit.
 func setCacheControl(w http.ResponseWriter) {
-	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(config.CacheExpiration.Seconds())))
+	scope := "public"
+	if len(config.AuthClients) > 0 {
+		scope = "private"
+	}
+	w.Header().Set("Cache-Control", fmt.Sprintf("%s, max-age=%d", scope, int(config.CacheExpiration.Seconds())))
 }
 
 // missLabel is the X-Cache value for a response that went upstream: REFRESH

--- a/internal/handlers/headers_test.go
+++ b/internal/handlers/headers_test.go
@@ -1,0 +1,31 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/config"
+)
+
+// TestSetCacheControlScope verifies responses are publicly cacheable on an
+// open instance but marked private once API key authentication is enabled,
+// so a shared cache cannot serve authenticated results past the key check.
+func TestSetCacheControlScope(t *testing.T) {
+	oldClients := config.AuthClients
+	t.Cleanup(func() { config.AuthClients = oldClients })
+
+	config.AuthClients = nil
+	w := httptest.NewRecorder()
+	setCacheControl(w)
+	if cc := w.Header().Get("Cache-Control"); !strings.HasPrefix(cc, "public, max-age=") {
+		t.Errorf("open instance: Cache-Control = %q, want public, max-age=...", cc)
+	}
+
+	config.AuthClients = []config.AuthClient{{Name: "test", Key: "k"}}
+	w = httptest.NewRecorder()
+	setCacheControl(w)
+	if cc := w.Header().Get("Cache-Control"); !strings.HasPrefix(cc, "private, max-age=") {
+		t.Errorf("authenticated instance: Cache-Control = %q, want private, max-age=...", cc)
+	}
+}

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -18,18 +18,27 @@
       "url": "/"
     }
   ],
+  "security": [
+    {},
+    {
+      "bearerAuth": []
+    },
+    {
+      "apiKeyHeader": []
+    }
+  ],
   "paths": {
     "/{resource}": {
       "get": {
         "operationId": "query",
         "summary": "Query a domain, IP address/CIDR prefix, or ASN (auto-detected)",
-        "description": "The resource type is detected automatically: an IP address or CIDR prefix is looked up as an IP network, a number with optional `as`/`asn` prefix as an autnum, anything else as a domain name. Unicode (IDN) domain names are accepted and converted to punycode. For explicit typing use /domain/, /ip/ or /autnum/.",
+        "description": "The resource type is detected automatically: an IP address or CIDR prefix is looked up as an IP network, a number with optional `as`/`asn` prefix as an autnum, anything else as a domain name. Unicode (IDN) domain names are accepted and converted to punycode. For explicit typing use /domain/, /ip/ or /autnum/. CIDR prefixes contain a slash and therefore span two path segments (`/192.0.2.0/24`); that form is documented as /ip/{address}/{prefixlen}.",
         "parameters": [
           {
             "name": "resource",
             "in": "path",
             "required": true,
-            "description": "Domain name (`example.com`, `例子.cn`), IP address (`192.0.2.1`, `2001:db8::`), CIDR prefix (`192.0.2.0/24`), or ASN (`205794`, `as205794`).",
+            "description": "Domain name (`example.com`, `例子.cn`), IP address (`192.0.2.1`, `2001:db8::`), or ASN (`205794`, `as205794`).",
             "schema": {
               "type": "string"
             }
@@ -150,15 +159,90 @@
       "get": {
         "operationId": "queryIP",
         "summary": "Query an IP network (RFC 9082-style typed path)",
-        "description": "Accepts a single IPv4/IPv6 address or a CIDR prefix whose slash is part of the path, e.g. `/ip/192.0.2.0/24` or `/ip/2001:db8::/32`. Returns 400 when the resource is not a valid IP or prefix.",
+        "description": "Accepts a single IPv4/IPv6 address; for a CIDR prefix, whose slash adds a second path segment, see /ip/{address}/{prefixlen}. Returns 400 when the resource is not a valid IP.",
         "parameters": [
           {
             "name": "address",
             "in": "path",
             "required": true,
-            "description": "IP address (`192.0.2.1`) or CIDR prefix (`192.0.2.0/24`).",
+            "description": "IP address (`192.0.2.1`, `2001:db8::`).",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/refresh"
+          },
+          {
+            "$ref": "#/components/parameters/ifNoneMatch"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "IP network registration data.",
+            "headers": {
+              "X-Cache": {
+                "$ref": "#/components/headers/X-Cache"
+              },
+              "Cache-Control": {
+                "$ref": "#/components/headers/Cache-Control"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IPNetwork"
+                }
+              }
+            }
+          },
+          "304": {
+            "$ref": "#/components/responses/NotModified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/QueryDenied"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
+    "/ip/{address}/{prefixlen}": {
+      "get": {
+        "operationId": "queryIPPrefix",
+        "summary": "Query a CIDR prefix (RFC 9082-style typed path)",
+        "description": "The CIDR form of /ip/{address}: the prefix length follows the network address as its own path segment, e.g. `/ip/192.0.2.0/24` or `/ip/2001:db8::/32`. Returns 400 when the two segments do not form a valid CIDR prefix.",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "description": "Network address (`192.0.2.0`, `2001:db8::`).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "prefixlen",
+            "in": "path",
+            "required": true,
+            "description": "Prefix length in bits (`24`, `32`).",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{1,3}$"
             }
           },
           {

--- a/internal/handlers/singleflight.go
+++ b/internal/handlers/singleflight.go
@@ -47,6 +47,20 @@ func dedupedQuery(ctx context.Context, key string, fn func(context.Context) (que
 		}
 		return res.Val.(queryOutcome), nil
 	case <-ctx.Done():
+		// The handler's defer frees its concurrency slot as soon as we
+		// return, but the detached flight's upstream request is still
+		// running. Hold a slot on its behalf until it completes, so
+		// server.rateLimit stays a true cap on concurrent upstream work —
+		// otherwise a client could disconnect repeatedly to stack detached
+		// flights beyond the configured limit. (nil only in tests that
+		// bypass config.Load.)
+		if limiter := config.ConcurrencyLimiter; limiter != nil {
+			go func() {
+				limiter <- struct{}{}
+				<-ch
+				<-limiter
+			}()
+		}
 		return queryOutcome{}, ctx.Err()
 	}
 }

--- a/internal/handlers/singleflight.go
+++ b/internal/handlers/singleflight.go
@@ -22,10 +22,13 @@ type queryOutcome struct {
 
 // dedupedQuery runs fn through sfGroup under the given key. The flight gets
 // its own timeout, detached from the first caller's context, so one client
-// disconnecting does not fail the other requests waiting on the same key.
+// disconnecting does not fail the other requests waiting on the same key —
+// but each waiter honors its own context and stops waiting (releasing its
+// concurrency slot) when that context ends, while the flight runs to
+// completion and still populates the cache for later requests.
 // Stable not-found/denied errors are negative-cached once per flight.
 func dedupedQuery(ctx context.Context, key string, fn func(context.Context) (queryOutcome, error)) (queryOutcome, error) {
-	v, err, _ := sfGroup.Do(key, func() (any, error) {
+	ch := sfGroup.DoChan(key, func() (any, error) {
 		qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), config.RequestTimeout)
 		defer cancel()
 
@@ -36,8 +39,14 @@ func dedupedQuery(ctx context.Context, key string, fn func(context.Context) (que
 		}
 		return outcome, nil
 	})
-	if err != nil {
-		return queryOutcome{}, err
+
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return queryOutcome{}, res.Err
+		}
+		return res.Val.(queryOutcome), nil
+	case <-ctx.Done():
+		return queryOutcome{}, ctx.Err()
 	}
-	return v.(queryOutcome), nil
 }

--- a/internal/handlers/singleflight_test.go
+++ b/internal/handlers/singleflight_test.go
@@ -1,0 +1,75 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
+)
+
+// TestDedupedQueryWaiterCancel verifies that a waiter whose context ends
+// stops waiting immediately (releasing its concurrency slot), while the
+// flight itself keeps running detached and delivers its result to the
+// remaining waiters.
+func TestDedupedQueryWaiterCancel(t *testing.T) {
+	oldCache := config.CacheManager
+	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
+	t.Cleanup(func() { config.CacheManager = oldCache })
+
+	var flights atomic.Int32
+	release := make(chan struct{})
+	started := make(chan struct{})
+	fn := func(context.Context) (queryOutcome, error) {
+		flights.Add(1)
+		close(started)
+		<-release
+		return queryOutcome{body: "shared", contentType: "application/json"}, nil
+	}
+
+	const key = "whois:sfcanceltest"
+
+	// First waiter starts the flight, then gets canceled mid-flight.
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := dedupedQuery(ctx, key, fn)
+		errCh <- err
+	}()
+	<-started
+
+	// Second waiter joins the same in-flight query with a healthy context.
+	outCh := make(chan queryOutcome, 1)
+	go func() {
+		out, _ := dedupedQuery(context.Background(), key, fn)
+		outCh <- out
+	}()
+	time.Sleep(100 * time.Millisecond) // let the second waiter join the flight
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("canceled waiter error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled waiter did not return until the flight finished")
+	}
+
+	close(release)
+	select {
+	case out := <-outCh:
+		if out.body != "shared" {
+			t.Errorf("surviving waiter got body %q, want the shared flight result", out.body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("surviving waiter never received the flight result")
+	}
+
+	if n := flights.Load(); n != 1 {
+		t.Errorf("flight ran %d times, want 1 (waiters must share one flight)", n)
+	}
+}

--- a/internal/handlers/singleflight_test.go
+++ b/internal/handlers/singleflight_test.go
@@ -16,9 +16,10 @@ import (
 // flight itself keeps running detached and delivers its result to the
 // remaining waiters.
 func TestDedupedQueryWaiterCancel(t *testing.T) {
-	oldCache := config.CacheManager
+	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
 	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
-	t.Cleanup(func() { config.CacheManager = oldCache })
+	config.ConcurrencyLimiter = make(chan struct{}, 4)
+	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
 
 	var flights atomic.Int32
 	release := make(chan struct{})
@@ -59,6 +60,13 @@ func TestDedupedQueryWaiterCancel(t *testing.T) {
 		t.Fatal("canceled waiter did not return until the flight finished")
 	}
 
+	// While the flight is detached, the canceled waiter's accounting
+	// goroutine must hold one concurrency slot on its behalf, so the
+	// configured limit stays a true cap on concurrent upstream work.
+	waitFor(t, "detached flight to be counted against the limiter", func() bool {
+		return len(config.ConcurrencyLimiter) == 1
+	})
+
 	close(release)
 	select {
 	case out := <-outCh:
@@ -69,7 +77,24 @@ func TestDedupedQueryWaiterCancel(t *testing.T) {
 		t.Fatal("surviving waiter never received the flight result")
 	}
 
+	// The flight is done; its slot must be released again.
+	waitFor(t, "the flight's limiter slot to be released", func() bool {
+		return len(config.ConcurrencyLimiter) == 0
+	})
+
 	if n := flights.Load(); n != 1 {
 		t.Errorf("flight ran %d times, want 1 (waiters must share one flight)", n)
+	}
+}
+
+// waitFor polls cond until it holds, failing the test after two seconds.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -165,5 +165,14 @@ func NewHandler(version string) http.Handler {
 		// localhost. Behind a reverse proxy the Host header is the public
 		// domain, so protection is off unless mcp.localhostprotection is set.
 		DisableLocalhostProtection: !config.MCPLocalhostProtection,
+		// The server only exposes tools — it never sends notifications or
+		// server-initiated requests — so sessions carry no state worth keeping.
+		// Stateless mode closes the per-request session when the request ends
+		// (idle stateful sessions are otherwise never cleaned up, since
+		// SessionTimeout's zero value disables cleanup), and JSONResponse
+		// answers tool calls with plain application/json instead of an SSE
+		// stream, which the server's global WriteTimeout would cut short.
+		Stateless:    true,
+		JSONResponse: true,
 	})
 }

--- a/internal/mcp/mcp_server_test.go
+++ b/internal/mcp/mcp_server_test.go
@@ -2,6 +2,9 @@ package mcp
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -93,5 +96,45 @@ func TestBatchToolMixedResults(t *testing.T) {
 	}
 	if !strings.Contains(payload, domain) {
 		t.Errorf("payload missing cached domain data: %s", payload)
+	}
+}
+
+// TestHandlerStatelessJSON drives the streamable HTTP handler end to end and
+// verifies its stateless + JSON configuration: a tools/call POST that carries
+// no Mcp-Session-Id header (and was never preceded by an initialize request
+// on this connection) is answered directly with application/json rather than
+// rejected for lacking a session or streamed over SSE.
+func TestHandlerStatelessJSON(t *testing.T) {
+	setupBatchTest(t, false, 10)
+
+	srv := httptest.NewServer(NewHandler("test"))
+	defer srv.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"whois_lookup","arguments":{"query":"!!invalid!!"}}}`
+	req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(payload), "Invalid input") {
+		t.Errorf("expected the tool's invalid-input error in the response, got: %s", payload)
 	}
 }

--- a/internal/rdap/rdap_query.go
+++ b/internal/rdap/rdap_query.go
@@ -36,6 +36,9 @@ var proxyOnce sync.Once
 
 func initProxy() {
 	if config.ProxyServer != "" {
+		// config.Load validated the URL at startup (an invalid proxy.server
+		// fails the process rather than silently sending traffic direct), so
+		// the error branch here is purely defensive.
 		proxyURL, err := url.Parse(config.ProxyServer)
 		if err == nil {
 			if config.ProxyUsername != "" && config.ProxyPassword != "" {

--- a/internal/serverlist/bootstrap.go
+++ b/internal/serverlist/bootstrap.go
@@ -97,12 +97,12 @@ func fetchBootstrap(ctx context.Context, client *http.Client, url string) (map[s
 	return result, nil
 }
 
-// FetchIANA fetches all four IANA bootstrap files and merges them into one map.
-// Categories that fail to fetch are omitted from the result (caller uses compiled
-// fallback) and their names are returned so the caller can report a partial update
-// rather than a clean success.
-func FetchIANA(ctx context.Context, client *http.Client) (merged map[string]string, failed []string) {
-	merged = make(map[string]string)
+// FetchIANA fetches all four IANA bootstrap files. Results are keyed by
+// category so the caller can commit each independently; categories that fail
+// to fetch are absent from the map and listed in failed, so the caller can
+// report a partial update rather than a clean success.
+func FetchIANA(ctx context.Context, client *http.Client) (perCategory map[string]map[string]string, failed []string) {
+	perCategory = make(map[string]map[string]string)
 	for category, url := range ianaBootstrapURLs {
 		data, err := fetchBootstrap(ctx, client, url)
 		if err != nil {
@@ -110,12 +110,37 @@ func FetchIANA(ctx context.Context, client *http.Client) (merged map[string]stri
 			failed = append(failed, category)
 			continue
 		}
+		perCategory[category] = data
+		slog.Debug("RDAP bootstrap fetched", "category", category, "entries", len(data))
+	}
+	return perCategory, failed
+}
+
+// commitBootstrap folds one round of per-category fetch results into
+// lastGood and rebuilds the active index from every category's last-known-good
+// data, so a category whose refresh failed keeps serving its most recent
+// successful fetch (at most one interval stale) instead of reverting to the
+// compiled baseline. It returns the outcome label for the refresh metric —
+// "failure" (nothing fetched, index untouched), "partial" or "success" —
+// and the number of entries committed.
+func commitBootstrap(lastGood, perCategory map[string]map[string]string, failed []string) (outcome string, entries int) {
+	if len(perCategory) == 0 {
+		return "failure", 0
+	}
+	for category, data := range perCategory {
+		lastGood[category] = data
+	}
+	merged := make(map[string]string)
+	for _, data := range lastGood {
 		for k, v := range data {
 			merged[k] = v
 		}
-		slog.Debug("RDAP bootstrap fetched", "category", category, "entries", len(data))
 	}
-	return merged, failed
+	UpdateFromIANA(merged)
+	if len(failed) > 0 {
+		return "partial", len(merged)
+	}
+	return "success", len(merged)
 }
 
 // StartBootstrapRefresh fetches IANA data immediately on startup, then
@@ -125,29 +150,26 @@ func StartBootstrapRefresh(ctx context.Context, client *http.Client, interval ti
 	if interval <= 0 {
 		return
 	}
+	// lastGood holds each category's most recent successful fetch. refresh
+	// only ever runs on the single goroutine below, so no locking is needed.
+	lastGood := make(map[string]map[string]string)
 	refresh := func() {
 		fetchCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
 
-		data, failed := FetchIANA(fetchCtx, client)
-		if len(data) == 0 {
+		perCategory, failed := FetchIANA(fetchCtx, client)
+		outcome, entries := commitBootstrap(lastGood, perCategory, failed)
+		metrics.BootstrapRefreshTotal.WithLabelValues(outcome).Inc()
+		switch outcome {
+		case "failure":
 			slog.Warn("RDAP bootstrap: no data fetched, retaining current index")
-			metrics.BootstrapRefreshTotal.WithLabelValues("failure").Inc()
-			return
+		case "partial":
+			slog.Warn("RDAP bootstrap partially updated; failed categories retain last-known-good data",
+				"failed", failed, "entries", entries)
+		default:
+			metrics.BootstrapLastFetchTimestamp.Set(float64(time.Now().Unix()))
+			slog.Info("RDAP bootstrap index updated", "entries", entries)
 		}
-		UpdateFromIANA(data)
-		metrics.BootstrapLastFetchTimestamp.Set(float64(time.Now().Unix()))
-		if len(failed) > 0 {
-			// The failed categories were not in `data`, so UpdateFromIANA just
-			// reverted them to the compiled baseline. Surface that instead of
-			// reporting a clean success.
-			slog.Warn("RDAP bootstrap partially updated; failed categories reverted to compiled baseline",
-				"failed", failed, "entries", len(data))
-			metrics.BootstrapRefreshTotal.WithLabelValues("partial").Inc()
-			return
-		}
-		metrics.BootstrapRefreshTotal.WithLabelValues("success").Inc()
-		slog.Info("RDAP bootstrap index updated", "entries", len(data))
 	}
 
 	// Initial fetch at startup (non-blocking).

--- a/internal/serverlist/bootstrap_test.go
+++ b/internal/serverlist/bootstrap_test.go
@@ -1,0 +1,46 @@
+package serverlist
+
+import "testing"
+
+// TestCommitBootstrapLastKnownGood verifies that a category whose refresh
+// fails keeps serving its most recent successful fetch instead of reverting
+// to the compiled baseline, and that outcomes are labelled correctly.
+func TestCommitBootstrapLastKnownGood(t *testing.T) {
+	t.Cleanup(func() { UpdateFromIANA(nil) })
+
+	lastGood := make(map[string]map[string]string)
+
+	// Round 1: both categories fetch successfully. The zzlkg TLD exists only
+	// in the fetched data, never in the compiled baseline, so its survival
+	// proves last-known-good retention.
+	outcome, entries := commitBootstrap(lastGood, map[string]map[string]string{
+		"dns":  {"zzlkg": "https://round1.example/rdap/"},
+		"ipv4": {"192.0.2.0/24": "https://round1.example/rdap/"},
+	}, nil)
+	if outcome != "success" || entries != 2 {
+		t.Fatalf("round 1: outcome=%q entries=%d, want success/2", outcome, entries)
+	}
+
+	// Round 2: dns fails, ipv4 fetches fresh data.
+	outcome, entries = commitBootstrap(lastGood, map[string]map[string]string{
+		"ipv4": {"192.0.2.0/24": "https://round2.example/rdap/"},
+	}, []string{"dns"})
+	if outcome != "partial" || entries != 2 {
+		t.Fatalf("round 2: outcome=%q entries=%d, want partial/2", outcome, entries)
+	}
+	if url, ok := LookupRdapServer("zzlkg"); !ok || url != "https://round1.example/rdap/" {
+		t.Errorf("failed dns category: zzlkg = %q, %v; want round-1 last-known-good data", url, ok)
+	}
+	if url, ok := LookupRdapServer("192.0.2.0/24"); !ok || url != "https://round2.example/rdap/" {
+		t.Errorf("refreshed ipv4 category: got %q, %v; want round-2 data", url, ok)
+	}
+
+	// Round 3: everything fails; the index must be left untouched.
+	outcome, entries = commitBootstrap(lastGood, map[string]map[string]string{}, []string{"dns", "ipv4", "ipv6", "asn"})
+	if outcome != "failure" || entries != 0 {
+		t.Fatalf("round 3: outcome=%q entries=%d, want failure/0", outcome, entries)
+	}
+	if url, ok := LookupRdapServer("zzlkg"); !ok || url != "https://round1.example/rdap/" {
+		t.Errorf("total failure: zzlkg = %q, %v; want index untouched", url, ok)
+	}
+}

--- a/internal/utils/response.go
+++ b/internal/utils/response.go
@@ -121,7 +121,14 @@ func HandleQueryError(ctx context.Context, w http.ResponseWriter, err error) {
 	case errors.Is(err, ErrQueryDenied):
 		writeProblem(w, http.StatusForbidden, "query-denied", "The registry denied the query", "")
 	default:
-		slog.ErrorContext(ctx, "query failed", "err", err)
+		// A canceled or expired context is the request's own lifecycle
+		// (client disconnect, request timeout), not an upstream failure;
+		// log it below error level so disconnects don't page anyone.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			slog.WarnContext(ctx, "query aborted", "err", err)
+		} else {
+			slog.ErrorContext(ctx, "query failed", "err", err)
+		}
 		writeProblem(w, http.StatusInternalServerError, "query-failed",
 			"Query failed", "Please try again later.")
 	}

--- a/main.go
+++ b/main.go
@@ -375,19 +375,34 @@ func main() {
 		}
 	}()
 
-	// Wait for shutdown signal, then drain in-flight requests before exiting.
+	// Wait for shutdown signal, then stop accepting new requests before
+	// draining the in-flight ones: under sustained traffic the wait group
+	// never reaches zero while the listener keeps admitting requests (and
+	// waiting concurrently with new Add calls misuses the WaitGroup).
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	<-sigCh
 
-	slog.Info("shutdown signal received, waiting for in-flight requests")
-	config.Wg.Wait()
-
-	slog.Info("all requests completed, shutting down")
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	slog.Info("shutdown signal received, draining in-flight requests")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout+5*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("server shutdown error", "err", err)
+	}
+
+	// The listener is closed, so no new Wg.Add races this wait; it only
+	// covers requests Shutdown may have given up on, and is bounded so a
+	// hung upstream cannot stall the exit forever.
+	drained := make(chan struct{})
+	go func() {
+		config.Wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		slog.Info("all requests completed, shutting down")
+	case <-time.After(5 * time.Second):
+		slog.Warn("timed out waiting for in-flight requests, exiting anyway")
 	}
 
 	if c, ok := config.CacheManager.(io.Closer); ok {

--- a/main.go
+++ b/main.go
@@ -35,8 +35,7 @@ func (sw *statusWriter) WriteHeader(code int) {
 }
 
 // Unwrap exposes the underlying writer to http.ResponseController, so
-// optional interfaces like http.Flusher keep working through the wrapper —
-// the MCP endpoint's SSE stream needs Flush to deliver its initial response.
+// optional interfaces like http.Flusher keep working through the wrapper.
 func (sw *statusWriter) Unwrap() http.ResponseWriter {
 	return sw.ResponseWriter
 }

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -66,10 +66,12 @@ func TestBatchBadRequests(t *testing.T) {
 	withTestBatch(t, true, 2)
 
 	for name, body := range map[string]string{
-		"not json":      `not json at all`,
-		"unknown field": `{"queris": ["example.com"]}`,
-		"empty list":    `{"queries": []}`,
-		"over maxItems": `{"queries": ["a.com", "b.com", "c.com"]}`,
+		"not json":       `not json at all`,
+		"unknown field":  `{"queris": ["example.com"]}`,
+		"empty list":     `{"queries": []}`,
+		"over maxItems":  `{"queries": ["a.com", "b.com", "c.com"]}`,
+		"trailing value": `{"queries": ["a.com"]}{"queries": ["b.com"]}`,
+		"trailing junk":  `{"queries": ["a.com"]} extra`,
 	} {
 		w := postBatch(t, body)
 		if w.Code != http.StatusBadRequest {


### PR DESCRIPTION
处置一份外部审计报告（含二进制漏洞扫描）的全部成立项，共 9 项修复 + 2 项工程修正。

## 高优先级

- **Go 1.26.5**：修复二进制可达的 `crypto/tls` 漏洞 GO-2026-5856（官方修复版本 1.26.5）。CI 用 `go-version-file: go.mod` 自动跟随；本地 `govulncheck ./...` 确认无剩余已知漏洞。
- **`/mcp` 改 stateless + JSON response**：此前有状态会话且 `SessionTimeout` 为零值（SDK 明确说明空闲会话永不清理），公网可被持续创建会话耗内存；SSE 响应还会被全局 `WriteTimeout=20s` 掐断。纯工具服务无需会话，`Stateless + JSONResponse` 一并消除会话泄漏、SSE 超时冲突和未在 CORS 声明的 DELETE 方法缺口。符合 Streamable HTTP 规范的客户端不受影响。
- **关停顺序反转**：原先先 `Wg.Wait()` 后 `srv.Shutdown()`，监听器持续收新请求时计数器永不归零，持续流量下关停会无限挂起（且 Wait 与 Add 并发属 WaitGroup 误用）。现在先 `Shutdown`（`RequestTimeout+5s` 超时）停止接入并排空存量，再有界等待 Wg（5s 兜底）。实测持续压请求下 SIGTERM 毫秒级排空退出。

## 中优先级

- **Cache-Control 按鉴权切换**：开启 `auth.keys` 时响应改 `private`，防止共享 CDN 把缓存结果直接发给未带 key 的客户端、绕过鉴权与按 key 限流；开放实例维持 `public`。
- **singleflight 改 `DoChan`**：客户端断开或批量条目到期的等待者立即释放并发槽（原先同步 `Do` 会空等满 15s）；共享回源仍脱离调用方跑完并写缓存。ctx 取消/超时在 `HandleQueryError` 降为 Warn 日志，响应维持 500（与既定批量 deadline 语义一致）。
- **OpenAPI 修正**：顶层补 `security`（匿名 / bearer / X-API-Key 三选，鉴权仅在配置 `auth.keys` 时强制）；CIDR 改为独立的 `/ip/{address}/{prefixlen}` 条目，不再让 path 参数含未转义斜杠（违反 OpenAPI 规范）。运行时路由不变，`/ip/192.0.2.0/24` 与根路径 CIDR 实测均正常。
- **IANA bootstrap 按类别 last-known-good**：某类别刷新失败时保留其上次成功抓取（最多陈旧一个刷新周期），不再瞬间回退到编译期基线；`whois_bootstrap_last_fetch_timestamp_seconds` 仅在全量成功时推进，partial 指标与告警保留。
- **代理配置 fail-fast**：非法 `proxy.server` URL 启动即报错退出（原先静默改直连，造成本应走代理的流量泄漏）；`proxy.suffixes` 加载时统一小写（查询侧全小写，大写后缀原先永远匹配不上）。
- **`/batch` 拒绝尾随 JSON**：合法对象后附加第二段 JSON/杂散字节原先被静默接受，现在解码后要求 EOF，否则 400。

## 工程项

- `.ide/Dockerfile`：Go 1.24.1 → 1.26.5（低于 go.mod 要求的工具链版本，该镜像被 CNB 发布流程使用）。
- `.ide/.goreleaser.yml`：弃用的 `archives.format` → `formats`（与 #37 同款修法）。

## 审计意见中明确不改

- 查询端点限制 HTTP 方法：既定 won't-fix（无副作用端点，限制反伤调用方）。
- 全局配置 / DefaultServeMux / os.Exit 重构与覆盖率空白：审计自身也标注首轮无需大改，记 backlog。

## 验证

- `gofmt` / `go vet` / `go test -race ./...` 全绿（154+ 测试，含 8 个新增：MCP stateless HTTP 层、singleflight 等待者取消、bootstrap last-known-good、proxy 校验、Cache-Control、batch 尾随 JSON）。
- `govulncheck ./...`：No vulnerabilities found。
- 端到端实测：`/mcp` 无会话 tools/call 返回纯 JSON；CIDR 两种路径 200；鉴权实例 `Cache-Control: private` + 无 key 401；非法 proxy 启动退出码 1；SIGTERM 压测下毫秒级排空。

🤖 Generated with [Claude Code](https://claude.com/claude-code)