### PR TITLE
feat: reposition as self-hosted WHOIS/RDAP API + MCP server, memory-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `memory` backend. Previously an empty address made the client dial the
   implicit `localhost:6379` and fall back on failure. `cache.requireRedis: true`
   combined with an empty `redis.addr` is now rejected at startup as
-  contradictory.
+  contradictory. `WHOIS_REDIS_ADDR` distinguishes unset (keep the config-file
+  value) from explicitly empty (disable Redis), so container deployments can
+  opt into memory-only mode without mounting a config file.
 
 ### Changed
 - `/openapi.json` now reflects the running instance's authentication mode:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Memory-only mode: leaving `redis.addr` empty now disables Redis outright — no
+  client is created, no connection attempts are made, and `/health` reports the
+  `memory` backend. Previously an empty address made the client dial the
+  implicit `localhost:6379` and fall back on failure. `cache.requireRedis: true`
+  combined with an empty `redis.addr` is now rejected at startup as
+  contradictory.
+
 ### Changed
 - `/openapi.json` now reflects the running instance's authentication mode:
   when `auth.keys` is configured, the anonymous alternative is dropped from

--- a/README.md
+++ b/README.md
@@ -2,9 +2,27 @@
 
 [English](README_EN.md)
 
-## 介绍
-基于 Golang 实现的域名 Whois 查询工具，支持所有允许公开查询的 TLD 后缀的域名、IPv4/v6、ASN 的 Whois 信息查询。
-根据 ICANN 《通用顶级域名注册数据临时政策细则（Temporary Specification for gTLD Registration Data）》和欧盟《通用数据保护条例》合规要求，在查询域名信息时，程序只返回了部分必要的信息（详见下方返回结果示例），不会返回所有者的`联系方式`、`地址`、`电话`、`邮箱`等字段。
+# whois
+
+**可自托管的 WHOIS/RDAP API 与 MCP 服务：统一查询域名、IPv4/v6、CIDR 前缀和 ASN，返回一致的 JSON。**
+
+```bash
+docker run -d --name whois -p 8043:8043 jinzeyang/whois
+```
+
+用演示站直接试一试：
+
+```bash
+curl https://whois.ddnsip.cn/example.com   # 域名
+curl https://whois.ddnsip.cn/8.8.8.8       # IP（也支持 CIDR，如 1.0.0.0/24）
+curl https://whois.ddnsip.cn/AS13335       # ASN
+```
+
+- **域名 / IP / CIDR / ASN 统一入口**：RDAP 优先、传统 WHOIS 兜底，字段统一为 RDAP（RFC 9083）风格
+- **REST API + OpenAPI 3.1 + MCP**：AI 助手可通过 `/mcp` 端点直接调用 WHOIS 查询（[接入方法](docs/mcp.md)）
+- **开箱即用**：单二进制 / 单容器，无需第三方 API Key；默认内存缓存，生产可选 Redis
+- **面向生产**：API Key 认证、按 key 限流、批量查询、Prometheus 指标、ETag / 缓存头、健康检查端点
+- **合规**：遵循 ICANN《gTLD 注册数据临时政策细则》与 GDPR，域名结果不返回联系人、地址、电话、邮箱等隐私字段
 
 演示站点：
 - [https://whois.ddnsip.cn](https://whois.ddnsip.cn)
@@ -13,12 +31,17 @@
 ## 使用方法
 ### Docker部署
 ```bash
-# 安装 Redis
+# 一行启动（内存缓存，适合体验和单实例部署）
+docker run -d --name whois -p 8043:8043 jinzeyang/whois
+# 大陆推荐镜像源
+docker run -d --name whois -p 8043:8043 docker.cnb.cool/kincaidyang/whois
+```
+
+生产环境或多实例部署建议接入 Redis（缓存持久化、多实例共享）：
+
+```bash
 docker run -d --name redis -p 6379:6379 redis:latest
-# 运行 whois
 docker run -d --name whois -p 8043:8043 --link redis:redis jinzeyang/whois
-# 运行 whois（大陆推荐）
-docker run -d --name whois -p 8043:8043 --link redis:redis docker.cnb.cool/kincaidyang/whois
 ```
 
 ### 下载
@@ -30,8 +53,6 @@ git clone https://github.com/KincaidYang/whois.git
 cd whois
 go build
 ```
-### 安装依赖
-本程序需要 Redis 服务支持，您可参照 https://redis.io/docs/install/install-redis/install-redis-on-linux/ 进行安装。
 
 ### 编辑配置文件
 ```bash
@@ -55,7 +76,7 @@ cache:
   memoryCleanInterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
 
 redis:
-  addr: "redis:6379"           # Redis服务器地址
+  addr: "redis:6379"           # Redis服务器地址；留空则完全不使用 Redis，仅用内存缓存（单实例部署足够）
   password: ""                 # Redis密码，如无密码则留空
   db: 0                        # Redis数据库编号
   tls: false                   # 通过不可信网络连接 Redis 时建议开启 TLS
@@ -101,7 +122,7 @@ mcp:
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` 时 Redis 不可用则启动失败 |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | 内存缓存最大条目数 |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | 内存缓存清理间隔（秒） |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | 空 | Redis 地址；不可用时自动降级到内存缓存（除非开启 requireRedis） |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | 空 | Redis 地址；留空则不使用 Redis（纯内存缓存），配置后连接失败时自动降级到内存缓存（除非开启 requireRedis） |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | 空 | Redis 密码 |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis 数据库编号 |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` 启用 Redis TLS |
@@ -129,7 +150,7 @@ docker run -d --name whois -p 8043:8043 \
 ```
 
 **配置说明：**
-- **Redis配置**：建议使用Redis以获得更好的性能和多实例缓存共享能力
+- **Redis配置**：可选。留空 `redis.addr` 则以纯内存缓存运行；生产环境或多实例部署建议接入 Redis，以获得缓存持久化和多实例共享能力
 - **缓存过期时间**：根据查询频率调整，建议3600秒
 - **内存缓存**：Redis 不可用时的兜底，达到上限后按 LRU（最近最少使用）淘汰
 - **负向缓存**：将“未找到/被拒”的查询结果短时间缓存，避免对不存在的资源反复请求上游；默认 60 秒
@@ -445,6 +466,8 @@ curl http://localhost:8043/205794
 
 **MCP 服务器地址：** `http://ip:端口/mcp`
 
+Claude Code / Claude Desktop / Cursor 等客户端的具体接入配置、认证方式见 [docs/mcp.md](docs/mcp.md)。
+
 ## 版本与稳定性
 
 自 v1.0.0 起，本项目遵循[语义化版本](https://semver.org/lang/zh-CN/)。以下面向用户的契约在 1.x 内保持稳定，不兼容变更只会出现在下一个主版本（2.0.0）：
@@ -460,40 +483,8 @@ curl http://localhost:8043/205794
 ## 已知问题
 程序向注册局查询 Whois 信息主要依靠 RDAP 协议查询，但由于大部分 ccTLD 不支持 RDAP 协议，程序会对其原始的 Whois 信息格式化后返回 JSON 数据。由于本人精力有限，未对所有的 ccTLD 后缀进行适配，未适配的后缀会返回 `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`，如您常用的后缀没有被覆盖，可以提交 Issue 或者贡献匹配规则至 `internal/whois/whois_parsers.go` 文件中，在此表示感谢！
 
-## 项目依赖
+## 致谢与数据来源
 
-本项目使用了以下Go标准库：
+本项目使用了 [go-redis](https://github.com/redis/go-redis)、[prometheus/client_golang](https://github.com/prometheus/client_golang)、[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk)、[golang.org/x/net](https://pkg.go.dev/golang.org/x/net)（idna、publicsuffix）和 [yaml.v3](https://gopkg.in/yaml.v3)。
 
-- [`bytes`](https://golang.org/pkg/bytes/)：操作字节切片的函数。
-- [`context`](https://golang.org/pkg/context/)：定义了Context类型，用于在API边界和进程之间传递截止日期、取消信号和其他请求范围的值。
-- [`encoding/json`](https://golang.org/pkg/encoding/json/)：编码和解码JSON对象的函数。
-- [`errors`](https://golang.org/pkg/errors/)：创建错误和操作错误的函数。
-- [`fmt`](https://golang.org/pkg/fmt/)：格式化I/O函数。
-- [`io`](https://golang.org/pkg/io/)：I/O原语函数。
-- [`log/slog`](https://golang.org/pkg/log/slog/)：结构化日志服务。
-- [`net`](https://golang.org/pkg/net/)：网络I/O原语的函数。
-- [`net/http`](https://golang.org/pkg/net/http/)：HTTP客户端和服务器实现。
-- [`os`](https://golang.org/pkg/os/)：操作系统功能的函数。
-- [`os/signal`](https://golang.org/pkg/os/signal/)：接收操作系统信号的函数。
-- [`regexp`](https://golang.org/pkg/regexp/)：正则表达式搜索。
-- [`strconv`](https://golang.org/pkg/strconv/)：将字符串转换为基本类型的函数。
-- [`strings`](https://golang.org/pkg/strings/)：操作字符串的函数。
-- [`sync`](https://golang.org/pkg/sync/)：基本的同步原语。
-- [`syscall`](https://golang.org/pkg/syscall/)：访问操作系统底层调用的函数。
-- [`time`](https://golang.org/pkg/time/)：测量和显示时间的函数。
-
-本项目还使用了以下第三方库：
-
-- [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis)：Go语言Redis客户端。
-- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang)：Prometheus 指标采集与暴露。
-- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk)：MCP（Model Context Protocol）Go SDK。
-- [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna)：实现了IDNA（国际化域名在应用程序）规范。
-- [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix)：实现了公共后缀列表规范。
-- [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3)：YAML 解析库。
-
-WHOIS/RDAP 服务器列表来自于：
-- [IANA](https://www.iana.org/domains/root/db)
-- [IANA RDAP Bootstrap](https://data.iana.org/rdap/)
-- [IANA RDAP Bootstrap (IPv4)](https://data.iana.org/rdap/ipv4.json)
-- [IANA RDAP Bootstrap (IPv6)](https://data.iana.org/rdap/ipv6.json)
-- [IANA RDAP Bootstrap (AS)](https://data.iana.org/rdap/asn.json)
+WHOIS/RDAP 服务器列表来自 [IANA 根域数据库](https://www.iana.org/domains/root/db)与 [IANA RDAP Bootstrap](https://data.iana.org/rdap/)（域名、IPv4/v6、ASN）。

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ mcp:
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` 时 Redis 不可用则启动失败 |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | 内存缓存最大条目数 |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | 内存缓存清理间隔（秒） |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | 空 | Redis 地址；留空则不使用 Redis（纯内存缓存），配置后连接失败时自动降级到内存缓存（除非开启 requireRedis） |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | 未设置 | Redis 地址；未设置时沿用配置文件，**显式设为空**（`WHOIS_REDIS_ADDR=`）则禁用 Redis（纯内存缓存）；配置后连接失败时自动降级到内存缓存（除非开启 requireRedis） |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | 空 | Redis 密码 |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis 数据库编号 |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` 启用 Redis TLS |

--- a/README_EN.md
+++ b/README_EN.md
@@ -128,7 +128,7 @@ Every configuration option can be overridden via environment variables (which ta
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` makes startup fail when Redis is unavailable |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | Max entries in the in-memory cache |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | In-memory cache cleanup interval in seconds |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | empty | Redis address; empty disables Redis (memory-only cache), when set the service falls back to the in-memory cache if Redis is unreachable (unless requireRedis) |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | unset | Redis address; unset keeps the config-file value, **explicitly empty** (`WHOIS_REDIS_ADDR=`) disables Redis (memory-only cache); when set, the service falls back to the in-memory cache if Redis is unreachable (unless requireRedis) |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | empty | Redis password |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis database number |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` enables TLS for Redis |

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,11 +2,27 @@
 
 [中文文档](README.md)
 
-## Introduction
+# whois
 
-A domain WHOIS query tool implemented in Golang, supporting WHOIS information queries for all publicly queryable TLD domains, IPv4/v6, and ASN.
+**A self-hosted WHOIS/RDAP API and MCP server for domains, IPv4/v6, CIDR prefixes and ASNs — one endpoint, consistent JSON.**
 
-In compliance with ICANN's "Temporary Specification for gTLD Registration Data" and the EU's "General Data Protection Regulation" (GDPR), when querying domain information, the program only returns essential information (see response examples below) and does not return the owner's `contact information`, `address`, `phone number`, `email`, and other personal fields.
+```bash
+docker run -d --name whois -p 8043:8043 jinzeyang/whois
+```
+
+Try it against the demo instance:
+
+```bash
+curl https://whois.ddnsip.cn/example.com   # domain
+curl https://whois.ddnsip.cn/8.8.8.8       # IP (CIDR prefixes work too, e.g. 1.0.0.0/24)
+curl https://whois.ddnsip.cn/AS13335       # ASN
+```
+
+- **One endpoint for domains / IPs / CIDRs / ASNs**: RDAP first with classic WHOIS fallback, normalized to RDAP-style (RFC 9083) JSON
+- **REST API + OpenAPI 3.1 + MCP**: AI assistants can call WHOIS lookups directly through the `/mcp` endpoint ([client setup](docs/mcp.md))
+- **Zero-dependency start**: a single binary / container, no third-party API keys; in-memory cache by default, Redis optional for production
+- **Production-ready**: API key auth, per-key rate limits, batch queries, Prometheus metrics, ETag / cache headers, health probes
+- **Compliant**: follows ICANN's Temporary Specification for gTLD Registration Data and the GDPR — domain responses omit the owner's contact information, address, phone number and email
 
 Demo Sites:
 - [https://whois.ddnsip.cn](https://whois.ddnsip.cn)
@@ -17,9 +33,14 @@ Demo Sites:
 ### Docker Deployment
 
 ```bash
-# Install Redis
+# One-line start (in-memory cache; fine for trying it out and single-instance deployments)
+docker run -d --name whois -p 8043:8043 jinzeyang/whois
+```
+
+For production or multi-instance deployments, add Redis (persistent cache, shared across instances):
+
+```bash
 docker run -d --name redis -p 6379:6379 redis:latest
-# Run whois
 docker run -d --name whois -p 8043:8043 --link redis:redis jinzeyang/whois
 ```
 
@@ -36,10 +57,6 @@ git clone https://github.com/KincaidYang/whois.git
 cd whois
 go build
 ```
-
-### Install Dependencies
-
-This program requires Redis service support. You can refer to https://redis.io/docs/install/install-redis/install-redis-on-linux/ for installation.
 
 ### Edit Configuration File
 
@@ -65,7 +82,7 @@ cache:
   memoryCleanInterval: 300     # Memory cache cleanup interval in seconds (default: 300)
 
 redis:
-  addr: "redis:6379"           # Redis server address
+  addr: "redis:6379"           # Redis server address; leave empty to run without Redis on the in-memory cache alone (enough for single instances)
   password: ""                 # Redis password, leave empty if none
   db: 0                        # Redis database number
   tls: false                   # Enable TLS when Redis is reached over an untrusted network
@@ -111,7 +128,7 @@ Every configuration option can be overridden via environment variables (which ta
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` makes startup fail when Redis is unavailable |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | Max entries in the in-memory cache |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | In-memory cache cleanup interval in seconds |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | empty | Redis address; the service falls back to the in-memory cache when unreachable (unless requireRedis) |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | empty | Redis address; empty disables Redis (memory-only cache), when set the service falls back to the in-memory cache if Redis is unreachable (unless requireRedis) |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | empty | Redis password |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis database number |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` enables TLS for Redis |
@@ -139,7 +156,7 @@ docker run -d --name whois -p 8043:8043 \
 ```
 
 **Configuration Notes:**
-- **Redis Configuration**: Redis is recommended for better performance and multi-instance cache sharing
+- **Redis Configuration**: Optional. An empty `redis.addr` runs the service on the in-memory cache alone; Redis is recommended for production and multi-instance deployments (persistent, shared cache)
 - **Cache Expiration**: Adjust based on query frequency, 3600 seconds recommended
 - **Memory Cache**: Fallback when Redis is unavailable; evicts least-recently-used (LRU) entries once full
 - **Negative Cache**: Briefly caches "not found / denied" results to avoid repeatedly hitting upstream for missing resources; defaults to 60 seconds
@@ -438,6 +455,8 @@ Returns per-query results, matching the behavior of `POST /batch` (subject to th
 
 **MCP server URL:** `http://ip:port/mcp`
 
+See [docs/mcp.md](docs/mcp.md) for client setup (Claude Code, Claude Desktop, Cursor, …) and authentication.
+
 ## Versioning & Stability
 
 From v1.0.0 on, this project follows [Semantic Versioning](https://semver.org/). The following user-facing contract is stable within the 1.x line and may only change incompatibly in the next major release (2.0.0):
@@ -454,43 +473,11 @@ The 0.x breaking-change period is over; see the [CHANGELOG](CHANGELOG.md) for th
 
 The program queries WHOIS information from registries primarily using the RDAP protocol. However, since most ccTLDs do not support RDAP, the program will format and return the original WHOIS information as JSON data. Due to limited resources, not all ccTLD suffixes have been adapted; unadapted suffixes return `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`. If your commonly used suffix is not covered, please submit an Issue or contribute matching rules to `internal/whois/whois_parsers.go`. Thank you!
 
-## Dependencies
+## Acknowledgements & Data Sources
 
-This project uses the following Go standard libraries:
+This project uses [go-redis](https://github.com/redis/go-redis), [prometheus/client_golang](https://github.com/prometheus/client_golang), the [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk), [golang.org/x/net](https://pkg.go.dev/golang.org/x/net) (idna, publicsuffix) and [yaml.v3](https://gopkg.in/yaml.v3).
 
-- [`bytes`](https://golang.org/pkg/bytes/): Functions for byte slice operations
-- [`context`](https://golang.org/pkg/context/): Context type for passing deadlines, cancellation signals, and request-scoped values
-- [`encoding/json`](https://golang.org/pkg/encoding/json/): JSON encoding and decoding
-- [`errors`](https://golang.org/pkg/errors/): Error creation and manipulation
-- [`fmt`](https://golang.org/pkg/fmt/): Formatted I/O functions
-- [`io`](https://golang.org/pkg/io/): I/O primitives
-- [`log/slog`](https://golang.org/pkg/log/slog/): Structured logging
-- [`net`](https://golang.org/pkg/net/): Network I/O primitives
-- [`net/http`](https://golang.org/pkg/net/http/): HTTP client and server implementation
-- [`os`](https://golang.org/pkg/os/): OS functionality
-- [`os/signal`](https://golang.org/pkg/os/signal/): OS signal handling
-- [`regexp`](https://golang.org/pkg/regexp/): Regular expression search
-- [`strconv`](https://golang.org/pkg/strconv/): String conversion functions
-- [`strings`](https://golang.org/pkg/strings/): String manipulation functions
-- [`sync`](https://golang.org/pkg/sync/): Basic synchronization primitives
-- [`syscall`](https://golang.org/pkg/syscall/): Low-level OS calls
-- [`time`](https://golang.org/pkg/time/): Time measurement and display
-
-This project also uses the following third-party libraries:
-
-- [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis): Redis client for Go
-- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang): Prometheus metrics instrumentation and exposition
-- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk): MCP (Model Context Protocol) Go SDK
-- [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna): IDNA (Internationalized Domain Names in Applications) implementation
-- [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix): Public Suffix List implementation
-- [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3): YAML parsing library
-
-WHOIS/RDAP server lists are sourced from:
-- [IANA](https://www.iana.org/domains/root/db)
-- [IANA RDAP Bootstrap](https://data.iana.org/rdap/)
-- [IANA RDAP Bootstrap (IPv4)](https://data.iana.org/rdap/ipv4.json)
-- [IANA RDAP Bootstrap (IPv6)](https://data.iana.org/rdap/ipv6.json)
-- [IANA RDAP Bootstrap (AS)](https://data.iana.org/rdap/asn.json)
+WHOIS/RDAP server lists are sourced from the [IANA root zone database](https://www.iana.org/domains/root/db) and the [IANA RDAP Bootstrap registries](https://data.iana.org/rdap/) (domains, IPv4/v6, ASN).
 
 ## License
 

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -13,9 +13,9 @@ cache:
   memoryCleanInterval: 300
 
 redis:
-  # Redis server address; override with WHOIS_REDIS_ADDR. When no Redis is
-  # reachable the service falls back to the in-memory cache. Leave empty to
-  # run without Redis entirely (no connection attempts).
+  # Redis server address; override with WHOIS_REDIS_ADDR (set it to an empty
+  # value to disable Redis entirely and run memory-only). When no Redis is
+  # reachable the service falls back to the in-memory cache.
   addr: "redis:6379"
   password: ""
   db: 0

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -13,6 +13,9 @@ cache:
   memoryCleanInterval: 300
 
 redis:
+  # Redis server address; override with WHOIS_REDIS_ADDR. When no Redis is
+  # reachable the service falls back to the in-memory cache. Leave empty to
+  # run without Redis entirely (no connection attempts).
   addr: "redis:6379"
   password: ""
   db: 0

--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,8 @@ cache:
   memoryCleanInterval: 300
 
 redis:
+  # Redis server address. Leave empty to run without Redis entirely, on the
+  # in-memory cache alone (fine for single-instance deployments).
   addr: "127.0.0.1:6379"
   password: ""
   db: 0

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,106 @@
+# MCP Integration
+
+The service exposes a [Model Context Protocol](https://modelcontextprotocol.io)
+endpoint at `/mcp` (Streamable HTTP transport, stateless, plain JSON
+responses), so AI assistants can run WHOIS/RDAP lookups as a tool — no
+separate MCP server process is needed; every deployment of this service is
+already one.
+
+```text
+https://your-instance/mcp
+```
+
+You can try it against the public demo instance: `https://whois.ddnsip.cn/mcp`.
+
+## Tools
+
+### `whois_lookup`
+
+```json
+{ "query": "example.com" }
+```
+
+`query` accepts a domain name (IDN/Unicode names work), an IPv4/v6 address or
+CIDR prefix, or an ASN (`AS13335`). The result is the same RDAP-style JSON the
+REST API returns.
+
+### `whois_batch_lookup`
+
+```json
+{ "queries": ["example.com", "8.8.8.8", "AS15169"] }
+```
+
+The MCP face of `POST /batch`: disabled unless the operator sets
+`batch.enabled: true`, capped at `batch.maxItems` queries per call, and
+charged against per-key rate limits at one request per query.
+
+## Client setup
+
+### Claude Code
+
+```bash
+claude mcp add --transport http whois https://whois.ddnsip.cn/mcp
+```
+
+### Claude Desktop / claude.ai
+
+Settings → Connectors → **Add custom connector**, then enter the `/mcp` URL.
+
+### Cursor
+
+`.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
+
+```json
+{
+  "mcpServers": {
+    "whois": {
+      "url": "https://whois.ddnsip.cn/mcp"
+    }
+  }
+}
+```
+
+### Other clients
+
+Any client that speaks MCP over Streamable HTTP works the same way: point it
+at the `/mcp` URL. There is no SSE requirement — tool calls are answered with
+plain `application/json`.
+
+## Authentication
+
+When the instance has API key authentication enabled (`auth.keys` in the
+config), `/mcp` requires a key like every other endpoint. Send it as an HTTP
+header — either `Authorization: Bearer <key>` or `X-API-Key: <key>`:
+
+```bash
+claude mcp add --transport http whois https://your-instance/mcp \
+  --header "X-API-Key: your-secret-key"
+```
+
+```json
+{
+  "mcpServers": {
+    "whois": {
+      "url": "https://your-instance/mcp",
+      "headers": { "X-API-Key": "your-secret-key" }
+    }
+  }
+}
+```
+
+## Example
+
+> **User:** When does example.com expire, and is DNSSEC enabled?
+>
+> **Assistant:** *calls `whois_lookup` with `{"query": "example.com"}`* —
+> example.com expires on 2026-08-13, and DNSSEC is enabled
+> (`secureDNS.delegationSigned: true`).
+
+## Notes for operators
+
+- `mcp.localhostProtection` enables DNS-rebinding protection: `/mcp` then only
+  accepts requests whose `Host` header is localhost. Keep it `false` behind a
+  reverse proxy (the public hostname would be rejected); set it `true` when
+  the server is reached directly on localhost.
+- MCP calls share the same concurrency limiter, request timeout, cache and
+  rate-limit accounting as plain HTTP queries.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,33 +191,37 @@ func load() {
 		os.Exit(1)
 	}
 
-	// Initialize the Redis client with custom options
-	options := &redis.Options{
-		Addr:            config.Redis.Addr,
-		Password:        config.Redis.Password,
-		DB:              config.Redis.DB,
-		PoolSize:        10,
-		MinIdleConns:    0,
-		MaxRetries:      1,
-		MinRetryBackoff: 8 * time.Millisecond,
-		MaxRetryBackoff: 512 * time.Millisecond,
-		DialTimeout:     2 * time.Second,
-		ReadTimeout:     2 * time.Second,
-		WriteTimeout:    2 * time.Second,
-		PoolTimeout:     2 * time.Second,
-	}
-	if config.Redis.TLS {
-		options.TLSConfig = &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: config.Redis.TLSSkipVerify,
+	// Initialize the Redis client with custom options. An empty redis.addr
+	// means Redis is deliberately not used: no client is created (RedisClient
+	// stays nil) and the service runs on the in-memory cache alone.
+	if config.Redis.Addr != "" {
+		options := &redis.Options{
+			Addr:            config.Redis.Addr,
+			Password:        config.Redis.Password,
+			DB:              config.Redis.DB,
+			PoolSize:        10,
+			MinIdleConns:    0,
+			MaxRetries:      1,
+			MinRetryBackoff: 8 * time.Millisecond,
+			MaxRetryBackoff: 512 * time.Millisecond,
+			DialTimeout:     2 * time.Second,
+			ReadTimeout:     2 * time.Second,
+			WriteTimeout:    2 * time.Second,
+			PoolTimeout:     2 * time.Second,
 		}
+		if config.Redis.TLS {
+			options.TLSConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: config.Redis.TLSSkipVerify,
+			}
+		}
+
+		RedisClient = redis.NewClient(options)
+
+		// Suppress Redis client's internal error logging by setting a discard logger
+		// The client will still work, but won't spam logs on connection failures
+		redis.SetLogger(&discardLogger{})
 	}
-
-	RedisClient = redis.NewClient(options)
-
-	// Suppress Redis client's internal error logging by setting a discard logger
-	// The client will still work, but won't spam logs on connection failures
-	redis.SetLogger(&discardLogger{})
 
 	// Set the cache expiration time
 	CacheExpiration = time.Duration(config.Cache.Expiration) * time.Second
@@ -403,6 +407,9 @@ func validateConfig(config *Config) error {
 			return fmt.Errorf("proxy.server: %w", err)
 		}
 	}
+	if config.Cache.RequireRedis && config.Redis.Addr == "" {
+		return fmt.Errorf("cache.requireRedis is true but redis.addr is empty (Redis disabled); set redis.addr or turn requireRedis off")
+	}
 	return nil
 }
 
@@ -433,15 +440,20 @@ func validateProxyURL(s string) error {
 	return nil
 }
 
-// initializeCacheManager sets up the cache with Redis primary and memory fallback
+// initializeCacheManager sets up the cache: Redis primary with memory fallback,
+// or memory alone when Redis is disabled (empty redis.addr).
 func initializeCacheManager() {
-	// Create Redis cache
-	redisCache := utils.NewRedisCache(RedisClient)
-
-	// Create memory cache as fallback
 	memoryCache := utils.NewMemoryCache(MemoryMaxSize, MemoryCleanInterval)
 
+	if RedisClient == nil {
+		CacheManager = memoryCache
+		slog.Info("Redis disabled (empty redis.addr), using in-memory cache only")
+		slog.Info("cache configuration", "memory_max_entries", MemoryMaxSize, "clean_interval", MemoryCleanInterval)
+		return
+	}
+
 	// Create fallback cache that tries Redis first, then memory
+	redisCache := utils.NewRedisCache(RedisClient)
 	CacheManager = utils.NewFallbackCache(redisCache, memoryCache)
 
 	// Log cache configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -613,8 +613,11 @@ func parseBoolEnv(name, val string, current bool) bool {
 }
 
 func overrideConfigWithEnv(config *Config) {
-	// Override Redis configuration
-	if redisAddr := os.Getenv("WHOIS_REDIS_ADDR"); redisAddr != "" {
+	// Override Redis configuration. WHOIS_REDIS_ADDR distinguishes "set to
+	// empty" from "unset": an explicitly empty value disables Redis (memory-only
+	// mode), which is otherwise unreachable in deployments whose baked-in config
+	// file carries a non-empty address (the shipped Docker image does).
+	if redisAddr, ok := os.LookupEnv("WHOIS_REDIS_ADDR"); ok {
 		config.Redis.Addr = redisAddr
 	}
 	if redisPassword := os.Getenv("WHOIS_REDIS_PASSWORD"); redisPassword != "" {

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -36,7 +36,8 @@ func isRedisHealthy() bool {
 	if fc, ok := config.CacheManager.(*utils.FallbackCache); ok {
 		return fc.IsPrimaryHealthy()
 	}
-	return config.CacheManager.IsHealthy()
+	// Not a Redis-backed manager: memory-only mode (empty redis.addr).
+	return false
 }
 
 // getCacheCheck returns the cache health check result


### PR DESCRIPTION
## 变更内容

### 代码：纯内存模式
- `redis.addr` 留空时完全禁用 Redis：不创建客户端、无连接尝试，`/health` 如实报告 `memory` 后端。此前空地址会隐式连 go-redis 默认的 `localhost:6379` 再降级。
- `cache.requireRedis: true` + 空 `redis.addr` 属矛盾配置，启动时直接报错拒绝。
- Docker 镜像内置默认值不变（`redis:6379`），现有 `--link redis` 部署升级后行为不受影响。

### 文档：重新定位
- README 首屏重写：一句话定位（可自托管的 WHOIS/RDAP API 与 MCP 服务）→ 一行 Docker 启动 → 演示站 curl 示例 → 特性列表。原首屏"本程序需要 Redis 服务支持"与 `requireRedis: false` 默认值矛盾，已修正为"默认内存缓存、生产可选 Redis"。
- 砍掉 17 个 Go 标准库的依赖清单，压缩为致谢与数据来源一节。
- 新增 `docs/mcp.md`：Claude Code / Claude Desktop / Cursor 接入配置、认证方式、运维注意事项；README 的 MCP 一节链接过去。
- README_EN 同步全部改动。

### 验证
- `go build` / `go vet` / `go test ./...` 全绿。
- 真机验证：空 addr 启动日志干净、`/health` 报 `memory`、example.com 查询 MISS→HIT;矛盾配置（含 `WHOIS_REQUIRE_REDIS=1` env 路径）启动即拒;不可达 Redis 的降级回退行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)