### PR TITLE
test: raise coverage to 91.5% (cache, Redis health, bootstrap, config env, health handlers)

### DIFF
--- a/internal/config/config_more_test.go
+++ b/internal/config/config_more_test.go
@@ -1,0 +1,229 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/utils"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestOverrideConfigWithEnvAllFields(t *testing.T) {
+	t.Setenv("WHOIS_REDIS_ADDR", "redis.example:6380")
+	t.Setenv("WHOIS_REDIS_PASSWORD", "secret")
+	t.Setenv("WHOIS_REDIS_DB", "3")
+	t.Setenv("WHOIS_REDIS_TLS", "true")
+	t.Setenv("WHOIS_REDIS_TLS_SKIP_VERIFY", "1")
+	t.Setenv("WHOIS_CACHE_EXPIRATION", "120")
+	t.Setenv("WHOIS_REQUIRE_REDIS", "true")
+	t.Setenv("WHOIS_MEMORY_MAX_SIZE", "500")
+	t.Setenv("WHOIS_MEMORY_CLEAN_INTERVAL", "60")
+	t.Setenv("WHOIS_NEGATIVE_CACHE_EXPIRATION", "30")
+	t.Setenv("WHOIS_PORT", "9999")
+	t.Setenv("WHOIS_RATE_LIMIT", "77")
+	t.Setenv("WHOIS_PROXY_SERVER", "socks5://proxy.example:1080")
+	t.Setenv("WHOIS_PROXY_USERNAME", "user")
+	t.Setenv("WHOIS_PROXY_PASSWORD", "pass")
+	t.Setenv("WHOIS_BATCH_ENABLED", "true")
+	t.Setenv("WHOIS_BATCH_MAX_ITEMS", "42")
+	t.Setenv("WHOIS_LOG_LEVEL", "debug")
+	t.Setenv("WHOIS_MCP_LOCALHOST_PROTECTION", "false")
+
+	var cfg Config
+	cfg.MCP.LocalhostProtection = true
+	overrideConfigWithEnv(&cfg)
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"redis.addr", cfg.Redis.Addr, "redis.example:6380"},
+		{"redis.password", cfg.Redis.Password, "secret"},
+		{"redis.db", cfg.Redis.DB, 3},
+		{"redis.tls", cfg.Redis.TLS, true},
+		{"redis.tlsSkipVerify", cfg.Redis.TLSSkipVerify, true},
+		{"cache.expiration", cfg.Cache.Expiration, 120},
+		{"cache.requireRedis", cfg.Cache.RequireRedis, true},
+		{"cache.memoryMaxSize", cfg.Cache.MemoryMaxSize, 500},
+		{"cache.memoryCleanInterval", cfg.Cache.MemoryCleanInterval, 60},
+		{"cache.negativeExpiration", cfg.Cache.NegativeExpiration, 30},
+		{"server.port", cfg.Server.Port, 9999},
+		{"server.rateLimit", cfg.Server.RateLimit, 77},
+		{"proxy.server", cfg.Proxy.Server, "socks5://proxy.example:1080"},
+		{"proxy.username", cfg.Proxy.Username, "user"},
+		{"proxy.password", cfg.Proxy.Password, "pass"},
+		{"batch.enabled", cfg.Batch.Enabled, true},
+		{"batch.maxItems", cfg.Batch.MaxItems, 42},
+		{"log.level", cfg.Log.Level, "debug"},
+		{"mcp.localhostProtection", cfg.MCP.LocalhostProtection, false},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestOverrideConfigWithEnvExplicitEmptyRedisAddr(t *testing.T) {
+	// An explicitly empty WHOIS_REDIS_ADDR must clear a baked-in address
+	// (memory-only mode); this is the LookupEnv-vs-Getenv distinction.
+	t.Setenv("WHOIS_REDIS_ADDR", "")
+	cfg := Config{}
+	cfg.Redis.Addr = "baked-in:6379"
+	overrideConfigWithEnv(&cfg)
+	if cfg.Redis.Addr != "" {
+		t.Errorf("redis.addr = %q, want cleared by explicit empty env", cfg.Redis.Addr)
+	}
+}
+
+func TestOverrideConfigWithEnvBadNumbersIgnored(t *testing.T) {
+	t.Setenv("WHOIS_PORT", "not-a-number")
+	t.Setenv("WHOIS_REDIS_DB", "also-bad")
+	cfg := Config{}
+	cfg.Server.Port = 8043
+	cfg.Redis.DB = 1
+	overrideConfigWithEnv(&cfg)
+	if cfg.Server.Port != 8043 || cfg.Redis.DB != 1 {
+		t.Errorf("port/db = %d/%d, want unparseable env values ignored (8043/1)", cfg.Server.Port, cfg.Redis.DB)
+	}
+}
+
+func TestInitLoggerLevels(t *testing.T) {
+	old := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(old) })
+	ctx := context.Background()
+
+	cases := []struct {
+		level      string
+		enabledAt  slog.Level
+		disabledAt slog.Level
+	}{
+		{"debug", slog.LevelDebug, slog.LevelDebug - 1},
+		{"WARN", slog.LevelWarn, slog.LevelInfo},
+		{"error", slog.LevelError, slog.LevelWarn},
+		{"bogus", slog.LevelInfo, slog.LevelDebug}, // unknown value defaults to Info
+	}
+	for _, c := range cases {
+		initLogger(c.level)
+		if !slog.Default().Enabled(ctx, c.enabledAt) {
+			t.Errorf("initLogger(%q): level %v should be enabled", c.level, c.enabledAt)
+		}
+		if slog.Default().Enabled(ctx, c.disabledAt) {
+			t.Errorf("initLogger(%q): level %v should be disabled", c.level, c.disabledAt)
+		}
+	}
+}
+
+func TestReadConfigFile(t *testing.T) {
+	t.Run("no file", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		if _, _, err := readConfigFile(); err == nil {
+			t.Error("want error when no config file exists")
+		}
+	})
+
+	t.Run("yaml preferred", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("server:\n  port: 1\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		data, ext, err := readConfigFile()
+		if err != nil || ext != ".yaml" || len(data) == 0 {
+			t.Errorf("got ext %q err %v, want .yaml", ext, err)
+		}
+	})
+
+	t.Run("json fallback", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, ext, err := readConfigFile()
+		if err != nil || ext != ".json" {
+			t.Errorf("got ext %q err %v, want .json", ext, err)
+		}
+	})
+
+	t.Run("unreadable file", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		// A directory named config.yaml fails ReadFile with a non-NotExist
+		// error, which must stop the search instead of falling through.
+		if err := os.Mkdir(filepath.Join(dir, "config.yaml"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := readConfigFile(); err == nil {
+			t.Error("want error for unreadable config.yaml")
+		}
+	})
+}
+
+func TestInitVersionInfo(t *testing.T) {
+	oldV, oldB, oldG := Version, BuildTime, GitCommit
+	t.Cleanup(func() { Version, BuildTime, GitCommit = oldV, oldB, oldG })
+
+	initVersionInfo()
+	// Test binaries carry no release version or VCS stamps, so the documented
+	// defaults must hold rather than leaving the fields empty.
+	if Version == "" || BuildTime == "" || GitCommit == "" {
+		t.Errorf("version info left empty: %q/%q/%q", Version, BuildTime, GitCommit)
+	}
+}
+
+func TestInitializeCacheManagerMemoryOnly(t *testing.T) {
+	oldClient, oldManager := RedisClient, CacheManager
+	oldMax, oldInterval := MemoryMaxSize, MemoryCleanInterval
+	t.Cleanup(func() {
+		RedisClient, CacheManager = oldClient, oldManager
+		MemoryMaxSize, MemoryCleanInterval = oldMax, oldInterval
+	})
+
+	RedisClient = nil
+	MemoryMaxSize = 10
+	MemoryCleanInterval = time.Minute
+
+	initializeCacheManager()
+
+	mc, ok := CacheManager.(*utils.MemoryCache)
+	if !ok {
+		t.Fatalf("CacheManager = %T, want *utils.MemoryCache in memory-only mode", CacheManager)
+	}
+	_ = mc.Close()
+}
+
+func TestInitializeCacheManagerRedisUnavailableFallback(t *testing.T) {
+	oldClient, oldManager := RedisClient, CacheManager
+	oldMax, oldInterval, oldRequire := MemoryMaxSize, MemoryCleanInterval, RequireRedis
+	t.Cleanup(func() {
+		RedisClient, CacheManager = oldClient, oldManager
+		MemoryMaxSize, MemoryCleanInterval, RequireRedis = oldMax, oldInterval, oldRequire
+	})
+
+	// Port 1 refuses connections immediately: Redis is configured but down.
+	RedisClient = redis.NewClient(&redis.Options{Addr: "127.0.0.1:1", DialTimeout: 500 * time.Millisecond})
+	t.Cleanup(func() { _ = RedisClient.Close() })
+	MemoryMaxSize = 10
+	MemoryCleanInterval = time.Minute
+	RequireRedis = false
+
+	initializeCacheManager()
+
+	fc, ok := CacheManager.(*utils.FallbackCache)
+	if !ok {
+		t.Fatalf("CacheManager = %T, want *utils.FallbackCache with Redis configured", CacheManager)
+	}
+	if fc.IsPrimaryHealthy() {
+		t.Error("primary must be unhealthy with Redis unreachable")
+	}
+	if !fc.IsHealthy() {
+		t.Error("fallback memory cache must keep the manager healthy")
+	}
+	_ = fc.Close()
+}

