### PR TITLE
fix: add linux/loong64 to CNB goreleaser config

### DIFF
--- a/.ide/.goreleaser.yml
+++ b/.ide/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - arm
       - arm64
       - ppc64
+      - loong64
     goarm:
       - "7"
     ignore:


### PR DESCRIPTION
#43 只改了根目录 `.goreleaser.yml`，CNB 的 tag_push 流水线用的是 `.ide/.goreleaser.yml`，漏改导致 CNB 侧 v1.1.0 附件缺 loong64 包。补上同一行。

注意：本修复合并后只对**下一个 tag** 生效；CNB 侧 v1.1.0 的附件如需补全，需要在 CNB 重跑 v1.1.0 的 tag_push 流水线。

🤖 Generated with [Claude Code](https://claude.com/claude-code)