### PR TITLE
test: raise coverage past 80% (RDAP query/parse, IP/ASN/WHOIS handlers)

### DIFF
--- a/internal/rdap/rdap_parse_test.go
+++ b/internal/rdap/rdap_parse_test.go
@@ -1,6 +1,7 @@
 package rdap
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -178,5 +179,149 @@ func TestParseRDAPDomainDsDataWithoutBoolean(t *testing.T) {
 	}
 	if !info.SecureDNS.DelegationSigned || len(info.SecureDNS.DSData) != 1 {
 		t.Errorf("secureDNS: %+v", info.SecureDNS)
+	}
+}
+
+func TestParseRDAPDomainMalformed(t *testing.T) {
+	if _, err := ParseRDAPResponseforDomain(`{"ldhName": 42`); err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+// TestExtractRegistrarName covers the malformed-vCard branches: the function
+// must return "" rather than fail on any shape a misbehaving server sends.
+func TestExtractRegistrarName(t *testing.T) {
+	raw := func(parts ...string) []json.RawMessage {
+		out := make([]json.RawMessage, len(parts))
+		for i, p := range parts {
+			out[i] = json.RawMessage(p)
+		}
+		return out
+	}
+	tests := []struct {
+		name  string
+		vcard []json.RawMessage
+		want  string
+	}{
+		{"nil array", nil, ""},
+		{"too short", raw(`"vcard"`), ""},
+		{"properties not an array", raw(`"vcard"`, `{"fn": "x"}`), ""},
+		{"property not an array", raw(`"vcard"`, `[{"fn": "x"}]`), ""},
+		{"property too short", raw(`"vcard"`, `[["fn", {}, "text"]]`), ""},
+		{"property name not a string", raw(`"vcard"`, `[[1, {}, "text", "x"]]`), ""},
+		{"no fn property", raw(`"vcard"`, `[["version", {}, "text", "4.0"]]`), ""},
+		{"fn value not a string", raw(`"vcard"`, `[["fn", {}, "text", 42]]`), ""},
+		{"fn after skipped properties", raw(`"vcard"`, `[["version", {}, "text", "4.0"], ["fn", {}, "text", "Registrar Inc."]]`), "Registrar Inc."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractRegistrarName(tt.vcard); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseRDAPIP covers the common RIR shape (modeled on ARIN): v4 CIDR,
+// type, country, events and remarks.
+func TestParseRDAPIP(t *testing.T) {
+	response := `{
+		"objectClassName": "ip network",
+		"handle": "NET-192-0-2-0-1",
+		"startAddress": "192.0.2.0",
+		"endAddress": "192.0.2.255",
+		"name": "TEST-NET-1",
+		"cidr0_cidrs": [{"v4prefix": "192.0.2.0", "length": 24}],
+		"type": "ASSIGNMENT",
+		"country": "US",
+		"status": ["active"],
+		"events": [
+			{"eventAction": "registration", "eventDate": "2010-01-01T00:00:00Z"},
+			{"eventAction": "last changed", "eventDate": "2020-06-15T12:00:00Z"}
+		],
+		"remarks": [{"title": "Note", "description": ["Documentation range"]}]
+	}`
+
+	info, err := ParseRDAPResponseforIP(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := model.IPInfo{
+		ObjectClassName:  model.ObjectClassIPNetwork,
+		Handle:           "NET-192-0-2-0-1",
+		StartAddress:     "192.0.2.0",
+		EndAddress:       "192.0.2.255",
+		CIDR:             "192.0.2.0/24",
+		Name:             "TEST-NET-1",
+		Type:             "ASSIGNMENT",
+		Country:          "US",
+		Status:           []string{"active"},
+		RegistrationDate: "2010-01-01T00:00:00Z",
+		LastChangedDate:  "2020-06-15T12:00:00Z",
+		Remarks:          []model.Remark{{Title: "Note", Description: []string{"Documentation range"}}},
+	}
+	if !reflect.DeepEqual(info, expected) {
+		t.Errorf("expected %+v, got %+v", expected, info)
+	}
+}
+
+// TestParseRDAPIPV6Prefix verifies the v6prefix branch of CIDR extraction.
+func TestParseRDAPIPV6Prefix(t *testing.T) {
+	response := `{
+		"handle": "2001-DB8",
+		"cidr0_cidrs": [{"v6prefix": "2001:db8::", "length": 32}]
+	}`
+
+	info, err := ParseRDAPResponseforIP(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.CIDR != "2001:db8::/32" {
+		t.Errorf("cidr: %q", info.CIDR)
+	}
+}
+
+func TestParseRDAPIPMalformed(t *testing.T) {
+	if _, err := ParseRDAPResponseforIP(`not json`); err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestParseRDAPASN(t *testing.T) {
+	response := `{
+		"objectClassName": "autnum",
+		"handle": "AS64500",
+		"name": "EXAMPLE-AS",
+		"status": ["active"],
+		"events": [
+			{"eventAction": "registration", "eventDate": "2005-03-01T00:00:00Z"},
+			{"eventAction": "last changed", "eventDate": "2021-11-30T08:00:00Z"}
+		],
+		"remarks": [{"title": "Note", "description": ["Documentation ASN"]}]
+	}`
+
+	info, err := ParseRDAPResponseforASN(response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := model.ASNInfo{
+		ObjectClassName:  model.ObjectClassAutnum,
+		Handle:           "AS64500",
+		Name:             "EXAMPLE-AS",
+		Status:           []string{"active"},
+		RegistrationDate: "2005-03-01T00:00:00Z",
+		LastChangedDate:  "2021-11-30T08:00:00Z",
+		Remarks:          []model.Remark{{Title: "Note", Description: []string{"Documentation ASN"}}},
+	}
+	if !reflect.DeepEqual(info, expected) {
+		t.Errorf("expected %+v, got %+v", expected, info)
+	}
+}
+
+func TestParseRDAPASNMalformed(t *testing.T) {
+	if _, err := ParseRDAPResponseforASN(`[`); err == nil {
+		t.Fatal("expected error for malformed JSON")
 	}
 }

--- a/internal/rdap/rdap_query_test.go
+++ b/internal/rdap/rdap_query_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/KincaidYang/whois/internal/config"
@@ -110,9 +111,10 @@ func TestRDAPQueryASNNoServer(t *testing.T) {
 
 func TestRDAPQueryIP(t *testing.T) {
 	const body = `{"objectClassName": "ip network", "handle": "NET-192-0-2-0-1"}`
-	var gotPath string
+	// Written by the httptest handler goroutine, read by the test goroutine.
+	var gotPath atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath.Store(r.URL.Path)
 		w.Header().Set("Content-Type", "application/rdap+json")
 		_, _ = w.Write([]byte(body))
 	}))
@@ -125,17 +127,17 @@ func TestRDAPQueryIP(t *testing.T) {
 	if got != body {
 		t.Errorf("response body: %q", got)
 	}
-	if gotPath != "/ip/192.0.2.1" {
-		t.Errorf("request path: %q", gotPath)
+	if got, _ := gotPath.Load().(string); got != "/ip/192.0.2.1" {
+		t.Errorf("request path: %q", got)
 	}
 }
 
 // TestRDAPQueryIPCIDR verifies the slash in a CIDR query survives as a path
 // separator (RFC 9082 ip/<prefix>/<length> form).
 func TestRDAPQueryIPCIDR(t *testing.T) {
-	var gotPath string
+	var gotPath atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath.Store(r.URL.Path)
 		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer srv.Close()
@@ -143,16 +145,16 @@ func TestRDAPQueryIPCIDR(t *testing.T) {
 	if _, err := RDAPQueryIP(context.Background(), "192.0.2.0/24", srv.URL+"/"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotPath != "/ip/192.0.2.0/24" {
-		t.Errorf("request path: %q", gotPath)
+	if got, _ := gotPath.Load().(string); got != "/ip/192.0.2.0/24" {
+		t.Errorf("request path: %q", got)
 	}
 }
 
 func TestRDAPQueryASN(t *testing.T) {
 	const body = `{"objectClassName": "autnum", "handle": "AS64500"}`
-	var gotPath string
+	var gotPath atomic.Value
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath.Store(r.URL.Path)
 		_, _ = w.Write([]byte(body))
 	}))
 	defer srv.Close()
@@ -164,7 +166,7 @@ func TestRDAPQueryASN(t *testing.T) {
 	if got != body {
 		t.Errorf("response body: %q", got)
 	}
-	if gotPath != "/autnum/64500" {
-		t.Errorf("request path: %q", gotPath)
+	if got, _ := gotPath.Load().(string); got != "/autnum/64500" {
+		t.Errorf("request path: %q", got)
 	}
 }

--- a/internal/rdap/rdap_query_test.go
+++ b/internal/rdap/rdap_query_test.go
@@ -1,0 +1,170 @@
+package rdap
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
+)
+
+// TestMain seeds proxy settings before any test runs: initProxy is guarded by
+// a package-level sync.Once, so the configuration must be in place before the
+// first getHTTPClient call anywhere in this test binary.
+func TestMain(m *testing.M) {
+	config.ProxyServer = "http://proxy.invalid:3128"
+	config.ProxyUsername = "user"
+	config.ProxyPassword = "pass"
+	config.ProxySuffixes = []string{"proxied"}
+	os.Exit(m.Run())
+}
+
+func TestGetHTTPClientProxySelection(t *testing.T) {
+	proxied := getHTTPClient("proxied")
+	if proxied == config.HttpClient {
+		t.Fatal("TLD in proxy.suffixes should get the proxy client, got the default client")
+	}
+	if proxied != proxyClient {
+		t.Fatalf("expected the shared proxy client, got %+v", proxied)
+	}
+	if direct := getHTTPClient("com"); direct != config.HttpClient {
+		t.Fatalf("TLD outside proxy.suffixes should get config.HttpClient, got %+v", direct)
+	}
+}
+
+func TestDoRDAPRequestStatusMapping(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr error
+	}{
+		{"not found", http.StatusNotFound, utils.ErrResourceNotFound},
+		{"forbidden", http.StatusForbidden, utils.ErrQueryDenied},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			defer srv.Close()
+
+			_, err := doRDAPRequest(context.Background(), config.HttpClient, srv.URL)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("status %d: expected %v, got %v", tt.status, tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDoRDAPRequestUnexpectedStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	_, err := doRDAPRequest(context.Background(), config.HttpClient, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "unexpected status code: 502") {
+		t.Fatalf("expected unexpected-status error, got %v", err)
+	}
+}
+
+func TestDoRDAPRequestOversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		chunk := make([]byte, 64<<10)
+		for written := 0; written <= maxResponseSize; written += len(chunk) {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	_, err := doRDAPRequest(context.Background(), config.HttpClient, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected oversized-response error, got %v", err)
+	}
+}
+
+func TestDoRDAPRequestInvalidURL(t *testing.T) {
+	if _, err := doRDAPRequest(context.Background(), config.HttpClient, "://bad"); err == nil {
+		t.Fatal("expected error for unparseable URL")
+	}
+}
+
+func TestRDAPQueryIPNoServer(t *testing.T) {
+	if _, err := RDAPQueryIP(context.Background(), "192.0.2.1", ""); err == nil {
+		t.Fatal("expected error when no RDAP server is known for the IP")
+	}
+}
+
+func TestRDAPQueryASNNoServer(t *testing.T) {
+	if _, err := RDAPQueryASN(context.Background(), "64500", ""); err == nil {
+		t.Fatal("expected error when no RDAP server is known for the ASN")
+	}
+}
+
+func TestRDAPQueryIP(t *testing.T) {
+	const body = `{"objectClassName": "ip network", "handle": "NET-192-0-2-0-1"}`
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/rdap+json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	got, err := RDAPQueryIP(context.Background(), "192.0.2.1", srv.URL+"/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != body {
+		t.Errorf("response body: %q", got)
+	}
+	if gotPath != "/ip/192.0.2.1" {
+		t.Errorf("request path: %q", gotPath)
+	}
+}
+
+// TestRDAPQueryIPCIDR verifies the slash in a CIDR query survives as a path
+// separator (RFC 9082 ip/<prefix>/<length> form).
+func TestRDAPQueryIPCIDR(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	if _, err := RDAPQueryIP(context.Background(), "192.0.2.0/24", srv.URL+"/"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotPath != "/ip/192.0.2.0/24" {
+		t.Errorf("request path: %q", gotPath)
+	}
+}
+
+func TestRDAPQueryASN(t *testing.T) {
+	const body = `{"objectClassName": "autnum", "handle": "AS64500"}`
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	got, err := RDAPQueryASN(context.Background(), "64500", srv.URL+"/")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != body {
+		t.Errorf("response body: %q", got)
+	}
+	if gotPath != "/autnum/64500" {
+		t.Errorf("request path: %q", gotPath)
+	}
+}

--- a/main_ip_asn_test.go
+++ b/main_ip_asn_test.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/handlers"
 	"github.com/KincaidYang/whois/internal/serverlist"
+	"github.com/KincaidYang/whois/internal/utils"
 )
 
 // withFakeRDAP registers a fake RDAP upstream for the given serverlist keys
@@ -35,9 +37,10 @@ func withFakeRDAP(t *testing.T, h http.HandlerFunc, keys ...string) *httptest.Se
 // TestHandleIPMissAndHit drives a full IP query: cache miss routed to the
 // fake upstream, then a second request served from cache.
 func TestHandleIPMissAndHit(t *testing.T) {
-	var gotPath string
+	// Written by the httptest handler goroutine, read by the test goroutine.
+	var gotPath atomic.Value
 	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath.Store(r.URL.Path)
 		w.Header().Set("Content-Type", "application/rdap+json")
 		_, _ = w.Write([]byte(`{"objectClassName":"ip network","handle":"NET-ZZIPTEST","startAddress":"192.0.2.128","endAddress":"192.0.2.255"}`))
 	}, "192.0.2.128/25")
@@ -52,8 +55,8 @@ func TestHandleIPMissAndHit(t *testing.T) {
 	if got := w.Header().Get("X-Cache"); got != "MISS" {
 		t.Errorf("X-Cache: got %q, want MISS", got)
 	}
-	if gotPath != "/ip/192.0.2.130" {
-		t.Errorf("upstream path: %q", gotPath)
+	if got, _ := gotPath.Load().(string); got != "/ip/192.0.2.130" {
+		t.Errorf("upstream path: %q", got)
 	}
 	if !strings.Contains(w.Body.String(), "NET-ZZIPTEST") {
 		t.Errorf("body missing upstream data: %s", w.Body.String())
@@ -139,9 +142,9 @@ func TestHandleIPRefresh(t *testing.T) {
 // using a range inside the RFC 6996 private 32-bit space that no RIR entry
 // covers.
 func TestHandleASNMissAndHit(t *testing.T) {
-	var gotPath string
+	var gotPath atomic.Value
 	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotPath.Store(r.URL.Path)
 		_, _ = w.Write([]byte(`{"objectClassName":"autnum","handle":"AS-ZZASNTEST"}`))
 	}, "4199999990-4199999999")
 
@@ -154,8 +157,8 @@ func TestHandleASNMissAndHit(t *testing.T) {
 	if got := w.Header().Get("X-Cache"); got != "MISS" {
 		t.Errorf("X-Cache: got %q, want MISS", got)
 	}
-	if gotPath != "/autnum/4199999995" {
-		t.Errorf("upstream path: %q", gotPath)
+	if got, _ := gotPath.Load().(string); got != "/autnum/4199999995" {
+		t.Errorf("upstream path: %q", got)
 	}
 	if !strings.Contains(w.Body.String(), "AS-ZZASNTEST") {
 		t.Errorf("body missing upstream data: %s", w.Body.String())
@@ -199,11 +202,20 @@ func TestHandleASNRefresh(t *testing.T) {
 }
 
 // TestHandleReadyRequireRedis verifies /ready reports 503 when Redis is
-// required but the instance runs on the memory cache.
+// required but the instance runs on the memory cache. The cache manager is
+// swapped to a memory-only instance so the result does not depend on whether
+// the machine running the tests happens to have Redis reachable.
 func TestHandleReadyRequireRedis(t *testing.T) {
 	orig := config.RequireRedis
+	origCache := config.CacheManager
+	mem := utils.NewMemoryCache(16, time.Minute)
 	config.RequireRedis = true
-	t.Cleanup(func() { config.RequireRedis = orig })
+	config.CacheManager = mem
+	t.Cleanup(func() {
+		config.RequireRedis = orig
+		config.CacheManager = origCache
+		mem.Close()
+	})
 
 	w := httptest.NewRecorder()
 	handlers.HandleReady(w, httptest.NewRequest("GET", "/ready", nil))

--- a/main_ip_asn_test.go
+++ b/main_ip_asn_test.go
@@ -214,7 +214,7 @@ func TestHandleReadyRequireRedis(t *testing.T) {
 	t.Cleanup(func() {
 		config.RequireRedis = orig
 		config.CacheManager = origCache
-		mem.Close()
+		_ = mem.Close()
 	})
 
 	w := httptest.NewRecorder()

--- a/main_ip_asn_test.go
+++ b/main_ip_asn_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/handlers"
+	"github.com/KincaidYang/whois/internal/serverlist"
+)
+
+// withFakeRDAP registers a fake RDAP upstream for the given serverlist keys
+// (CIDR prefixes or ASN ranges) and restores the built-in index on cleanup.
+// The injected prefixes are more specific than any built-in RIR entry, so the
+// lookup's rightmost-start binary search always resolves to the fake.
+func withFakeRDAP(t *testing.T, h http.HandlerFunc, keys ...string) *httptest.Server {
+	t.Helper()
+	fake := httptest.NewServer(h)
+	entries := make(map[string]string, len(keys))
+	for _, k := range keys {
+		entries[k] = fake.URL + "/"
+	}
+	serverlist.UpdateFromIANA(entries)
+	t.Cleanup(func() {
+		fake.Close()
+		serverlist.UpdateFromIANA(nil)
+	})
+	return fake
+}
+
+// TestHandleIPMissAndHit drives a full IP query: cache miss routed to the
+// fake upstream, then a second request served from cache.
+func TestHandleIPMissAndHit(t *testing.T) {
+	var gotPath string
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/rdap+json")
+		_, _ = w.Write([]byte(`{"objectClassName":"ip network","handle":"NET-ZZIPTEST","startAddress":"192.0.2.128","endAddress":"192.0.2.255"}`))
+	}, "192.0.2.128/25")
+
+	req := httptest.NewRequest("GET", "/ip/192.0.2.130", nil)
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "MISS" {
+		t.Errorf("X-Cache: got %q, want MISS", got)
+	}
+	if gotPath != "/ip/192.0.2.130" {
+		t.Errorf("upstream path: %q", gotPath)
+	}
+	if !strings.Contains(w.Body.String(), "NET-ZZIPTEST") {
+		t.Errorf("body missing upstream data: %s", w.Body.String())
+	}
+
+	// Second request must be served from cache without touching upstream.
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/192.0.2.130", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("cache hit: expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+}
+
+// TestHandleIPUpstreamNotFound verifies an upstream 404 is returned as a
+// problem response and negative-cached for the next request.
+func TestHandleIPUpstreamNotFound(t *testing.T) {
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}, "192.0.2.128/25")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/192.0.2.140", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// The negative result must be cached: the next request is a 404 cache hit.
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/192.0.2.140", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("negative cache hit: expected 404, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+}
+
+// TestHandleIPNegativeCacheDenied verifies a cached "denied" marker is served
+// as 403 without an upstream query.
+func TestHandleIPNegativeCacheDenied(t *testing.T) {
+	key := handlers.CacheKeyPrefix + "192.0.2.150"
+	if err := config.CacheManager.Set(context.Background(), key, "\x00neg:denied", time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/192.0.2.150", nil))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleIPRefresh verifies refresh=true bypasses a stale cache entry and
+// overwrites it with the upstream result.
+func TestHandleIPRefresh(t *testing.T) {
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"objectClassName":"ip network","handle":"NET-FRESH"}`))
+	}, "192.0.2.128/25")
+
+	key := handlers.CacheKeyPrefix + "192.0.2.160"
+	if err := config.CacheManager.Set(context.Background(), key, `{"handle":"NET-STALE"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	handlers.HandleIP(context.Background(), w, "192.0.2.160", handlers.CacheKeyPrefix, true)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "REFRESH" {
+		t.Errorf("X-Cache: got %q, want REFRESH", got)
+	}
+	if !strings.Contains(w.Body.String(), "NET-FRESH") {
+		t.Errorf("body should carry the refreshed data: %s", w.Body.String())
+	}
+}
+
+// TestHandleASNMissAndHit drives a full ASN query against a fake upstream,
+// using a range inside the RFC 6996 private 32-bit space that no RIR entry
+// covers.
+func TestHandleASNMissAndHit(t *testing.T) {
+	var gotPath string
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"objectClassName":"autnum","handle":"AS-ZZASNTEST"}`))
+	}, "4199999990-4199999999")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/autnum/4199999995", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "MISS" {
+		t.Errorf("X-Cache: got %q, want MISS", got)
+	}
+	if gotPath != "/autnum/4199999995" {
+		t.Errorf("upstream path: %q", gotPath)
+	}
+	if !strings.Contains(w.Body.String(), "AS-ZZASNTEST") {
+		t.Errorf("body missing upstream data: %s", w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/autnum/as4199999995", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("cache hit: expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+}
+
+// TestHandleASNInvalidFormat exercises the handler's own ASN validation
+// (routes normally pre-validate, so this calls the handler directly).
+func TestHandleASNInvalidFormat(t *testing.T) {
+	w := httptest.NewRecorder()
+	handlers.HandleASN(context.Background(), w, "asnotanumber", handlers.CacheKeyPrefix, false)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleASNRefresh verifies the refresh path for ASN queries.
+func TestHandleASNRefresh(t *testing.T) {
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"objectClassName":"autnum","handle":"AS-FRESH"}`))
+	}, "4199999990-4199999999")
+
+	w := httptest.NewRecorder()
+	handlers.HandleASN(context.Background(), w, "as4199999991", handlers.CacheKeyPrefix, true)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "REFRESH" {
+		t.Errorf("X-Cache: got %q, want REFRESH", got)
+	}
+}
+
+// TestHandleReadyRequireRedis verifies /ready reports 503 when Redis is
+// required but the instance runs on the memory cache.
+func TestHandleReadyRequireRedis(t *testing.T) {
+	orig := config.RequireRedis
+	config.RequireRedis = true
+	t.Cleanup(func() { config.RequireRedis = orig })
+
+	w := httptest.NewRecorder()
+	handlers.HandleReady(w, httptest.NewRequest("GET", "/ready", nil))
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "redis required but unavailable") {
+		t.Errorf("body: %s", w.Body.String())
+	}
+}

--- a/main_whois_test.go
+++ b/main_whois_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/serverlist"
+)
+
+// withMockWhoisServer starts a loopback WHOIS server answering every
+// connection with the given response, and maps the given TLDs to it in
+// serverlist.TLDToWhoisServer (restored on cleanup).
+func withMockWhoisServer(t *testing.T, response string, tlds ...string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock WHOIS server: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 1024)
+				if _, err := c.Read(buf); err != nil {
+					return
+				}
+				_, _ = c.Write([]byte(response))
+			}(conn)
+		}
+	}()
+
+	orig := serverlist.TLDToWhoisServer
+	replaced := make(map[string]string, len(orig)+len(tlds))
+	for k, v := range orig {
+		replaced[k] = v
+	}
+	for _, tld := range tlds {
+		replaced[tld] = listener.Addr().String()
+	}
+	serverlist.TLDToWhoisServer = replaced
+	t.Cleanup(func() {
+		serverlist.TLDToWhoisServer = orig
+		_ = listener.Close()
+	})
+}
+
+// TestWhoisDomainWithParser drives the WHOIS query path for a TLD that has a
+// registered parser (.cn — WHOIS server, no RDAP), asserting the response is
+// parsed into the regular JSON shape.
+func TestWhoisDomainWithParser(t *testing.T) {
+	withMockWhoisServer(t, `Domain Name: whoisparsertest.cn
+ROID: 20030312s10001s00082127-cn
+Domain Status: ok
+Sponsoring Registrar: MockRegistrar
+Name Server: ns1.example.cn
+Name Server: ns2.example.cn
+Registration Time: 2003-03-17 12:20:05
+Expiration Time: 2027-03-17 12:20:05
+DNSSEC: unsigned
+`, "cn")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/whoisparsertest.cn", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"registrar":"MockRegistrar"`) {
+		t.Errorf("parsed registrar missing: %s", body)
+	}
+	if !strings.Contains(body, "ns1.example.cn") {
+		t.Errorf("parsed nameservers missing: %s", body)
+	}
+	if strings.Contains(body, `"unparsed":true`) {
+		t.Errorf("response should be parsed, not raw-wrapped: %s", body)
+	}
+
+	// Second request must come from cache.
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/whoisparsertest.cn", nil))
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+}
+
+// TestWhoisDomainWithoutParser verifies a TLD with a WHOIS server but no
+// parser gets the raw text wrapped in the stable JSON shape (unparsed=true).
+func TestWhoisDomainWithoutParser(t *testing.T) {
+	withMockWhoisServer(t, "Domain Name: test.zzwhoisonly\nSome unstructured registry text\n", "zzwhoisonly")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/test.zzwhoisonly", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"unparsed":true`) {
+		t.Errorf("expected unparsed marker: %s", body)
+	}
+	if !strings.Contains(body, "Some unstructured registry text") {
+		t.Errorf("raw text missing from rawText field: %s", body)
+	}
+}
+
+// TestWhoisDomainRaw verifies ?raw=1 returns the bare WHOIS text as
+// text/plain and serves the follow-up request from the raw: cache namespace.
+func TestWhoisDomainRaw(t *testing.T) {
+	const rawResponse = "Domain Name: rawtest.zzwhoisonly\nRaw registry answer\n"
+	withMockWhoisServer(t, rawResponse, "zzwhoisonly")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/rawtest.zzwhoisonly?raw=1", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type: got %q", ct)
+	}
+	if w.Body.String() != rawResponse {
+		t.Errorf("raw body: %q", w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/rawtest.zzwhoisonly?raw=1", nil))
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+	if ct := w.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("cached raw Content-Type: got %q", ct)
+	}
+}
+
+// TestWhoisDomainRawNoServer verifies ?raw=1 for a TLD without a WHOIS
+// server is rejected with 404 (RDAP has no raw-text form to fall back to).
+func TestWhoisDomainRawNoServer(t *testing.T) {
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/example.zzqqxxnotld?raw=1", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "No WHOIS server known") {
+		t.Errorf("body: %s", w.Body.String())
+	}
+}
+
+// TestWhoisDomainNotFound verifies a registry "no matching record" answer for
+// a parser TLD maps to a 404 problem response.
+func TestWhoisDomainNotFound(t *testing.T) {
+	withMockWhoisServer(t, "No matching record.\n", "cn")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/domain/whoisnotfound.cn", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## 变更内容

补充四处测试,总覆盖率(`go test ./... -coverpkg=./...`)从 **75.1% → 82.8%**:

- `internal/rdap/rdap_query_test.go`(新增):代理客户端选择(`proxy.suffixes` 命中/未命中)、`doRDAPRequest` 状态码映射(404→ErrResourceNotFound、403→ErrQueryDenied、非预期 5xx)、超大响应截断、CIDR 查询路径保留斜杠(RFC 9082)、无服务器时的报错路径。
- `internal/rdap/rdap_parse_test.go`:malformed JSON、vCard 各种畸形分支(`extractRegistrarName` 对任意坏形状返回空串)、ARIN 风格 IP 网络解析。
- `main_ip_asn_test.go`(新增):以 fake RDAP 上游端到端驱动 `/ip`、`/autnum`:MISS→HIT、上游 404 负缓存、缓存 denied 标记→403、`refresh=true` 绕过并覆写缓存、ASN 非法格式 400、`/ready` 在 require_redis 下 503。
- `main_whois_test.go`(新增):以环回 mock WHOIS 服务器驱动 `.cn`(有解析器)与无解析器 TLD:结构化解析、`unparsed` 包裹、`?raw=1` 的 text/plain 与独立缓存命名空间、无 WHOIS 服务器时 raw 404、注册局"无记录"→404。

## 验证

- `go test ./...`、`go test -race ./...`、`-shuffle=on` 均通过;`gofmt`/`go vet` 干净。
- 所有 mock 均为环回监听,不触真实注册局;全局状态(serverlist 索引、WHOIS 服务器表)在 cleanup 中恢复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)