### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
       run: go test -v -coverpkg=./... -coverprofile=coverage.out ./...
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         files: coverage.out
         use_oidc: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Codecov tokenless (OIDC) upload
     steps:
     - uses: actions/checkout@v7
 
@@ -36,4 +39,10 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v -coverpkg=./... -cover ./...
+      run: go test -v -coverpkg=./... -coverprofile=coverage.out ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: coverage.out
+        use_oidc: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/KincaidYang/whois.svg)](https://pkg.go.dev/github.com/KincaidYang/whois) [![Go](https://github.com/KincaidYang/whois/actions/workflows/go.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/go.yml) [![CodeQL](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/KincaidYang/whois.svg)](https://pkg.go.dev/github.com/KincaidYang/whois) [![Go](https://github.com/KincaidYang/whois/actions/workflows/go.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/go.yml) [![CodeQL](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml) [![codecov](https://codecov.io/gh/KincaidYang/whois/graph/badge.svg)](https://codecov.io/gh/KincaidYang/whois)
 
 [English](README_EN.md)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,4 +1,4 @@
-[![Go Reference](https://pkg.go.dev/badge/github.com/KincaidYang/whois.svg)](https://pkg.go.dev/github.com/KincaidYang/whois) [![Go](https://github.com/KincaidYang/whois/actions/workflows/go.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/go.yml) [![CodeQL](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/KincaidYang/whois.svg)](https://pkg.go.dev/github.com/KincaidYang/whois) [![Go](https://github.com/KincaidYang/whois/actions/workflows/go.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/go.yml) [![CodeQL](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml/badge.svg)](https://github.com/KincaidYang/whois/actions/workflows/codeql.yml) [![codecov](https://codecov.io/gh/KincaidYang/whois/graph/badge.svg)](https://codecov.io/gh/KincaidYang/whois)
 
 [中文文档](README.md)
 


### PR DESCRIPTION
## 变更

- \`go.yml\`：测试步骤输出 \`coverage.out\`，新增 \`codecov/codecov-action@v5\` 上传步骤，走 OIDC 免 token（job 加 \`id-token: write\` 权限）
- README / README_EN 徽章行末尾加 Codecov 徽章

## 背景

awesome-go 提交清单要求仓库文档带覆盖率服务链接（goreportcard.com 已于 2026-07-01 关站，该项如今走形式，覆盖率链接才是实际缺口）。当前总覆盖率 83.2%（本地 `go tool cover -func` 验证），满足 ≥80% 要求。

首次上传前需在 codecov.io 用 GitHub 登录激活本仓库（公开仓库免费，OIDC 无需配 token/secret）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)