### PR TITLE
feat: OpenAPI security reflects runtime auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `/openapi.json` now reflects the running instance's authentication mode:
+  when `auth.keys` is configured, the anonymous alternative is dropped from
+  the document's `security` requirements, so a generated client knows a
+  credential is required rather than merely possible. Open instances serve
+  the document unchanged; its `Cache-Control` also switches to `private`
+  when authentication is enabled, matching the query endpoints.
+
 ### Fixed
 - A deduplicated upstream query whose waiters all disconnect now holds exactly
   one concurrency slot, no matter how many waiters canceled. Previously every

--- a/internal/handlers/openapi.go
+++ b/internal/handlers/openapi.go
@@ -2,26 +2,87 @@ package handlers
 
 import (
 	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
+	"sync"
 
+	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/utils"
 )
 
 //go:embed openapi.json
 var openAPISpec []byte
 
-// openAPIETag is computed once: the spec is embedded and immutable.
-var openAPIETag = utils.ETagFor(openAPISpec)
+// servedOpenAPI returns the spec bytes and ETag this instance serves. The
+// embedded document declares anonymous, bearer and API-key access as
+// alternatives (auth is a deployment choice unknown at build time); when this
+// instance enforces authentication, the anonymous alternative is dropped so a
+// generated client knows a credential is required rather than merely
+// possible. Computed once on first use: configuration is loaded before the
+// server accepts requests and cannot change at runtime.
+var servedOpenAPI = sync.OnceValues(func() ([]byte, string) {
+	spec := openAPISpec
+	if len(config.AuthClients) > 0 {
+		patched, err := withoutAnonymousSecurity(spec)
+		if err != nil {
+			// Serve the embedded document rather than breaking the endpoint.
+			slog.Warn("could not drop anonymous security from OpenAPI spec", "err", err)
+		} else {
+			spec = patched
+		}
+	}
+	return spec, utils.ETagFor(spec)
+})
 
-// HandleOpenAPI serves the embedded OpenAPI 3.1 description of this service,
-// honouring If-None-Match revalidation.
+// withoutAnonymousSecurity removes the empty (anonymous) requirement from the
+// document's top-level security array. Only the top level is re-marshaled;
+// every other member keeps its embedded bytes.
+func withoutAnonymousSecurity(spec []byte) ([]byte, error) {
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(spec, &doc); err != nil {
+		return nil, err
+	}
+	rawSecurity, ok := doc["security"]
+	if !ok {
+		return nil, fmt.Errorf("spec has no top-level security member")
+	}
+	var security []map[string]json.RawMessage
+	if err := json.Unmarshal(rawSecurity, &security); err != nil {
+		return nil, err
+	}
+	filtered := security[:0]
+	for _, alternative := range security {
+		if len(alternative) > 0 {
+			filtered = append(filtered, alternative)
+		}
+	}
+	if len(filtered) == len(security) {
+		return nil, fmt.Errorf("spec declares no anonymous security alternative")
+	}
+	patchedSecurity, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, err
+	}
+	doc["security"] = patchedSecurity
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+// HandleOpenAPI serves the OpenAPI 3.1 description of this service, honouring
+// If-None-Match revalidation.
 func HandleOpenAPI(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("ETag", openAPIETag)
-	w.Header().Set("Cache-Control", "public, max-age=86400")
-	if utils.ETagMatches(r.Header.Get("If-None-Match"), openAPIETag) {
+	spec, etag := servedOpenAPI()
+	w.Header().Set("ETag", etag)
+	scope := "public"
+	if len(config.AuthClients) > 0 {
+		scope = "private"
+	}
+	w.Header().Set("Cache-Control", scope+", max-age=86400")
+	if utils.ETagMatches(r.Header.Get("If-None-Match"), etag) {
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write(openAPISpec)
+	_, _ = w.Write(spec)
 }

--- a/internal/handlers/openapi_test.go
+++ b/internal/handlers/openapi_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestWithoutAnonymousSecurity verifies that patching the embedded spec drops
+// exactly the anonymous alternative from the top-level security array and
+// leaves the rest of the document intact.
+func TestWithoutAnonymousSecurity(t *testing.T) {
+	patched, err := withoutAnonymousSecurity(openAPISpec)
+	if err != nil {
+		t.Fatalf("withoutAnonymousSecurity(embedded spec) error: %v", err)
+	}
+
+	var doc struct {
+		OpenAPI  string                       `json:"openapi"`
+		Security []map[string]json.RawMessage `json:"security"`
+		Paths    map[string]json.RawMessage   `json:"paths"`
+	}
+	if err := json.Unmarshal(patched, &doc); err != nil {
+		t.Fatalf("patched spec is not valid JSON: %v", err)
+	}
+
+	if len(doc.Security) == 0 {
+		t.Fatal("patched spec has no security requirements left")
+	}
+	for i, alternative := range doc.Security {
+		if len(alternative) == 0 {
+			t.Errorf("security[%d] is still the anonymous alternative", i)
+		}
+	}
+	names := make(map[string]bool)
+	for _, alternative := range doc.Security {
+		for name := range alternative {
+			names[name] = true
+		}
+	}
+	if !names["bearerAuth"] || !names["apiKeyHeader"] {
+		t.Errorf("patched security lost a scheme: got %v, want bearerAuth and apiKeyHeader", names)
+	}
+
+	var orig struct {
+		OpenAPI string                     `json:"openapi"`
+		Paths   map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(openAPISpec, &orig); err != nil {
+		t.Fatalf("embedded spec is not valid JSON: %v", err)
+	}
+	if doc.OpenAPI != orig.OpenAPI {
+		t.Errorf("openapi version changed: %q -> %q", orig.OpenAPI, doc.OpenAPI)
+	}
+	if len(doc.Paths) != len(orig.Paths) {
+		t.Errorf("paths changed: %d -> %d entries", len(orig.Paths), len(doc.Paths))
+	}
+
+	// A spec with no anonymous alternative must be reported, not silently
+	// left as-is: the guard exists so a future edit to openapi.json that
+	// removes the anonymous entry (or renames security) fails loudly.
+	if _, err := withoutAnonymousSecurity(patched); err == nil {
+		t.Error("patching a spec without an anonymous alternative should error")
+	}
+}


### PR DESCRIPTION
外部审计第 4 条：`security: [{}, bearerAuth, apiKeyHeader]` 三选一让生成的客户端看得到认证定义、但判断不了当前实例是否强制认证。

现在 `/openapi.json` 按运行时鉴权状态动态化：配置了 `auth.keys` 的实例在首次请求时把顶层 security 里的匿名项 `{}` 去掉（config 运行期不可变，`sync.OnceValues` 算一次并缓存 ETag）；未开鉴权的实例原样输出嵌入文档。只重排顶层成员，其余字节原样保留；patch 失败则日志告警并回退嵌入文档，端点不会因此坏掉。

顺手对齐 #42：鉴权实例下该端点的 `Cache-Control` 从硬编码 `public` 改为 `private`，与查询端点一致。

测试：对嵌入文档 patch 后断言匿名项消失、两个 scheme 保留、paths/版本不变；对无匿名项的文档再 patch 必须报错（防未来改 openapi.json 时静默失效）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)