### PR TITLE
ci: publish to MCP Registry on release tags

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,33 @@
+name: Publish to MCP Registry
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication
+      contents: read
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v7
+      -
+        name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+      -
+        name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+      -
+        name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          jq --arg v "$VERSION" '.version = $v' server.json > server.tmp && mv server.tmp server.json
+      -
+        name: Publish server to MCP Registry
+        run: ./mcp-publisher publish


### PR DESCRIPTION
打 `v*` tag 时自动把 `server.json` 发布到官方 MCP Registry：

- **GitHub OIDC 认证**（`id-token: write`），不需要配置任何 secret
- 发布前用 jq 把 `server.json` 的 `version` 字段改写为 tag 版本号，**发版不再需要手动 bump**（仓库里的 server.json 保持上次发布的版本即可）
- 触发条件 `v*` 与现有 goreleaser 流程的 tag 习惯一致

参考官方文档：https://modelcontextprotocol.io/registry/github-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)