--- a/internal/handlers/health_test.go
+++ b/internal/handlers/health_test.go
@@ -1,0 +1,156 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
+)
+
+// healthStubCache is a Cache with scripted health, standing in for the Redis
+// primary inside a FallbackCache.
+type healthStubCache struct {
+	healthy bool
+}
+
+func (s *healthStubCache) Get(ctx context.Context, key string) (utils.CacheResult, error) {
+	return utils.CacheResult{Found: false}, nil
+}
+
+func (s *healthStubCache) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
+	return nil
+}
+
+func (s *healthStubCache) IsHealthy() bool { return s.healthy }
+
+func saveCacheGlobals(t *testing.T) {
+	t.Helper()
+	oldManager, oldRequire := config.CacheManager, config.RequireRedis
+	t.Cleanup(func() {
+		config.CacheManager, config.RequireRedis = oldManager, oldRequire
+	})
+}
+
+func decodeHealth(t *testing.T, w *httptest.ResponseRecorder) HealthStatus {
+	t.Helper()
+	var status HealthStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &status); err != nil {
+		t.Fatalf("response is not JSON: %v (%q)", err, w.Body.String())
+	}
+	return status
+}
+
+func TestGetCacheCheckNotInitialized(t *testing.T) {
+	saveCacheGlobals(t)
+	config.CacheManager = nil
+
+	check, ok := getCacheCheck()
+	if ok || check.Status != "fail" {
+		t.Errorf("uninitialized cache: check = %+v ok=%v, want fail/false", check, ok)
+	}
+
+	// /ready must report unavailable before the cache manager exists.
+	config.RequireRedis = false
+	w := httptest.NewRecorder()
+	HandleReady(w, httptest.NewRequest("GET", "/ready", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("/ready = %d, want 503 with no cache manager", w.Code)
+	}
+}
+
+func TestGetCacheCheckMemoryOnly(t *testing.T) {
+	saveCacheGlobals(t)
+	mc := utils.NewMemoryCache(4, time.Minute)
+	t.Cleanup(func() { _ = mc.Close() })
+	config.CacheManager = mc
+
+	check, ok := getCacheCheck()
+	if !ok || check.Status != "ok" || check.Message != "memory" {
+		t.Errorf("memory-only: check = %+v ok=%v, want ok/memory", check, ok)
+	}
+	if isRedisHealthy() {
+		t.Error("memory-only mode must never report Redis as healthy")
+	}
+}
+
+func TestGetCacheCheckRedisHealthy(t *testing.T) {
+	saveCacheGlobals(t)
+	mc := utils.NewMemoryCache(4, time.Minute)
+	t.Cleanup(func() { _ = mc.Close() })
+	config.CacheManager = utils.NewFallbackCache(&healthStubCache{healthy: true}, mc)
+
+	check, ok := getCacheCheck()
+	if !ok || check.Message != "redis" {
+		t.Errorf("healthy redis: check = %+v ok=%v, want ok/redis", check, ok)
+	}
+
+	w := httptest.NewRecorder()
+	HandleHealth(w, httptest.NewRequest("GET", "/health", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("/health = %d, want 200", w.Code)
+	}
+	if status := decodeHealth(t, w); status.Checks["cache"].Message != "redis" {
+		t.Errorf("/health cache check = %+v, want redis", status.Checks["cache"])
+	}
+}
+
+func TestHandleReadyRequireRedisUnavailable(t *testing.T) {
+	saveCacheGlobals(t)
+	mc := utils.NewMemoryCache(4, time.Minute)
+	t.Cleanup(func() { _ = mc.Close() })
+	config.CacheManager = utils.NewFallbackCache(&healthStubCache{healthy: false}, mc)
+	config.RequireRedis = true
+
+	w := httptest.NewRecorder()
+	HandleReady(w, httptest.NewRequest("GET", "/ready", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready = %d, want 503 when required Redis is down", w.Code)
+	}
+	status := decodeHealth(t, w)
+	if status.Status != "unavailable" || status.Checks["cache"].Status != "fail" {
+		t.Errorf("/ready body = %+v, want unavailable with failed cache check", status)
+	}
+}
+
+func TestGetCapacityCheckAtLimit(t *testing.T) {
+	oldLimiter, oldLimit := config.ConcurrencyLimiter, config.RateLimit
+	t.Cleanup(func() {
+		config.ConcurrencyLimiter, config.RateLimit = oldLimiter, oldLimit
+	})
+
+	config.RateLimit = 1
+	config.ConcurrencyLimiter = make(chan struct{}, 1)
+
+	if check := getCapacityCheck(); check.Status != "ok" {
+		t.Errorf("idle: check = %+v, want ok", check)
+	}
+
+	config.ConcurrencyLimiter <- struct{}{}
+	if check := getCapacityCheck(); check.Status != "warning" {
+		t.Errorf("at limit: check = %+v, want warning", check)
+	}
+}
+
+func TestHandleInfoIncludesBuildInfo(t *testing.T) {
+	oldBuild, oldCommit := config.BuildTime, config.GitCommit
+	t.Cleanup(func() { config.BuildTime, config.GitCommit = oldBuild, oldCommit })
+
+	config.BuildTime = "2026-01-02T03:04:05Z"
+	config.GitCommit = "abc1234"
+
+	w := httptest.NewRecorder()
+	HandleInfo(w, httptest.NewRequest("GET", "/info", nil))
+
+	var info RuntimeInfo
+	if err := json.Unmarshal(w.Body.Bytes(), &info); err != nil {
+		t.Fatalf("response is not JSON: %v", err)
+	}
+	if info.BuildTime != "2026-01-02T03:04:05Z" || info.GitCommit != "abc1234" {
+		t.Errorf("info = %+v, want stamped build time and commit", info)
+	}
+}

--- a/internal/serverlist/bootstrap_fetch_test.go
+++ b/internal/serverlist/bootstrap_fetch_test.go
@@ -1,0 +1,187 @@
+package serverlist
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFetchBootstrapParsesServices(t *testing.T) {
+	// One well-formed service with an HTTPS alternative, plus every malformed
+	// service shape the parser must skip without failing the whole file.
+	body := `{"services":[
+		[["com","net"],["http://insecure.example/","https://secure.example/rdap/"]],
+		[["tooshort"]],
+		[[123],["https://badids.example/"]],
+		[["badurls"],"not-an-array"],
+		[["nourls"],[]],
+		[["httponly"],["http://plain.example/"]]
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	got, err := fetchBootstrap(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetchBootstrap: %v", err)
+	}
+
+	want := map[string]string{
+		"com":      "https://secure.example/rdap/", // HTTPS preferred over first URL
+		"net":      "https://secure.example/rdap/",
+		"httponly": "http://plain.example/", // no HTTPS available: first URL
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d entries (%v), want %d", len(got), got, len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestFetchBootstrapErrors(t *testing.T) {
+	newServer := func(handler http.HandlerFunc) *httptest.Server {
+		srv := httptest.NewServer(handler)
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("non-200 status", func(t *testing.T) {
+		srv := newServer(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		if _, err := fetchBootstrap(context.Background(), srv.Client(), srv.URL); err == nil || !strings.Contains(err.Error(), "unexpected status") {
+			t.Errorf("err = %v, want unexpected status", err)
+		}
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		srv := newServer(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("{not json"))
+		})
+		if _, err := fetchBootstrap(context.Background(), srv.Client(), srv.URL); err == nil {
+			t.Error("want JSON decode error")
+		}
+	})
+
+	t.Run("oversized response", func(t *testing.T) {
+		srv := newServer(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write(make([]byte, maxBootstrapResponseSize+1))
+		})
+		if _, err := fetchBootstrap(context.Background(), srv.Client(), srv.URL); err == nil || !strings.Contains(err.Error(), "exceeds") {
+			t.Errorf("err = %v, want size limit error", err)
+		}
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		if _, err := fetchBootstrap(context.Background(), http.DefaultClient, "://bad"); err == nil {
+			t.Error("want request creation error")
+		}
+	})
+
+	t.Run("unreachable server", func(t *testing.T) {
+		srv := newServer(func(w http.ResponseWriter, r *http.Request) {})
+		url := srv.URL
+		srv.Close()
+		if _, err := fetchBootstrap(context.Background(), http.DefaultClient, url); err == nil {
+			t.Error("want connection error")
+		}
+	})
+}
+
+// swapBootstrapURLs points every IANA category at test URLs and restores the
+// real ones on cleanup.
+func swapBootstrapURLs(t *testing.T, urls map[string]string) {
+	t.Helper()
+	old := ianaBootstrapURLs
+	ianaBootstrapURLs = urls
+	t.Cleanup(func() { ianaBootstrapURLs = old })
+}
+
+func TestFetchIANAPartialFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			_, _ = w.Write([]byte(`{"services":[[["example"],["https://ok.example/rdap/"]]]}`))
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	swapBootstrapURLs(t, map[string]string{
+		"dns":  srv.URL + "/ok",
+		"ipv4": srv.URL + "/ok",
+		"ipv6": srv.URL + "/broken",
+		"asn":  srv.URL + "/broken",
+	})
+
+	perCategory, failed := FetchIANA(context.Background(), srv.Client())
+
+	for _, want := range []string{"dns", "ipv4"} {
+		if data, ok := perCategory[want]; !ok || data["example"] != "https://ok.example/rdap/" {
+			t.Errorf("category %s = %v, want fetched data", want, data)
+		}
+	}
+	sort.Strings(failed)
+	if len(failed) != 2 || failed[0] != "asn" || failed[1] != "ipv6" {
+		t.Errorf("failed = %v, want [asn ipv6]", failed)
+	}
+}
+
+func TestStartBootstrapRefreshDisabled(t *testing.T) {
+	// interval <= 0 must be a no-op: no goroutine, no fetch.
+	swapBootstrapURLs(t, map[string]string{"dns": "http://must-not-be-called.invalid/"})
+	StartBootstrapRefresh(context.Background(), http.DefaultClient, 0)
+}
+
+func TestStartBootstrapRefreshUpdatesIndex(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/broken" {
+			// One permanently failing category exercises the partial-update path.
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"services":[[["zzrefresh"],["https://refresh.example/rdap/"]]]}`))
+	}))
+
+	swapBootstrapURLs(t, map[string]string{
+		"dns":  srv.URL + "/ok",
+		"ipv4": srv.URL + "/ok",
+		"ipv6": srv.URL + "/ok",
+		"asn":  srv.URL + "/broken",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() {
+		cancel()
+		// Let an in-flight refresh finish before URLs are restored and the
+		// index is reset.
+		time.Sleep(50 * time.Millisecond)
+		srv.Close()
+		UpdateFromIANA(nil)
+	})
+
+	StartBootstrapRefresh(ctx, srv.Client(), 25*time.Millisecond)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if url, ok := LookupRdapServer("zzrefresh"); ok {
+			if url != "https://refresh.example/rdap/" {
+				t.Fatalf("zzrefresh = %q, want refreshed URL", url)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("bootstrap refresh never updated the index")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/utils/cache_interface_more_test.go
+++ b/internal/utils/cache_interface_more_test.go
@@ -1,0 +1,223 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// stubCache is a Cache whose health, contents and errors are scripted, so
+// FallbackCache routing can be asserted without a real backend.
+type stubCache struct {
+	healthy bool
+	data    map[string]string
+	setErr  error
+	sets    int
+	closed  int
+}
+
+func (s *stubCache) Get(ctx context.Context, key string) (CacheResult, error) {
+	if v, ok := s.data[key]; ok {
+		return CacheResult{Data: v, Found: true}, nil
+	}
+	return CacheResult{Found: false}, nil
+}
+
+func (s *stubCache) Set(ctx context.Context, key string, value string, expiration time.Duration) error {
+	s.sets++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	if s.data == nil {
+		s.data = make(map[string]string)
+	}
+	s.data[key] = value
+	return nil
+}
+
+func (s *stubCache) IsHealthy() bool { return s.healthy }
+
+func (s *stubCache) Close() error {
+	s.closed++
+	return nil
+}
+
+func TestMemoryCacheLRUEviction(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryCache(2, time.Hour)
+	defer func() { _ = cache.Close() }()
+
+	mustSet := func(k, v string) {
+		t.Helper()
+		if err := cache.Set(ctx, k, v, time.Hour); err != nil {
+			t.Fatalf("Set(%q): %v", k, err)
+		}
+	}
+
+	mustSet("a", "1")
+	mustSet("b", "2")
+
+	// Touch "a" so "b" becomes the least recently used entry.
+	if r, _ := cache.Get(ctx, "a"); !r.Found {
+		t.Fatal("expected hit for a")
+	}
+
+	// Inserting at capacity must evict the LRU entry ("b"), not "a".
+	mustSet("c", "3")
+	if r, _ := cache.Get(ctx, "b"); r.Found {
+		t.Error("b should have been evicted as least recently used")
+	}
+	if r, _ := cache.Get(ctx, "a"); !r.Found {
+		t.Error("a was recently used and must survive eviction")
+	}
+	if r, _ := cache.Get(ctx, "c"); !r.Found {
+		t.Error("newly inserted c must be present")
+	}
+
+	// Updating an existing key at capacity replaces in place: no eviction.
+	mustSet("a", "1-updated")
+	if r, _ := cache.Get(ctx, "a"); !r.Found || r.Data != "1-updated" {
+		t.Errorf("a = %+v, want updated value", r)
+	}
+	if r, _ := cache.Get(ctx, "c"); !r.Found {
+		t.Error("updating a must not evict c")
+	}
+}
+
+func TestMemoryCacheCleanExpired(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryCache(10, time.Hour) // cleaner ticker never fires in-test
+	defer func() { _ = cache.Close() }()
+
+	if err := cache.Set(ctx, "live", "v", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Set(ctx, "dead1", "v", time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.Set(ctx, "dead2", "v", time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * time.Millisecond)
+
+	cache.cleanExpired()
+
+	cache.mu.Lock()
+	n := len(cache.items)
+	cache.mu.Unlock()
+	if n != 1 {
+		t.Errorf("after cleanExpired: %d entries, want 1 (only the live one)", n)
+	}
+	if r, _ := cache.Get(ctx, "live"); !r.Found {
+		t.Error("live entry must survive the sweep")
+	}
+}
+
+func TestMemoryCacheCleanerLoop(t *testing.T) {
+	ctx := context.Background()
+	cache := NewMemoryCache(10, 20*time.Millisecond)
+	defer func() { _ = cache.Close() }()
+
+	if err := cache.Set(ctx, "dead", "v", time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+
+	// The background cleaner (not a lazy Get) must remove the expired entry.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		cache.mu.Lock()
+		n := len(cache.items)
+		cache.mu.Unlock()
+		if n == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("background cleaner did not remove the expired entry in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestMemoryCacheCloseIdempotent(t *testing.T) {
+	cache := NewMemoryCache(10, time.Hour)
+	if err := cache.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := cache.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestFallbackCacheUnhealthyPrimary(t *testing.T) {
+	ctx := context.Background()
+	primary := &stubCache{healthy: false, data: map[string]string{"k": "from-primary"}}
+	fallback := &stubCache{healthy: true, data: map[string]string{"k": "from-fallback"}}
+	fc := NewFallbackCache(primary, fallback)
+
+	// An unhealthy primary must be bypassed entirely, even when it has the key.
+	r, err := fc.Get(ctx, "k")
+	if err != nil || !r.Found || r.Data != "from-fallback" {
+		t.Errorf("Get = %+v, %v; want fallback value", r, err)
+	}
+
+	// Set must skip the unhealthy primary and still write the fallback.
+	if err := fc.Set(ctx, "new", "v", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if primary.sets != 0 {
+		t.Errorf("primary received %d writes while unhealthy, want 0", primary.sets)
+	}
+	if _, ok := fallback.data["new"]; !ok {
+		t.Error("fallback missed the write")
+	}
+
+	if !fc.IsHealthy() {
+		t.Error("FallbackCache must report healthy while the fallback is healthy")
+	}
+	if fc.IsPrimaryHealthy() {
+		t.Error("IsPrimaryHealthy must reflect the unhealthy primary")
+	}
+}
+
+func TestFallbackCachePrimaryMissFallsThrough(t *testing.T) {
+	ctx := context.Background()
+	// Healthy but empty primary: entries written to memory during a Redis
+	// outage must still be served after Redis recovers (documented behavior).
+	primary := &stubCache{healthy: true}
+	fallback := &stubCache{healthy: true, data: map[string]string{"k": "survived"}}
+	fc := NewFallbackCache(primary, fallback)
+
+	r, err := fc.Get(ctx, "k")
+	if err != nil || !r.Found || r.Data != "survived" {
+		t.Errorf("Get = %+v, %v; want fall-through to fallback on primary miss", r, err)
+	}
+}
+
+func TestFallbackCacheSetPrimaryError(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("primary write failed")
+	primary := &stubCache{healthy: true, setErr: wantErr}
+	fallback := &stubCache{healthy: true}
+	fc := NewFallbackCache(primary, fallback)
+
+	if err := fc.Set(ctx, "k", "v", time.Minute); !errors.Is(err, wantErr) {
+		t.Errorf("Set error = %v, want primary error", err)
+	}
+	if _, ok := fallback.data["k"]; !ok {
+		t.Error("fallback must be written even when the primary write fails")
+	}
+}
+
+func TestFallbackCacheClose(t *testing.T) {
+	primary := &stubCache{healthy: true}
+	fallback := &stubCache{healthy: true}
+	fc := NewFallbackCache(primary, fallback)
+
+	if err := fc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if primary.closed != 1 || fallback.closed != 1 {
+		t.Errorf("closed counts = %d/%d, want 1/1", primary.closed, fallback.closed)
+	}
+}

--- a/internal/utils/log_handler_test.go
+++ b/internal/utils/log_handler_test.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// logLine emits one Info record through logger and decodes the JSON output.
+func logLine(t *testing.T, buf *bytes.Buffer, logger *slog.Logger, ctx context.Context) map[string]any {
+	t.Helper()
+	buf.Reset()
+	logger.InfoContext(ctx, "msg")
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("log output is not JSON: %v (%q)", err, buf.String())
+	}
+	return m
+}
+
+func TestContextHandlerAddsRequestAttributes(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	ctx := WithClient(WithRequestID(context.Background(), "req-123"), "acme")
+	m := logLine(t, &buf, logger, ctx)
+	if m["request_id"] != "req-123" {
+		t.Errorf("request_id = %v, want req-123", m["request_id"])
+	}
+	if m["client"] != "acme" {
+		t.Errorf("client = %v, want acme", m["client"])
+	}
+
+	// A bare context must not produce empty correlation attributes.
+	m = logLine(t, &buf, logger, context.Background())
+	if _, ok := m["request_id"]; ok {
+		t.Error("request_id present without one in the context")
+	}
+}
+
+func TestContextHandlerWithAttrsKeepsExtraction(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	// WithAttrs must return a ContextHandler, not the bare inner handler —
+	// otherwise request-id extraction silently stops after logger.With().
+	derived := logger.With("component", "test")
+	ctx := WithRequestID(context.Background(), "req-456")
+	m := logLine(t, &buf, derived, ctx)
+	if m["component"] != "test" {
+		t.Errorf("component = %v, want test", m["component"])
+	}
+	if m["request_id"] != "req-456" {
+		t.Errorf("request_id = %v, want req-456 after With()", m["request_id"])
+	}
+}
+
+func TestContextHandlerWithGroupKeepsExtraction(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(NewContextHandler(slog.NewJSONHandler(&buf, nil)))
+
+	derived := logger.WithGroup("grp")
+	ctx := WithRequestID(context.Background(), "req-789")
+	buf.Reset()
+	derived.InfoContext(ctx, "msg")
+	// The record attr lands inside the open group; asserting on the raw JSON
+	// avoids coupling the test to slog's group nesting layout.
+	if !strings.Contains(buf.String(), "req-789") {
+		t.Errorf("output %q lost the request id after WithGroup()", buf.String())
+	}
+}

--- a/internal/utils/redis_cache_test.go
+++ b/internal/utils/redis_cache_test.go
@@ -1,0 +1,293 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// fakeRedisServer speaks just enough RESP2 for the go-redis client: HELLO is
+// rejected so the client downgrades from RESP3, PING/GET/SET behave, and any
+// command can be scripted to fail so error paths are reachable without a
+// real Redis.
+type fakeRedisServer struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	data     map[string]string
+	failCmds map[string]bool
+}
+
+func newFakeRedisServer(t *testing.T) *fakeRedisServer {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	s := &fakeRedisServer{
+		ln:       ln,
+		data:     make(map[string]string),
+		failCmds: make(map[string]bool),
+	}
+	go s.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return s
+}
+
+func (s *fakeRedisServer) addr() string { return s.ln.Addr().String() }
+
+func (s *fakeRedisServer) setFail(cmd string, fail bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failCmds[strings.ToUpper(cmd)] = fail
+}
+
+func (s *fakeRedisServer) serve() {
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *fakeRedisServer) handleConn(conn net.Conn) {
+	defer func() { _ = conn.Close() }()
+	r := bufio.NewReader(conn)
+	for {
+		args, err := readRESPCommand(r)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			continue
+		}
+		cmd := strings.ToUpper(args[0])
+
+		s.mu.Lock()
+		fail := s.failCmds[cmd]
+		s.mu.Unlock()
+		if fail {
+			fmt.Fprintf(conn, "-ERR scripted failure for %s\r\n", cmd)
+			continue
+		}
+
+		switch cmd {
+		case "HELLO":
+			// Force the client down to RESP2, like pre-6.0 servers.
+			fmt.Fprintf(conn, "-ERR unknown command 'HELLO'\r\n")
+		case "PING":
+			fmt.Fprintf(conn, "+PONG\r\n")
+		case "GET":
+			s.mu.Lock()
+			v, ok := s.data[args[1]]
+			s.mu.Unlock()
+			if ok {
+				fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(v), v)
+			} else {
+				fmt.Fprintf(conn, "$-1\r\n")
+			}
+		case "SET":
+			s.mu.Lock()
+			s.data[args[1]] = args[2]
+			s.mu.Unlock()
+			fmt.Fprintf(conn, "+OK\r\n")
+		default:
+			// CLIENT SETINFO, SELECT, ... — acknowledge and move on.
+			fmt.Fprintf(conn, "+OK\r\n")
+		}
+	}
+}
+
+// readRESPCommand parses one client command (an array of bulk strings).
+func readRESPCommand(r *bufio.Reader) ([]string, error) {
+	line, err := respLine(r)
+	if err != nil {
+		return nil, err
+	}
+	if len(line) == 0 || line[0] != '*' {
+		return nil, fmt.Errorf("unexpected line %q", line)
+	}
+	n, err := strconv.Atoi(line[1:])
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		bulk, err := respLine(r)
+		if err != nil {
+			return nil, err
+		}
+		if len(bulk) == 0 || bulk[0] != '$' {
+			return nil, fmt.Errorf("unexpected bulk header %q", bulk)
+		}
+		l, err := strconv.Atoi(bulk[1:])
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, l+2) // payload + trailing \r\n
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf[:l]))
+	}
+	return args, nil
+}
+
+func respLine(r *bufio.Reader) (string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func newTestRedisCache(t *testing.T, addr string) *RedisCache {
+	t.Helper()
+	client := redis.NewClient(&redis.Options{
+		Addr:        addr,
+		DialTimeout: time.Second,
+		ReadTimeout: time.Second,
+		MaxRetries:  -1,
+	})
+	t.Cleanup(func() { _ = client.Close() })
+	rc := NewRedisCache(client)
+	t.Cleanup(func() { _ = rc.Close() })
+	return rc
+}
+
+func TestRedisCacheBasic(t *testing.T) {
+	ctx := context.Background()
+	s := newFakeRedisServer(t)
+	rc := newTestRedisCache(t, s.addr())
+
+	if !rc.IsHealthy() {
+		t.Fatal("cache must be healthy after a successful initial ping")
+	}
+
+	r, err := rc.Get(ctx, "missing")
+	if err != nil || r.Found {
+		t.Errorf("Get(missing) = %+v, %v; want clean miss", r, err)
+	}
+
+	if err := rc.Set(ctx, "k", "v", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	r, err = rc.Get(ctx, "k")
+	if err != nil || !r.Found || r.Data != "v" {
+		t.Errorf("Get(k) = %+v, %v; want hit with v", r, err)
+	}
+}
+
+func TestRedisCacheErrorFlipsHealth(t *testing.T) {
+	ctx := context.Background()
+	s := newFakeRedisServer(t)
+	rc := newTestRedisCache(t, s.addr())
+
+	// A server-side GET error must mark the connection unhealthy.
+	s.setFail("GET", true)
+	if _, err := rc.Get(ctx, "k"); err == nil {
+		t.Fatal("expected error from scripted GET failure")
+	}
+	if rc.IsHealthy() {
+		t.Fatal("a Redis error must flip the health flag off")
+	}
+
+	// While unhealthy, Get short-circuits to a miss and Set is a silent no-op.
+	if r, err := rc.Get(ctx, "k"); err != nil || r.Found {
+		t.Errorf("unhealthy Get = %+v, %v; want silent miss", r, err)
+	}
+	if err := rc.Set(ctx, "k", "v", time.Minute); err != nil {
+		t.Errorf("unhealthy Set = %v; want silent nil", err)
+	}
+
+	// A later health check against a recovered server restores service.
+	s.setFail("GET", false)
+	rc.checkHealth(false)
+	if !rc.IsHealthy() {
+		t.Fatal("health must recover after a successful ping")
+	}
+
+	// SET errors flip health too.
+	s.setFail("SET", true)
+	if err := rc.Set(ctx, "k", "v", time.Minute); err == nil {
+		t.Fatal("expected error from scripted SET failure")
+	}
+	if rc.IsHealthy() {
+		t.Error("a SET error must flip the health flag off")
+	}
+}
+
+func TestRedisCacheHealthLostAndRestored(t *testing.T) {
+	s := newFakeRedisServer(t)
+	rc := newTestRedisCache(t, s.addr())
+
+	s.setFail("PING", true)
+	rc.checkHealth(false) // "connection lost" transition
+	if rc.IsHealthy() {
+		t.Fatal("failed ping must mark the cache unhealthy")
+	}
+
+	s.setFail("PING", false)
+	rc.checkHealth(false) // "connection restored" transition
+	if !rc.IsHealthy() {
+		t.Fatal("successful ping must mark the cache healthy again")
+	}
+}
+
+func TestRedisCacheCancelledContextKeepsHealth(t *testing.T) {
+	s := newFakeRedisServer(t)
+	rc := newTestRedisCache(t, s.addr())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// One caller's aborted request must not poison the shared health flag.
+	if _, err := rc.Get(ctx, "k"); err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !rc.IsHealthy() {
+		t.Error("cancelled Get must not flip health")
+	}
+	if err := rc.Set(ctx, "k", "v", time.Minute); err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !rc.IsHealthy() {
+		t.Error("cancelled Set must not flip health")
+	}
+}
+
+func TestRedisCacheUnavailableAtStart(t *testing.T) {
+	// Grab a port that refuses connections.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	_ = ln.Close()
+
+	rc := newTestRedisCache(t, addr)
+	if rc.IsHealthy() {
+		t.Fatal("cache must start unhealthy when Redis is unreachable")
+	}
+}
+
+func TestRedisCacheCloseIdempotent(t *testing.T) {
+	s := newFakeRedisServer(t)
+	rc := newTestRedisCache(t, s.addr())
+	if err := rc.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := rc.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/internal/utils/redis_cache_test.go
+++ b/internal/utils/redis_cache_test.go
@@ -77,33 +77,33 @@ func (s *fakeRedisServer) handleConn(conn net.Conn) {
 		fail := s.failCmds[cmd]
 		s.mu.Unlock()
 		if fail {
-			fmt.Fprintf(conn, "-ERR scripted failure for %s\r\n", cmd)
+			_, _ = fmt.Fprintf(conn, "-ERR scripted failure for %s\r\n", cmd)
 			continue
 		}
 
 		switch cmd {
 		case "HELLO":
 			// Force the client down to RESP2, like pre-6.0 servers.
-			fmt.Fprintf(conn, "-ERR unknown command 'HELLO'\r\n")
+			_, _ = fmt.Fprintf(conn, "-ERR unknown command 'HELLO'\r\n")
 		case "PING":
-			fmt.Fprintf(conn, "+PONG\r\n")
+			_, _ = fmt.Fprintf(conn, "+PONG\r\n")
 		case "GET":
 			s.mu.Lock()
 			v, ok := s.data[args[1]]
 			s.mu.Unlock()
 			if ok {
-				fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(v), v)
+				_, _ = fmt.Fprintf(conn, "$%d\r\n%s\r\n", len(v), v)
 			} else {
-				fmt.Fprintf(conn, "$-1\r\n")
+				_, _ = fmt.Fprintf(conn, "$-1\r\n")
 			}
 		case "SET":
 			s.mu.Lock()
 			s.data[args[1]] = args[2]
 			s.mu.Unlock()
-			fmt.Fprintf(conn, "+OK\r\n")
+			_, _ = fmt.Fprintf(conn, "+OK\r\n")
 		default:
 			// CLIENT SETINFO, SELECT, ... — acknowledge and move on.
-			fmt.Fprintf(conn, "+OK\r\n")
+			_, _ = fmt.Fprintf(conn, "+OK\r\n")
 		}
 	}
 }

--- a/main_maxbytes_test.go
+++ b/main_maxbytes_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KincaidYang/whois/internal/config"
+)
+
+// TestMaxBytes verifies the body-size wrapper: requests under the cap pass
+// through untouched, oversized ones fail at read time so a handler can never
+// buffer an unbounded body.
+func TestMaxBytes(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.ReadAll(r.Body); err != nil {
+			http.Error(w, "body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	h := maxBytes(inner, 8)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/mcp", strings.NewReader("small")))
+	if w.Code != http.StatusOK {
+		t.Errorf("body under limit: got %d, want 200", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/mcp", strings.NewReader("definitely more than eight bytes")))
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("body over limit: got %d, want 413", w.Code)
+	}
+}
+
+// TestBatchHandlerConcurrencyLimit verifies /batch competes for the same
+// concurrency slots as single queries and is rejected with 429 when they are
+// exhausted.
+func TestBatchHandlerConcurrencyLimit(t *testing.T) {
+	n := cap(config.ConcurrencyLimiter)
+	for i := 0; i < n; i++ {
+		config.ConcurrencyLimiter <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < n; i++ {
+			<-config.ConcurrencyLimiter
+		}
+	}()
+
+	req := httptest.NewRequest("POST", "/batch", strings.NewReader(`{"queries":["example.com"]}`))
+	w := httptest.NewRecorder()
+	batchHandler(w, req)
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected 429 with concurrency slots exhausted, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## 变更

纯测试补充，产品代码零改动。语句覆盖率 83.2% → **91.5%**，Codecov 行覆盖口径预计 79% → ~87%（把 awesome-go 审查者会看到的那个数字顶过 80% 线）。

按包：

- **utils/MemoryCache**：LRU 淘汰顺序、容量满时原地更新不误淘汰、过期清扫（直接调用 + 后台 cleaner 两条路径）、Close 幂等
- **utils/FallbackCache**：主缓存不健康时绕过（即使主缓存有数据）、主 miss 落到 fallback（Redis 恢复后内存数据仍可服务的既有语义）、主写失败错误上抛且 fallback 仍写入、Close 扇出
- **utils/RedisCache**：测试内起了一个 ~100 行的极简 RESP2 假服务器（拒绝 HELLO 迫使客户端降级，不引入新依赖），覆盖：服务端错误翻转健康位、不健康时 Get 静默 miss / Set 静默跳过、**调用方 ctx 取消不得污染共享健康位**（这是当初修过的行为，现在有回归保护）、lost/restored 两个状态迁移、启动时 Redis 不可达
- **utils/ContextHandler**：WithAttrs/WithGroup 之后 request_id/client 提取不丢（曾经典型的 wrapper 退化 bug 形态）
- **serverlist**：fetchBootstrap 解析（HTTPS 优先、各种畸形 service 条目逐个跳过、2 MiB 上限、非 200、坏 JSON、连接失败）、FetchIANA 部分失败归类、StartBootstrapRefresh 的 interval<=0 守卫和真实刷新循环（含 partial 路径）
- **config**：overrideConfigWithEnv 全字段扫描、**WHOIS_REDIS_ADDR 显式空清空烘焙地址**（LookupEnv 语义，PR #49 Codex 意见的回归保护）、非法数字忽略、initLogger 四档、readConfigFile 查找顺序与非 NotExist 错误即停、initVersionInfo 默认值、cache manager 纯内存/Redis 宕机回退两分支
- **handlers**：/health /ready 的缓存四态（未初始化、纯内存、redis 健康、requireRedis+宕机→503）、容量到顶 warning、/info 带构建信息
- **main**：maxBytes 包装器（超限 body 读取报错）、/batch 并发槽耗尽 429

## 验证

- `go test ./...` 全绿，`go vet` / `gofmt` 干净
- 无新增依赖；假 RESP 服务器仅存在于测试文件

🤖 Generated with [Claude Code](https://claude.com/claude-code)