### PR TITLE
docs: correct bootstrap last-known-good staleness wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,8 +99,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the server's write timeout. MCP clients following the Streamable HTTP
   specification are unaffected.
 - When an IANA RDAP bootstrap category fails to refresh, it now keeps serving its
-  most recent successful fetch (at most one refresh interval stale) instead of
-  reverting to the compiled-in baseline from build time. A partial refresh (some
+  most recent successful fetch instead of reverting to the compiled-in baseline
+  from build time (under consecutive failures that data can be several refresh
+  intervals stale; every failed round is logged and counted). A partial refresh (some
   categories fetched, others failed) is logged as a partial update and recorded as
   `whois_bootstrap_refresh_total{result="partial"}` rather than `success`, and
   `whois_bootstrap_last_fetch_timestamp_seconds` is only advanced on a full

--- a/internal/serverlist/bootstrap.go
+++ b/internal/serverlist/bootstrap.go
@@ -119,8 +119,10 @@ func FetchIANA(ctx context.Context, client *http.Client) (perCategory map[string
 // commitBootstrap folds one round of per-category fetch results into
 // lastGood and rebuilds the active index from every category's last-known-good
 // data, so a category whose refresh failed keeps serving its most recent
-// successful fetch (at most one interval stale) instead of reverting to the
-// compiled baseline. It returns the outcome label for the refresh metric —
+// successful fetch instead of reverting to the compiled baseline. With
+// consecutive failures that data can be several intervals stale — staleness
+// is unbounded, traded for availability; each failed round is visible in the
+// logs and the refresh metric. It returns the outcome label for the metric —
 // "failure" (nothing fetched, index untouched), "partial" or "success" —
 // and the number of entries committed.
 func commitBootstrap(lastGood, perCategory map[string]map[string]string, failed []string) (outcome string, entries int) {


### PR DESCRIPTION
外部审计第 5 条：`commitBootstrap` 注释和 v1.1.0 CHANGELOG 里最多陈旧一个刷新周期的说法只在单次失败时成立，连续失败时陈旧无上界。两处改为如实描述取舍（可用性优先、陈旧无上界、每轮失败有日志和 `whois_bootstrap_refresh_total` 计数可观测）。纯注释/文档，无行为变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)