### PR TITLE
chore: add server.json for the official MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.KincaidYang/whois",
+  "title": "WHOIS",
+  "description": "Query WHOIS/RDAP information for domains, IP addresses, CIDR prefixes and ASNs. Self-hostable.",
+  "repository": {
+    "url": "https://github.com/KincaidYang/whois",
+    "source": "github"
+  },
+  "version": "1.1.0",
+  "websiteUrl": "https://github.com/KincaidYang/whois",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://whois.ddnsip.cn/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
已发布到官方 MCP Registry：`io.github.KincaidYang/whois` v1.1.0（remote streamable-http 指向演示站 `https://whois.ddnsip.cn/mcp`）。

此文件为 Registry 的元数据源，入库便于追踪；**以后每次发版需同步 bump `version` 字段并重新 `mcp-publisher publish`**（后续可用官方 GitHub Action 在 release 时自动发布）。

验证：`curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.KincaidYang/whois"` 返回 active 条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)