### PR TITLE
docs: restore original README voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,9 @@
 
 [English](README_EN.md)
 
-# whois
-
-**可自托管的 WHOIS/RDAP API 与 MCP 服务：统一查询域名、IPv4/v6、CIDR 前缀和 ASN，返回一致的 JSON。**
-
-```bash
-docker run -d --name whois -p 8043:8043 jinzeyang/whois
-```
-
-用演示站直接试一试：
-
-```bash
-curl https://whois.ddnsip.cn/example.com   # 域名
-curl https://whois.ddnsip.cn/8.8.8.8       # IP（也支持 CIDR，如 1.0.0.0/24）
-curl https://whois.ddnsip.cn/AS13335       # ASN
-```
-
-- **域名 / IP / CIDR / ASN 统一入口**：RDAP 优先、传统 WHOIS 兜底，字段统一为 RDAP（RFC 9083）风格
-- **REST API + OpenAPI 3.1 + MCP**：AI 助手可通过 `/mcp` 端点直接调用 WHOIS 查询（[接入方法](docs/mcp.md)）
-- **开箱即用**：单二进制 / 单容器，无需第三方 API Key；默认内存缓存，生产可选 Redis
-- **面向生产**：API Key 认证、按 key 限流、批量查询、Prometheus 指标、ETag / 缓存头、健康检查端点
-- **合规**：遵循 ICANN《gTLD 注册数据临时政策细则》与 GDPR，域名结果不返回联系人、地址、电话、邮箱等隐私字段
+## 介绍
+基于 Golang 实现的域名 Whois 查询工具，支持所有允许公开查询的 TLD 后缀的域名、IPv4/v6、ASN 的 Whois 信息查询。
+根据 ICANN 《通用顶级域名注册数据临时政策细则（Temporary Specification for gTLD Registration Data）》和欧盟《通用数据保护条例》合规要求，在查询域名信息时，程序只返回了部分必要的信息（详见下方返回结果示例），不会返回所有者的`联系方式`、`地址`、`电话`、`邮箱`等字段。
 
 演示站点：
 - [https://whois.ddnsip.cn](https://whois.ddnsip.cn)
@@ -31,17 +13,12 @@ curl https://whois.ddnsip.cn/AS13335       # ASN
 ## 使用方法
 ### Docker部署
 ```bash
-# 一行启动（内存缓存，适合体验和单实例部署）
-docker run -d --name whois -p 8043:8043 jinzeyang/whois
-# 大陆推荐镜像源
-docker run -d --name whois -p 8043:8043 docker.cnb.cool/kincaidyang/whois
-```
-
-生产环境或多实例部署建议接入 Redis（缓存持久化、多实例共享）：
-
-```bash
+# 安装 Redis
 docker run -d --name redis -p 6379:6379 redis:latest
+# 运行 whois
 docker run -d --name whois -p 8043:8043 --link redis:redis jinzeyang/whois
+# 运行 whois（大陆推荐）
+docker run -d --name whois -p 8043:8043 --link redis:redis docker.cnb.cool/kincaidyang/whois
 ```
 
 ### 下载
@@ -53,6 +30,8 @@ git clone https://github.com/KincaidYang/whois.git
 cd whois
 go build
 ```
+### 安装依赖
+本程序默认使用内存缓存，可直接运行；生产环境或多实例部署建议搭配 Redis 使用，您可参照 https://redis.io/docs/install/install-redis/install-redis-on-linux/ 进行安装。
 
 ### 编辑配置文件
 ```bash
@@ -76,7 +55,7 @@ cache:
   memoryCleanInterval: 300     # 内存缓存过期数据清理间隔，单位：秒（默认: 300）
 
 redis:
-  addr: "redis:6379"           # Redis服务器地址；留空则完全不使用 Redis，仅用内存缓存（单实例部署足够）
+  addr: "redis:6379"           # Redis服务器地址
   password: ""                 # Redis密码，如无密码则留空
   db: 0                        # Redis数据库编号
   tls: false                   # 通过不可信网络连接 Redis 时建议开启 TLS
@@ -122,7 +101,7 @@ mcp:
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` 时 Redis 不可用则启动失败 |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | 内存缓存最大条目数 |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | 内存缓存清理间隔（秒） |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | 未设置 | Redis 地址；未设置时沿用配置文件，**显式设为空**（`WHOIS_REDIS_ADDR=`）则禁用 Redis（纯内存缓存）；配置后连接失败时自动降级到内存缓存（除非开启 requireRedis） |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | 未设置 | Redis 地址；显式设为空（`WHOIS_REDIS_ADDR=`）则禁用 Redis 仅用内存缓存，配置后不可用时自动降级到内存缓存（除非开启 requireRedis） |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | 空 | Redis 密码 |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis 数据库编号 |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` 启用 Redis TLS |
@@ -150,7 +129,7 @@ docker run -d --name whois -p 8043:8043 \
 ```
 
 **配置说明：**
-- **Redis配置**：可选。留空 `redis.addr` 则以纯内存缓存运行；生产环境或多实例部署建议接入 Redis，以获得缓存持久化和多实例共享能力
+- **Redis配置**：建议使用Redis以获得更好的性能和多实例缓存共享能力
 - **缓存过期时间**：根据查询频率调整，建议3600秒
 - **内存缓存**：Redis 不可用时的兜底，达到上限后按 LRU（最近最少使用）淘汰
 - **负向缓存**：将“未找到/被拒”的查询结果短时间缓存，避免对不存在的资源反复请求上游；默认 60 秒
@@ -466,7 +445,7 @@ curl http://localhost:8043/205794
 
 **MCP 服务器地址：** `http://ip:端口/mcp`
 
-Claude Code / Claude Desktop / Cursor 等客户端的具体接入配置、认证方式见 [docs/mcp.md](docs/mcp.md)。
+客户端接入配置与认证方式见 [docs/mcp.md](docs/mcp.md)。
 
 ## 版本与稳定性
 
@@ -483,8 +462,40 @@ Claude Code / Claude Desktop / Cursor 等客户端的具体接入配置、认证
 ## 已知问题
 程序向注册局查询 Whois 信息主要依靠 RDAP 协议查询，但由于大部分 ccTLD 不支持 RDAP 协议，程序会对其原始的 Whois 信息格式化后返回 JSON 数据。由于本人精力有限，未对所有的 ccTLD 后缀进行适配，未适配的后缀会返回 `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`，如您常用的后缀没有被覆盖，可以提交 Issue 或者贡献匹配规则至 `internal/whois/whois_parsers.go` 文件中，在此表示感谢！
 
-## 致谢与数据来源
+## 项目依赖
 
-本项目使用了 [go-redis](https://github.com/redis/go-redis)、[prometheus/client_golang](https://github.com/prometheus/client_golang)、[MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk)、[golang.org/x/net](https://pkg.go.dev/golang.org/x/net)（idna、publicsuffix）和 [yaml.v3](https://gopkg.in/yaml.v3)。
+本项目使用了以下Go标准库：
 
-WHOIS/RDAP 服务器列表来自 [IANA 根域数据库](https://www.iana.org/domains/root/db)与 [IANA RDAP Bootstrap](https://data.iana.org/rdap/)（域名、IPv4/v6、ASN）。
+- [`bytes`](https://golang.org/pkg/bytes/)：操作字节切片的函数。
+- [`context`](https://golang.org/pkg/context/)：定义了Context类型，用于在API边界和进程之间传递截止日期、取消信号和其他请求范围的值。
+- [`encoding/json`](https://golang.org/pkg/encoding/json/)：编码和解码JSON对象的函数。
+- [`errors`](https://golang.org/pkg/errors/)：创建错误和操作错误的函数。
+- [`fmt`](https://golang.org/pkg/fmt/)：格式化I/O函数。
+- [`io`](https://golang.org/pkg/io/)：I/O原语函数。
+- [`log/slog`](https://golang.org/pkg/log/slog/)：结构化日志服务。
+- [`net`](https://golang.org/pkg/net/)：网络I/O原语的函数。
+- [`net/http`](https://golang.org/pkg/net/http/)：HTTP客户端和服务器实现。
+- [`os`](https://golang.org/pkg/os/)：操作系统功能的函数。
+- [`os/signal`](https://golang.org/pkg/os/signal/)：接收操作系统信号的函数。
+- [`regexp`](https://golang.org/pkg/regexp/)：正则表达式搜索。
+- [`strconv`](https://golang.org/pkg/strconv/)：将字符串转换为基本类型的函数。
+- [`strings`](https://golang.org/pkg/strings/)：操作字符串的函数。
+- [`sync`](https://golang.org/pkg/sync/)：基本的同步原语。
+- [`syscall`](https://golang.org/pkg/syscall/)：访问操作系统底层调用的函数。
+- [`time`](https://golang.org/pkg/time/)：测量和显示时间的函数。
+
+本项目还使用了以下第三方库：
+
+- [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis)：Go语言Redis客户端。
+- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang)：Prometheus 指标采集与暴露。
+- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk)：MCP（Model Context Protocol）Go SDK。
+- [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna)：实现了IDNA（国际化域名在应用程序）规范。
+- [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix)：实现了公共后缀列表规范。
+- [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3)：YAML 解析库。
+
+WHOIS/RDAP 服务器列表来自于：
+- [IANA](https://www.iana.org/domains/root/db)
+- [IANA RDAP Bootstrap](https://data.iana.org/rdap/)
+- [IANA RDAP Bootstrap (IPv4)](https://data.iana.org/rdap/ipv4.json)
+- [IANA RDAP Bootstrap (IPv6)](https://data.iana.org/rdap/ipv6.json)
+- [IANA RDAP Bootstrap (AS)](https://data.iana.org/rdap/asn.json)

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,27 +2,11 @@
 
 [中文文档](README.md)
 
-# whois
+## Introduction
 
-**A self-hosted WHOIS/RDAP API and MCP server for domains, IPv4/v6, CIDR prefixes and ASNs — one endpoint, consistent JSON.**
+A domain WHOIS query tool implemented in Golang, supporting WHOIS information queries for all publicly queryable TLD domains, IPv4/v6, and ASN.
 
-```bash
-docker run -d --name whois -p 8043:8043 jinzeyang/whois
-```
-
-Try it against the demo instance:
-
-```bash
-curl https://whois.ddnsip.cn/example.com   # domain
-curl https://whois.ddnsip.cn/8.8.8.8       # IP (CIDR prefixes work too, e.g. 1.0.0.0/24)
-curl https://whois.ddnsip.cn/AS13335       # ASN
-```
-
-- **One endpoint for domains / IPs / CIDRs / ASNs**: RDAP first with classic WHOIS fallback, normalized to RDAP-style (RFC 9083) JSON
-- **REST API + OpenAPI 3.1 + MCP**: AI assistants can call WHOIS lookups directly through the `/mcp` endpoint ([client setup](docs/mcp.md))
-- **Zero-dependency start**: a single binary / container, no third-party API keys; in-memory cache by default, Redis optional for production
-- **Production-ready**: API key auth, per-key rate limits, batch queries, Prometheus metrics, ETag / cache headers, health probes
-- **Compliant**: follows ICANN's Temporary Specification for gTLD Registration Data and the GDPR — domain responses omit the owner's contact information, address, phone number and email
+In compliance with ICANN's "Temporary Specification for gTLD Registration Data" and the EU's "General Data Protection Regulation" (GDPR), when querying domain information, the program only returns essential information (see response examples below) and does not return the owner's `contact information`, `address`, `phone number`, `email`, and other personal fields.
 
 Demo Sites:
 - [https://whois.ddnsip.cn](https://whois.ddnsip.cn)
@@ -33,14 +17,9 @@ Demo Sites:
 ### Docker Deployment
 
 ```bash
-# One-line start (in-memory cache; fine for trying it out and single-instance deployments)
-docker run -d --name whois -p 8043:8043 jinzeyang/whois
-```
-
-For production or multi-instance deployments, add Redis (persistent cache, shared across instances):
-
-```bash
+# Install Redis
 docker run -d --name redis -p 6379:6379 redis:latest
+# Run whois
 docker run -d --name whois -p 8043:8043 --link redis:redis jinzeyang/whois
 ```
 
@@ -57,6 +36,10 @@ git clone https://github.com/KincaidYang/whois.git
 cd whois
 go build
 ```
+
+### Install Dependencies
+
+This program runs on its in-memory cache by default, with no extra dependencies; Redis is recommended for production and multi-instance deployments. You can refer to https://redis.io/docs/install/install-redis/install-redis-on-linux/ for installation.
 
 ### Edit Configuration File
 
@@ -82,7 +65,7 @@ cache:
   memoryCleanInterval: 300     # Memory cache cleanup interval in seconds (default: 300)
 
 redis:
-  addr: "redis:6379"           # Redis server address; leave empty to run without Redis on the in-memory cache alone (enough for single instances)
+  addr: "redis:6379"           # Redis server address
   password: ""                 # Redis password, leave empty if none
   db: 0                        # Redis database number
   tls: false                   # Enable TLS when Redis is reached over an untrusted network
@@ -128,7 +111,7 @@ Every configuration option can be overridden via environment variables (which ta
 | `WHOIS_REQUIRE_REDIS` | `cache.requireRedis` | `false` | `true`/`1` makes startup fail when Redis is unavailable |
 | `WHOIS_MEMORY_MAX_SIZE` | `cache.memoryMaxSize` | `10000` | Max entries in the in-memory cache |
 | `WHOIS_MEMORY_CLEAN_INTERVAL` | `cache.memoryCleanInterval` | `300` | In-memory cache cleanup interval in seconds |
-| `WHOIS_REDIS_ADDR` | `redis.addr` | unset | Redis address; unset keeps the config-file value, **explicitly empty** (`WHOIS_REDIS_ADDR=`) disables Redis (memory-only cache); when set, the service falls back to the in-memory cache if Redis is unreachable (unless requireRedis) |
+| `WHOIS_REDIS_ADDR` | `redis.addr` | unset | Redis address; explicitly empty (`WHOIS_REDIS_ADDR=`) disables Redis (memory-only cache), when set the service falls back to the in-memory cache when unreachable (unless requireRedis) |
 | `WHOIS_REDIS_PASSWORD` | `redis.password` | empty | Redis password |
 | `WHOIS_REDIS_DB` | `redis.db` | `0` | Redis database number |
 | `WHOIS_REDIS_TLS` | `redis.tls` | `false` | `true`/`1` enables TLS for Redis |
@@ -156,7 +139,7 @@ docker run -d --name whois -p 8043:8043 \
 ```
 
 **Configuration Notes:**
-- **Redis Configuration**: Optional. An empty `redis.addr` runs the service on the in-memory cache alone; Redis is recommended for production and multi-instance deployments (persistent, shared cache)
+- **Redis Configuration**: Redis is recommended for better performance and multi-instance cache sharing
 - **Cache Expiration**: Adjust based on query frequency, 3600 seconds recommended
 - **Memory Cache**: Fallback when Redis is unavailable; evicts least-recently-used (LRU) entries once full
 - **Negative Cache**: Briefly caches "not found / denied" results to avoid repeatedly hitting upstream for missing resources; defaults to 60 seconds
@@ -455,7 +438,7 @@ Returns per-query results, matching the behavior of `POST /batch` (subject to th
 
 **MCP server URL:** `http://ip:port/mcp`
 
-See [docs/mcp.md](docs/mcp.md) for client setup (Claude Code, Claude Desktop, Cursor, …) and authentication.
+See [docs/mcp.md](docs/mcp.md) for client setup and authentication.
 
 ## Versioning & Stability
 
@@ -473,11 +456,43 @@ The 0.x breaking-change period is over; see the [CHANGELOG](CHANGELOG.md) for th
 
 The program queries WHOIS information from registries primarily using the RDAP protocol. However, since most ccTLDs do not support RDAP, the program will format and return the original WHOIS information as JSON data. Due to limited resources, not all ccTLD suffixes have been adapted; unadapted suffixes return `{"objectClassName": "domain", "unparsed": true, "rawText": "..."}`. If your commonly used suffix is not covered, please submit an Issue or contribute matching rules to `internal/whois/whois_parsers.go`. Thank you!
 
-## Acknowledgements & Data Sources
+## Dependencies
 
-This project uses [go-redis](https://github.com/redis/go-redis), [prometheus/client_golang](https://github.com/prometheus/client_golang), the [MCP Go SDK](https://github.com/modelcontextprotocol/go-sdk), [golang.org/x/net](https://pkg.go.dev/golang.org/x/net) (idna, publicsuffix) and [yaml.v3](https://gopkg.in/yaml.v3).
+This project uses the following Go standard libraries:
 
-WHOIS/RDAP server lists are sourced from the [IANA root zone database](https://www.iana.org/domains/root/db) and the [IANA RDAP Bootstrap registries](https://data.iana.org/rdap/) (domains, IPv4/v6, ASN).
+- [`bytes`](https://golang.org/pkg/bytes/): Functions for byte slice operations
+- [`context`](https://golang.org/pkg/context/): Context type for passing deadlines, cancellation signals, and request-scoped values
+- [`encoding/json`](https://golang.org/pkg/encoding/json/): JSON encoding and decoding
+- [`errors`](https://golang.org/pkg/errors/): Error creation and manipulation
+- [`fmt`](https://golang.org/pkg/fmt/): Formatted I/O functions
+- [`io`](https://golang.org/pkg/io/): I/O primitives
+- [`log/slog`](https://golang.org/pkg/log/slog/): Structured logging
+- [`net`](https://golang.org/pkg/net/): Network I/O primitives
+- [`net/http`](https://golang.org/pkg/net/http/): HTTP client and server implementation
+- [`os`](https://golang.org/pkg/os/): OS functionality
+- [`os/signal`](https://golang.org/pkg/os/signal/): OS signal handling
+- [`regexp`](https://golang.org/pkg/regexp/): Regular expression search
+- [`strconv`](https://golang.org/pkg/strconv/): String conversion functions
+- [`strings`](https://golang.org/pkg/strings/): String manipulation functions
+- [`sync`](https://golang.org/pkg/sync/): Basic synchronization primitives
+- [`syscall`](https://golang.org/pkg/syscall/): Low-level OS calls
+- [`time`](https://golang.org/pkg/time/): Time measurement and display
+
+This project also uses the following third-party libraries:
+
+- [`github.com/redis/go-redis/v9`](https://github.com/go-redis/redis): Redis client for Go
+- [`github.com/prometheus/client_golang`](https://github.com/prometheus/client_golang): Prometheus metrics instrumentation and exposition
+- [`github.com/modelcontextprotocol/go-sdk`](https://github.com/modelcontextprotocol/go-sdk): MCP (Model Context Protocol) Go SDK
+- [`golang.org/x/net/idna`](https://pkg.go.dev/golang.org/x/net/idna): IDNA (Internationalized Domain Names in Applications) implementation
+- [`golang.org/x/net/publicsuffix`](https://pkg.go.dev/golang.org/x/net/publicsuffix): Public Suffix List implementation
+- [`gopkg.in/yaml.v3`](https://gopkg.in/yaml.v3): YAML parsing library
+
+WHOIS/RDAP server lists are sourced from:
+- [IANA](https://www.iana.org/domains/root/db)
+- [IANA RDAP Bootstrap](https://data.iana.org/rdap/)
+- [IANA RDAP Bootstrap (IPv4)](https://data.iana.org/rdap/ipv4.json)
+- [IANA RDAP Bootstrap (IPv6)](https://data.iana.org/rdap/ipv6.json)
+- [IANA RDAP Bootstrap (AS)](https://data.iana.org/rdap/asn.json)
 
 ## License
 


### PR DESCRIPTION
撤销 #49 的 README 首屏改版，恢复原有的介绍段、Docker 部署说明和依赖清单——营销风格的首屏少了点人味。

保留 #49 代码变更所要求的三处事实性修正：

- "本程序需要 Redis 服务支持" → 默认内存缓存可直接运行、生产建议搭配 Redis（原说法与 `requireRedis: false` 及纯内存模式矛盾）
- env 表 `WHOIS_REDIS_ADDR` 行补充显式设空=禁用 Redis 的新语义
- MCP 一节保留指向 `docs/mcp.md` 的一行链接

代码、`docs/mcp.md`、CHANGELOG、配置示例注释均不动；仓库 About（描述/Topics）保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)