### PR TITLE
feat: add linux/loong64 build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - arm
       - arm64
       - ppc64
+      - loong64
     goarm:
       - "7"
     ignore:


### PR DESCRIPTION
为 GoReleaser 构建矩阵新增 `loong64`（LoongArch 64 位，新世界 ABI），产出 `linux_loong64` 归档。GoReleaser 会自动过滤无效的 OS/架构组合，故仅新增 Linux 一个目标。本地 `GOOS=linux GOARCH=loong64 CGO_ENABLED=0 go build ./...` 验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)