### PR TITLE
fix: 404 for serverless TLDs, canonical IP cache keys, isolated refresh flights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in flight for the same resource: the caller asked for a forced upstream
   fetch, but could be handed a result it did not force while the response
   still reported `X-Cache: REFRESH`. Concurrent refreshes still share one
-  upstream query with each other.
+  upstream query with each other, and a refresh owns the cache entry while it
+  runs: an ordinary query overlapping it no longer writes that entry, so its
+  older result — or its not-found marker — cannot land on top of the refreshed
+  one and be served for a full TTL.
 - A deduplicated upstream query whose waiters all disconnect now holds exactly
   one concurrency slot, no matter how many waiters canceled. Previously every
   canceled waiter transferred its own slot to the same shared flight, so many

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   when authentication is enabled, matching the query endpoints.
 
 ### Fixed
+- A domain whose TLD has neither a WHOIS nor an RDAP server now answers `404`
+  (`not-found`) instead of `500`. Having no server for a TLD is an answer about
+  the requested resource, not a server-side failure, and reporting it as one
+  put ordinary junk requests (`/favicon.ico`) into the 5xx metrics; the
+  `?raw` path already answered `404` for the same condition.
+- Equivalent spellings of one IP address or prefix now share a single cache
+  entry and a single upstream query: addresses and prefixes are canonicalized
+  before use (`2001:0db8:0:0:0:0:0:1` → `2001:db8::1`), and a prefix's host
+  bits are masked off (`192.0.2.5/24` → `192.0.2.0/24`), which is also the
+  network RFC 9082 defines the `ip` query to name.
+- `?refresh` queries no longer attach to a regular deduplicated query already
+  in flight for the same resource: the caller asked for a forced upstream
+  fetch, but could be handed a result it did not force while the response
+  still reported `X-Cache: REFRESH`. Concurrent refreshes still share one
+  upstream query with each other.
 - A deduplicated upstream query whose waiters all disconnect now holds exactly
   one concurrency slot, no matter how many waiters canceled. Previously every
   canceled waiter transferred its own slot to the same shared flight, so many

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -20,6 +20,10 @@ present, is human-readable context that may change between releases.
 registry returned no data for it. Not-found results are negatively cached for
 a short time (`cache.negativeExpiration`, default 60s).
 
+The same status is returned when the query is well-formed but this service
+knows no WHOIS or RDAP server for its TLD — the TLD is not in the root zone,
+or its registry publishes neither service.
+
 ## query-denied
 
 **Status: 403.** The upstream registry refused to answer the query (some

--- a/internal/handlers/asn.go
+++ b/internal/handlers/asn.go
@@ -53,7 +53,7 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 	serverURL, _ := serverlist.LookupASNKey(asnInt)
 
 	// Query and parse the RDAP information, deduplicating concurrent misses
-	outcome, err := dedupedQuery(ctx, key, func(qctx context.Context) (queryOutcome, error) {
+	outcome, err := dedupedQuery(ctx, key, refresh, func(qctx context.Context) (queryOutcome, error) {
 		queryResult, err := rdap.RDAPQueryASN(qctx, asn, serverURL)
 		if err != nil {
 			return queryOutcome{}, err

--- a/internal/handlers/asn.go
+++ b/internal/handlers/asn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -69,11 +68,7 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 			return queryOutcome{}, err
 		}
 
-		result := string(resultBytes)
-		if err := utils.SetToCache(qctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
-			slog.WarnContext(qctx, "cache write error", "key", key, "err", err)
-		}
-		return queryOutcome{body: result, contentType: "application/json"}, nil
+		return queryOutcome{body: string(resultBytes), contentType: "application/json"}, nil
 	})
 	if err != nil {
 		utils.HandleQueryError(ctx, w, err)

--- a/internal/handlers/batch.go
+++ b/internal/handlers/batch.go
@@ -176,16 +176,16 @@ func batchDeadlineItem(query string) BatchItem {
 // query (cache, singleflight and negative caching all apply).
 func runBatchItem(ctx context.Context, query string) BatchItem {
 	item := BatchItem{Query: query}
-	normalized := strings.ToLower(strings.TrimSpace(query))
+	kind, resource := utils.ClassifyResource(strings.ToLower(strings.TrimSpace(query)))
 
 	rc := NewResponseCapture()
-	switch {
-	case utils.IsIP(normalized) || utils.IsCIDR(normalized):
-		HandleIP(ctx, rc, normalized, CacheKeyPrefix, false)
-	case utils.IsASN(normalized):
-		HandleASN(ctx, rc, normalized, CacheKeyPrefix, false)
-	case utils.IsDomain(normalized):
-		HandleDomain(ctx, rc, normalized, CacheKeyPrefix, false, false)
+	switch kind {
+	case utils.KindIP:
+		HandleIP(ctx, rc, resource, CacheKeyPrefix, false)
+	case utils.KindASN:
+		HandleASN(ctx, rc, resource, CacheKeyPrefix, false)
+	case utils.KindDomain:
+		HandleDomain(ctx, rc, resource, CacheKeyPrefix, false, false)
 	default:
 		utils.HandleHTTPError(rc, utils.ErrorTypeBadRequest, "Invalid input. Please provide a valid domain, IP, or ASN.")
 	}

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -158,11 +158,14 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 			return queryWhoisDomain(qctx, domain, tld, key)
 		}
 	} else {
-		utils.HandleHTTPError(w, utils.ErrorTypeInternalServer, "No WHOIS or RDAP server known for TLD: "+tld)
+		// Nothing to query for this TLD: that is an answer about the requested
+		// resource, not a server-side failure, so it must not be reported as
+		// one (the ?raw path above answers the same way).
+		utils.HandleHTTPError(w, utils.ErrorTypeNotFound, "No WHOIS or RDAP server known for TLD: "+tld)
 		return
 	}
 
-	outcome, err := dedupedQuery(ctx, key, query)
+	outcome, err := dedupedQuery(ctx, key, refresh, query)
 	if err != nil {
 		utils.HandleQueryError(ctx, w, err)
 		return

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
 
@@ -147,15 +146,15 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 			return
 		}
 		query = func(qctx context.Context) (queryOutcome, error) {
-			return queryWhoisRaw(qctx, domain, tld, key)
+			return queryWhoisRaw(qctx, domain, tld)
 		}
 	} else if _, ok := serverlist.LookupRdapServer(tld); ok {
 		query = func(qctx context.Context) (queryOutcome, error) {
-			return queryRDAPDomain(qctx, domain, tld, key)
+			return queryRDAPDomain(qctx, domain, tld)
 		}
 	} else if _, ok := serverlist.TLDToWhoisServer[tld]; ok {
 		query = func(qctx context.Context) (queryOutcome, error) {
-			return queryWhoisDomain(qctx, domain, tld, key)
+			return queryWhoisDomain(qctx, domain, tld)
 		}
 	} else {
 		// Nothing to query for this TLD: that is an answer about the requested
@@ -177,9 +176,8 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	_, _ = fmt.Fprint(w, outcome.body)
 }
 
-// queryRDAPDomain queries RDAP for a domain, parses the response, and caches
-// the result.
-func queryRDAPDomain(ctx context.Context, domain, tld, key string) (queryOutcome, error) {
+// queryRDAPDomain queries RDAP for a domain and parses the response.
+func queryRDAPDomain(ctx context.Context, domain, tld string) (queryOutcome, error) {
 	queryResult, err := rdap.RDAPQuery(ctx, domain, tld)
 	if err != nil {
 		return queryOutcome{}, err
@@ -196,31 +194,23 @@ func queryRDAPDomain(ctx context.Context, domain, tld, key string) (queryOutcome
 		return queryOutcome{}, err
 	}
 
-	result := string(resultBytes)
-	if err := utils.SetToCache(ctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
-		slog.WarnContext(ctx, "cache write error", "key", key, "err", err)
-	}
-
-	return queryOutcome{body: result, contentType: "application/json"}, nil
+	return queryOutcome{body: string(resultBytes), contentType: "application/json"}, nil
 }
 
-// queryWhoisRaw queries WHOIS for a domain and caches/returns the unparsed
-// response as text/plain.
-func queryWhoisRaw(ctx context.Context, domain, tld, key string) (queryOutcome, error) {
+// queryWhoisRaw queries WHOIS for a domain and returns the unparsed response
+// as text/plain.
+func queryWhoisRaw(ctx context.Context, domain, tld string) (queryOutcome, error) {
 	queryResult, err := whois.Whois(ctx, domain, tld)
 	if err != nil {
 		return queryOutcome{}, err
 	}
 
-	if err := utils.SetToCache(ctx, config.CacheManager, key, queryResult, config.CacheExpiration); err != nil {
-		slog.WarnContext(ctx, "cache write error", "key", key, "err", err)
-	}
 	return queryOutcome{body: queryResult, contentType: "text/plain; charset=utf-8"}, nil
 }
 
-// queryWhoisDomain queries WHOIS for a domain, parses the response when a
-// parser exists for the TLD (raw text otherwise), and caches the result.
-func queryWhoisDomain(ctx context.Context, domain, tld, key string) (queryOutcome, error) {
+// queryWhoisDomain queries WHOIS for a domain, parsing the response when a
+// parser exists for the TLD (raw text otherwise).
+func queryWhoisDomain(ctx context.Context, domain, tld string) (queryOutcome, error) {
 	queryResult, err := whois.Whois(ctx, domain, tld)
 	if err != nil {
 		return queryOutcome{}, err
@@ -241,11 +231,7 @@ func queryWhoisDomain(ctx context.Context, domain, tld, key string) (queryOutcom
 		if err != nil {
 			return queryOutcome{}, err
 		}
-		result := string(resultBytes)
-		if err := utils.SetToCache(ctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
-			slog.WarnContext(ctx, "cache write error", "key", key, "err", err)
-		}
-		return queryOutcome{body: result, contentType: "application/json"}, nil
+		return queryOutcome{body: string(resultBytes), contentType: "application/json"}, nil
 	}
 
 	var domainInfo model.DomainInfo
@@ -261,10 +247,5 @@ func queryWhoisDomain(ctx context.Context, domain, tld, key string) (queryOutcom
 		return queryOutcome{}, err
 	}
 
-	result := string(resultBytes)
-	if err := utils.SetToCache(ctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
-		slog.WarnContext(ctx, "cache write error", "key", key, "err", err)
-	}
-
-	return queryOutcome{body: result, contentType: "application/json"}, nil
+	return queryOutcome{body: string(resultBytes), contentType: "application/json"}, nil
 }

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -48,7 +48,7 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 	serverURL, _ := serverlist.LookupIPKey(ip)
 
 	// Query and parse the RDAP information, deduplicating concurrent misses
-	outcome, err := dedupedQuery(ctx, key, func(qctx context.Context) (queryOutcome, error) {
+	outcome, err := dedupedQuery(ctx, key, refresh, func(qctx context.Context) (queryOutcome, error) {
 		queryResult, err := rdap.RDAPQueryIP(qctx, resource, serverURL)
 		if err != nil {
 			return queryOutcome{}, err

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -64,11 +63,7 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 			return queryOutcome{}, err
 		}
 
-		result := string(resultBytes)
-		if err := utils.SetToCache(qctx, config.CacheManager, key, result, config.CacheExpiration); err != nil {
-			slog.WarnContext(qctx, "cache write error", "key", key, "err", err)
-		}
-		return queryOutcome{body: result, contentType: "application/json"}, nil
+		return queryOutcome{body: string(resultBytes), contentType: "application/json"}, nil
 	})
 	if err != nil {
 		utils.HandleQueryError(ctx, w, err)

--- a/internal/handlers/singleflight.go
+++ b/internal/handlers/singleflight.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 
 	"github.com/KincaidYang/whois/internal/config"
@@ -26,9 +27,10 @@ type flight struct {
 	err     error         // written before done is closed
 
 	// The fields below are guarded by flightsMu.
-	waiters  int  // callers currently waiting on done
-	finished bool // set just before done is closed
-	slotHeld bool // a concurrency slot has been transferred to this flight
+	waiters    int  // callers currently waiting on done
+	finished   bool // set just before done is closed
+	slotHeld   bool // a concurrency slot has been transferred to this flight
+	superseded bool // an overlapping refresh flight owns the cache entry
 }
 
 var (
@@ -71,6 +73,18 @@ func dedupedQuery(ctx context.Context, key string, refresh bool, fn func(context
 	f, ok := flights[fkey]
 	if !ok {
 		f = &flight{done: make(chan struct{})}
+		// A refresh flight owns the cache entry for as long as it runs: a
+		// regular flight overlapping it skips its own write, whichever of the
+		// two started first. Otherwise the regular query — issued seconds
+		// earlier, and possibly answering not-found — could land on top of the
+		// forced result and survive there for a whole TTL.
+		if refresh {
+			if regular, running := flights[key]; running {
+				regular.superseded = true
+			}
+		} else if _, refreshing := flights[refreshFlightPrefix+key]; refreshing {
+			f.superseded = true
+		}
 		flights[fkey] = f
 		// The caller's own wait-group entry is still held here (handlers Add
 		// before querying), so the counter cannot be observed at zero by a
@@ -112,11 +126,12 @@ func dedupedQuery(ctx context.Context, key string, refresh bool, fn func(context
 	}
 }
 
-// run executes the flight and publishes its result. ctx is the first caller's
-// context: canceled callers must not cancel the shared query, but its values
-// (request ID) are kept for upstream logging via WithoutCancel. cacheKey is
-// where a negative result is recorded; fkey is this flight's registry key,
-// which differs for refresh queries.
+// run executes the flight, records its result in the cache and publishes it to
+// the waiters. ctx is the first caller's context: canceled callers must not
+// cancel the shared query, but its values (request ID) are kept for upstream
+// logging via WithoutCancel. cacheKey is the entry this flight writes — the
+// result, or a short-TTL negative marker for a stable not-found/denied error;
+// fkey is this flight's registry key, which differs for refresh queries.
 func (f *flight) run(ctx context.Context, cacheKey, fkey string, fn func(context.Context) (queryOutcome, error)) {
 	defer config.Wg.Done()
 
@@ -124,8 +139,21 @@ func (f *flight) run(ctx context.Context, cacheKey, fkey string, fn func(context
 	defer cancel()
 
 	outcome, err := fn(qctx)
-	if err != nil {
+
+	flightsMu.Lock()
+	superseded := f.superseded
+	flightsMu.Unlock()
+
+	// Write before publishing the result, so a caller that has seen the
+	// response can rely on the cache being populated.
+	switch {
+	case superseded:
+	case err != nil:
 		utils.CacheNegativeResult(qctx, config.CacheManager, cacheKey, err, config.NegativeCacheExpiration)
+	default:
+		if err := utils.SetToCache(qctx, config.CacheManager, cacheKey, outcome.body, config.CacheExpiration); err != nil {
+			slog.WarnContext(qctx, "cache write error", "key", cacheKey, "err", err)
+		}
 	}
 
 	flightsMu.Lock()

--- a/internal/handlers/singleflight.go
+++ b/internal/handlers/singleflight.go
@@ -36,6 +36,15 @@ var (
 	flights   = make(map[string]*flight)
 )
 
+// refreshFlightPrefix separates the flights of ?refresh queries from those of
+// regular ones. A refresh query asked for a forced upstream fetch, so joining
+// a regular flight already in progress would hand it a result it did not
+// force while the response still claimed X-Cache: REFRESH. Refresh queries
+// still share one flight with each other, and both kinds write the same cache
+// key. The NUL byte cannot occur in a cache key built from a validated
+// resource name, so the two namespaces cannot collide.
+const refreshFlightPrefix = "refresh\x00"
+
 // dedupedQuery runs fn once per key across concurrent callers. The flight gets
 // its own timeout, detached from the first caller's context, so one client
 // disconnecting does not fail the other requests waiting on the same key —
@@ -52,17 +61,22 @@ var (
 // configured limit. Each flight also holds an entry in the shutdown wait
 // group for its whole lifetime, so draining on shutdown waits for detached
 // flights (and their cache writes), not just for their former callers.
-func dedupedQuery(ctx context.Context, key string, fn func(context.Context) (queryOutcome, error)) (queryOutcome, error) {
+func dedupedQuery(ctx context.Context, key string, refresh bool, fn func(context.Context) (queryOutcome, error)) (queryOutcome, error) {
+	fkey := key
+	if refresh {
+		fkey = refreshFlightPrefix + key
+	}
+
 	flightsMu.Lock()
-	f, ok := flights[key]
+	f, ok := flights[fkey]
 	if !ok {
 		f = &flight{done: make(chan struct{})}
-		flights[key] = f
+		flights[fkey] = f
 		// The caller's own wait-group entry is still held here (handlers Add
 		// before querying), so the counter cannot be observed at zero by a
 		// concurrent Wait; adding the flight's entry does not race the drain.
 		config.Wg.Add(1)
-		go f.run(ctx, key, fn)
+		go f.run(ctx, key, fkey, fn)
 	}
 	f.waiters++
 	flightsMu.Unlock()
@@ -100,8 +114,10 @@ func dedupedQuery(ctx context.Context, key string, fn func(context.Context) (que
 
 // run executes the flight and publishes its result. ctx is the first caller's
 // context: canceled callers must not cancel the shared query, but its values
-// (request ID) are kept for upstream logging via WithoutCancel.
-func (f *flight) run(ctx context.Context, key string, fn func(context.Context) (queryOutcome, error)) {
+// (request ID) are kept for upstream logging via WithoutCancel. cacheKey is
+// where a negative result is recorded; fkey is this flight's registry key,
+// which differs for refresh queries.
+func (f *flight) run(ctx context.Context, cacheKey, fkey string, fn func(context.Context) (queryOutcome, error)) {
 	defer config.Wg.Done()
 
 	qctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), config.RequestTimeout)
@@ -109,11 +125,11 @@ func (f *flight) run(ctx context.Context, key string, fn func(context.Context) (
 
 	outcome, err := fn(qctx)
 	if err != nil {
-		utils.CacheNegativeResult(qctx, config.CacheManager, key, err, config.NegativeCacheExpiration)
+		utils.CacheNegativeResult(qctx, config.CacheManager, cacheKey, err, config.NegativeCacheExpiration)
 	}
 
 	flightsMu.Lock()
-	delete(flights, key)
+	delete(flights, fkey)
 	f.outcome, f.err = outcome, err
 	f.finished = true
 	flightsMu.Unlock()

--- a/internal/handlers/singleflight_test.go
+++ b/internal/handlers/singleflight_test.go
@@ -17,10 +17,7 @@ import (
 // waiter remains, no extra concurrency slot is transferred to the flight
 // (the surviving waiter's handler slot already covers it).
 func TestDedupedQueryWaiterCancel(t *testing.T) {
-	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
-	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
-	config.ConcurrencyLimiter = make(chan struct{}, 4)
-	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
+	setupFlightTest(t)
 
 	var flights atomic.Int32
 	release := make(chan struct{})
@@ -97,10 +94,7 @@ func TestDedupedQueryWaiterCancel(t *testing.T) {
 // would let clients drain the limiter by querying one slow resource and
 // disconnecting.
 func TestDedupedQueryCanceledWaitersShareOneSlot(t *testing.T) {
-	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
-	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
-	config.ConcurrencyLimiter = make(chan struct{}, 4)
-	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
+	setupFlightTest(t)
 
 	release := make(chan struct{})
 	started := make(chan struct{})
@@ -158,10 +152,7 @@ func TestDedupedQueryCanceledWaitersShareOneSlot(t *testing.T) {
 // drain in main waits for its upstream query and cache writes before the
 // cache and Redis clients are closed.
 func TestDedupedQueryShutdownDrainCoversFlight(t *testing.T) {
-	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
-	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
-	config.ConcurrencyLimiter = make(chan struct{}, 4)
-	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
+	setupFlightTest(t)
 
 	release := make(chan struct{})
 	started := make(chan struct{})
@@ -206,10 +197,7 @@ func TestDedupedQueryShutdownDrainCoversFlight(t *testing.T) {
 // forced fetch, and would otherwise be handed a result it did not force while
 // the response still reported X-Cache: REFRESH.
 func TestDedupedQueryRefreshDoesNotJoinRegularFlight(t *testing.T) {
-	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
-	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
-	config.ConcurrencyLimiter = make(chan struct{}, 4)
-	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
+	setupFlightTest(t)
 
 	const key = "whois:sfrefreshtest"
 	var runs atomic.Int32
@@ -271,6 +259,111 @@ func TestDedupedQueryRefreshDoesNotJoinRegularFlight(t *testing.T) {
 	if n := runs.Load(); n != 1 {
 		t.Errorf("refresh flight ran %d times, want 1 (refresh queries must share one flight)", n)
 	}
+}
+
+// TestRefreshFlightOwnsCacheEntry verifies a regular flight overlapping a
+// refresh does not write the cache: whichever of the two finishes last, the
+// forced result is what stays cached. Otherwise the regular query — issued
+// before the refresh, and possibly answering not-found — would land on top of
+// the refreshed entry and be served for a whole TTL.
+func TestRefreshFlightOwnsCacheEntry(t *testing.T) {
+	setupFlightTest(t)
+
+	cached := func(t *testing.T, key string) string {
+		t.Helper()
+		got, err := config.CacheManager.Get(context.Background(), key)
+		if err != nil {
+			t.Fatalf("cache read: %v", err)
+		}
+		if !got.Found {
+			return ""
+		}
+		return got.Data
+	}
+
+	// The regular flight starts first and finishes last, with an error: its
+	// negative marker must not replace the refreshed result.
+	const key = "whois:sfrefreshowner"
+	release := make(chan struct{})
+	regularStarted := make(chan struct{})
+	regularDone := make(chan error, 1)
+	go func() {
+		_, err := dedupedQuery(context.Background(), key, false, func(context.Context) (queryOutcome, error) {
+			close(regularStarted)
+			<-release
+			return queryOutcome{}, utils.ErrDomainNotFound
+		})
+		regularDone <- err
+	}()
+	<-regularStarted
+
+	if _, err := dedupedQuery(context.Background(), key, true, func(context.Context) (queryOutcome, error) {
+		return queryOutcome{body: "refreshed"}, nil
+	}); err != nil {
+		t.Fatalf("refresh query failed: %v", err)
+	}
+	if got := cached(t, key); got != "refreshed" {
+		t.Fatalf("after refresh, cache holds %q, want %q", got, "refreshed")
+	}
+
+	close(release)
+	if err := <-regularDone; !errors.Is(err, utils.ErrDomainNotFound) {
+		t.Errorf("regular waiter error = %v, want its own flight's error", err)
+	}
+	if got := cached(t, key); got != "refreshed" {
+		t.Errorf("the superseded flight overwrote the refreshed entry with %q", got)
+	}
+
+	// The reverse order: a regular flight started while a refresh is running
+	// is superseded too, so its result cannot outlive the refresh either.
+	const key2 = "whois:sfrefreshowner2"
+	release2 := make(chan struct{})
+	refreshStarted := make(chan struct{})
+	refreshDone := make(chan struct{})
+	go func() {
+		defer close(refreshDone)
+		_, _ = dedupedQuery(context.Background(), key2, true, func(context.Context) (queryOutcome, error) {
+			close(refreshStarted)
+			<-release2
+			return queryOutcome{body: "refreshed"}, nil
+		})
+	}()
+	<-refreshStarted
+
+	if _, err := dedupedQuery(context.Background(), key2, false, func(context.Context) (queryOutcome, error) {
+		return queryOutcome{body: "regular"}, nil
+	}); err != nil {
+		t.Fatalf("regular query failed: %v", err)
+	}
+	if got := cached(t, key2); got != "" {
+		t.Errorf("the superseded regular flight wrote %q while a refresh was in flight", got)
+	}
+
+	close(release2)
+	<-refreshDone
+	if got := cached(t, key2); got != "refreshed" {
+		t.Errorf("after the refresh finished, cache holds %q, want %q", got, "refreshed")
+	}
+}
+
+// setupFlightTest gives a flight test its own cache and concurrency limiter
+// without running config.Load. The cleanup waits for the flight registry to
+// drain first: a detached flight still writes the cache after its callers are
+// gone, and restoring config.CacheManager under it would be a data race.
+func setupFlightTest(t *testing.T) {
+	t.Helper()
+	oldCache, oldLimiter, oldTTL := config.CacheManager, config.ConcurrencyLimiter, config.CacheExpiration
+	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
+	config.ConcurrencyLimiter = make(chan struct{}, 4)
+	config.CacheExpiration = time.Minute
+	t.Cleanup(func() {
+		waitFor(t, "the flight registry to drain", func() bool {
+			flightsMu.Lock()
+			defer flightsMu.Unlock()
+			return len(flights) == 0
+		})
+		config.CacheManager, config.ConcurrencyLimiter, config.CacheExpiration = oldCache, oldLimiter, oldTTL
+	})
 }
 
 // waitFor polls cond until it holds, failing the test after two seconds.

--- a/internal/handlers/singleflight_test.go
+++ b/internal/handlers/singleflight_test.go
@@ -38,7 +38,7 @@ func TestDedupedQueryWaiterCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := dedupedQuery(ctx, key, fn)
+		_, err := dedupedQuery(ctx, key, false, fn)
 		errCh <- err
 	}()
 	<-started
@@ -46,7 +46,7 @@ func TestDedupedQueryWaiterCancel(t *testing.T) {
 	// Second waiter joins the same in-flight query with a healthy context.
 	outCh := make(chan queryOutcome, 1)
 	go func() {
-		out, _ := dedupedQuery(context.Background(), key, fn)
+		out, _ := dedupedQuery(context.Background(), key, false, fn)
 		outCh <- out
 	}()
 	time.Sleep(100 * time.Millisecond) // let the second waiter join the flight
@@ -117,7 +117,7 @@ func TestDedupedQueryCanceledWaitersShareOneSlot(t *testing.T) {
 	errs := make(chan error, waiters)
 	for i := 0; i < waiters; i++ {
 		go func() {
-			_, err := dedupedQuery(ctx, key, fn)
+			_, err := dedupedQuery(ctx, key, false, fn)
 			errs <- err
 		}()
 	}
@@ -174,7 +174,7 @@ func TestDedupedQueryShutdownDrainCoversFlight(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
 	go func() {
-		_, err := dedupedQuery(ctx, "whois:sfdraintest", fn)
+		_, err := dedupedQuery(ctx, "whois:sfdraintest", false, fn)
 		errCh <- err
 	}()
 	<-started
@@ -197,6 +197,79 @@ func TestDedupedQueryShutdownDrainCoversFlight(t *testing.T) {
 	case <-drained:
 	case <-time.After(2 * time.Second):
 		t.Fatal("shutdown drain did not complete after the flight finished")
+	}
+}
+
+// TestDedupedQueryRefreshDoesNotJoinRegularFlight verifies a ?refresh query
+// runs its own upstream query instead of attaching to a regular flight
+// already in progress for the same cache key: a refresh caller asked for a
+// forced fetch, and would otherwise be handed a result it did not force while
+// the response still reported X-Cache: REFRESH.
+func TestDedupedQueryRefreshDoesNotJoinRegularFlight(t *testing.T) {
+	oldCache, oldLimiter := config.CacheManager, config.ConcurrencyLimiter
+	config.CacheManager = utils.NewMemoryCache(10, time.Minute)
+	config.ConcurrencyLimiter = make(chan struct{}, 4)
+	t.Cleanup(func() { config.CacheManager, config.ConcurrencyLimiter = oldCache, oldLimiter })
+
+	const key = "whois:sfrefreshtest"
+	var runs atomic.Int32
+	release := make(chan struct{})
+	regularStarted := make(chan struct{})
+
+	go func() {
+		_, _ = dedupedQuery(context.Background(), key, false, func(context.Context) (queryOutcome, error) {
+			runs.Add(1)
+			close(regularStarted)
+			<-release
+			return queryOutcome{body: "regular"}, nil
+		})
+	}()
+	<-regularStarted
+
+	// The refresh query starts while the regular flight is still running.
+	out, err := dedupedQuery(context.Background(), key, true, func(context.Context) (queryOutcome, error) {
+		runs.Add(1)
+		return queryOutcome{body: "refreshed"}, nil
+	})
+	if err != nil {
+		t.Fatalf("refresh query failed: %v", err)
+	}
+	if out.body != "refreshed" {
+		t.Errorf("refresh query body = %q, want %q (it joined the regular flight)", out.body, "refreshed")
+	}
+
+	close(release)
+	waitFor(t, "both flights to finish", func() bool { return runs.Load() == 2 })
+
+	// Two refresh queries for the same key still share one flight.
+	runs.Store(0)
+	release2 := make(chan struct{})
+	refreshStarted := make(chan struct{})
+	fn := func(context.Context) (queryOutcome, error) {
+		runs.Add(1)
+		close(refreshStarted)
+		<-release2
+		return queryOutcome{body: "refreshed"}, nil
+	}
+	go func() { _, _ = dedupedQuery(context.Background(), key, true, fn) }()
+	<-refreshStarted
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if out, _ := dedupedQuery(context.Background(), key, true, fn); out.body != "refreshed" {
+			t.Errorf("second refresh body = %q, want the shared flight result", out.body)
+		}
+	}()
+	waitFor(t, "the second refresh waiter to join", func() bool {
+		flightsMu.Lock()
+		defer flightsMu.Unlock()
+		f := flights[refreshFlightPrefix+key]
+		return f != nil && f.waiters == 2
+	})
+	close(release2)
+	<-done
+	if n := runs.Load(); n != 1 {
+		t.Errorf("refresh flight ran %d times, want 1 (refresh queries must share one flight)", n)
 	}
 }
 

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -55,18 +55,19 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	ctx, cancel := context.WithTimeout(ctx, config.RequestTimeout)
 	defer cancel()
 
-	query := strings.TrimSpace(strings.ToLower(input.Query))
+	kind, query := utils.ClassifyResource(strings.TrimSpace(strings.ToLower(input.Query)))
 
 	rc := handlers.NewResponseCapture()
 	const cacheKeyPrefix = handlers.CacheKeyPrefix
 
-	if utils.IsIP(query) || utils.IsCIDR(query) {
+	switch kind {
+	case utils.KindIP:
 		handlers.HandleIP(ctx, rc, query, cacheKeyPrefix, false)
-	} else if utils.IsASN(query) {
+	case utils.KindASN:
 		handlers.HandleASN(ctx, rc, query, cacheKeyPrefix, false)
-	} else if utils.IsDomain(query) {
+	case utils.KindDomain:
 		handlers.HandleDomain(ctx, rc, query, cacheKeyPrefix, false, false)
-	} else {
+	default:
 		return errorResult("Invalid input: please provide a valid domain, IP address, or ASN"), nil, nil
 	}
 

--- a/internal/mcp/mcp_server_test.go
+++ b/internal/mcp/mcp_server_test.go
@@ -99,6 +99,38 @@ func TestBatchToolMixedResults(t *testing.T) {
 	}
 }
 
+// TestLookupToolClassifiesIPAndASN verifies the single-lookup tool routes IP,
+// CIDR and ASN queries to their handlers on the canonical form of the input,
+// the same way the HTTP endpoint does — each one answers from the cache entry
+// of that canonical form, network-free.
+func TestLookupToolClassifiesIPAndASN(t *testing.T) {
+	setupBatchTest(t, false, 10)
+
+	for _, tc := range []struct{ name, cacheKey, query, handle string }{
+		{"expanded IPv6", "2001:db8::1", "2001:0DB8:0:0:0:0:0:1", "seeded-ip"},
+		{"CIDR with host bits", "198.51.100.0/24", "198.51.100.7/24", "seeded-cidr"},
+		{"AS-prefixed number", "64496", "AS64496", "seeded-asn"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"objectClassName":"test","handle":"` + tc.handle + `"}`
+			if err := config.CacheManager.Set(context.Background(), handlers.CacheKeyPrefix+tc.cacheKey, body, time.Minute); err != nil {
+				t.Fatalf("failed to seed cache: %v", err)
+			}
+
+			result, _, err := whoisLookup(context.Background(), nil, &WhoisInput{Query: tc.query})
+			if err != nil {
+				t.Fatalf("tool error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("expected success, got error: %s", toolText(t, result))
+			}
+			if !strings.Contains(toolText(t, result), tc.handle) {
+				t.Errorf("expected the cached %s entry, got: %s", tc.handle, toolText(t, result))
+			}
+		})
+	}
+}
+
 // TestHandlerStatelessJSON drives the streamable HTTP handler end to end and
 // verifies its stateless + JSON configuration: a tools/call POST that carries
 // no Mcp-Session-Id header (and was never preceded by an initialize request

--- a/internal/utils/validate.go
+++ b/internal/utils/validate.go
@@ -22,16 +22,42 @@ func IsASN(resource string) bool {
 	return asnRegex.MatchString(resource)
 }
 
-// IsIP reports whether the given resource is a bare IPv4 or IPv6 address.
-func IsIP(resource string) bool {
-	return net.ParseIP(resource) != nil
-}
+// Resource kinds reported by ClassifyResource. The values double as the "type"
+// label on request metrics and as the resource type the RFC 9082-style typed
+// paths require, so they must stay stable.
+const (
+	KindDomain  = "domain"
+	KindIP      = "ip"
+	KindASN     = "asn"
+	KindUnknown = "unknown"
+)
 
-// IsCIDR reports whether the given resource is an IP prefix in CIDR notation
-// (e.g. "192.0.2.0/24", "2001:db8::/32").
-func IsCIDR(resource string) bool {
-	_, _, err := net.ParseCIDR(resource)
-	return err == nil
+// ClassifyResource reports which kind of resource s names, along with the
+// canonical form the query should use. It is the single entry-point
+// classifier: the HTTP handler, the batch endpoint and the MCP tool all route
+// through it so they agree on what a query string means.
+//
+// IP addresses and prefixes are canonicalized ("2001:0db8:0:0:0:0:0:1" →
+// "2001:db8::1", "192.0.2.5/24" → "192.0.2.0/24"), so equivalent spellings of
+// one resource share a cache entry and one upstream query instead of one per
+// spelling. Masking the host bits off a prefix also matches RFC 9082, which
+// defines the ip query as the network rather than an address inside it.
+// Domains and ASNs are returned unchanged: HandleDomain applies IDNA and
+// public-suffix normalization, HandleASN reduces an ASN to its digits.
+func ClassifyResource(s string) (kind, canonical string) {
+	if ip := net.ParseIP(s); ip != nil {
+		return KindIP, ip.String()
+	}
+	if _, ipNet, err := net.ParseCIDR(s); err == nil {
+		return KindIP, ipNet.String()
+	}
+	if IsASN(s) {
+		return KindASN, s
+	}
+	if IsDomain(s) {
+		return KindDomain, s
+	}
+	return KindUnknown, s
 }
 
 // IsDomain reports whether the given resource is a valid domain name.

--- a/internal/utils/validate_test.go
+++ b/internal/utils/validate_test.go
@@ -25,45 +25,40 @@ func TestIsASN(t *testing.T) {
 	}
 }
 
-func TestIsIP(t *testing.T) {
+func TestClassifyResource(t *testing.T) {
 	tests := []struct {
-		input    string
-		expected bool
+		input     string
+		kind      string
+		canonical string
 	}{
-		{"192.0.2.1", true},
-		{"2001:db8::", true},
-		{"192.0.2.0/24", false}, // CIDR is not a bare IP
-		{"example.com", false},
-		{"", false},
+		{"192.0.2.1", KindIP, "192.0.2.1"},
+		{"2001:db8::", KindIP, "2001:db8::"},
+		// Equivalent spellings of one address must collapse to one canonical
+		// form, so they share a cache entry instead of one entry per spelling.
+		{"2001:0db8:0:0:0:0:0:1", KindIP, "2001:db8::1"},
+		{"2001:db8:0000::0001", KindIP, "2001:db8::1"},
+		{"::ffff:192.0.2.1", KindIP, "192.0.2.1"},
+		{"192.0.2.0/24", KindIP, "192.0.2.0/24"},
+		// A prefix with host bits set names the same network (RFC 9082 defines
+		// the ip query as the network), so the bits are masked off.
+		{"192.0.2.5/24", KindIP, "192.0.2.0/24"},
+		{"2001:db8::1/32", KindIP, "2001:db8::/32"},
+		{"192.0.2.0/33", KindUnknown, "192.0.2.0/33"}, // mask too long for IPv4
+		{"192.0.2.0/", KindUnknown, "192.0.2.0/"},
+		{"as12345", KindASN, "as12345"},
+		{"12345", KindASN, "12345"},
+		{"example.com", KindDomain, "example.com"},
+		{"例子.中国", KindDomain, "例子.中国"}, // normalization is HandleDomain's job
+		{"example.com/24", KindUnknown, "example.com/24"},
+		{"!!not-valid!!", KindUnknown, "!!not-valid!!"},
+		{"", KindUnknown, ""},
 	}
 
 	for _, test := range tests {
-		result := IsIP(test.input)
-		if result != test.expected {
-			t.Errorf("IsIP(%q) = %v; want %v", test.input, result, test.expected)
-		}
-	}
-}
-
-func TestIsCIDR(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected bool
-	}{
-		{"192.0.2.0/24", true},
-		{"192.0.2.5/24", true}, // host bits set is still a valid prefix query
-		{"2001:db8::/32", true},
-		{"192.0.2.0/33", false}, // mask too long for IPv4
-		{"192.0.2.0/", false},
-		{"192.0.2.1", false}, // bare IP is not CIDR
-		{"example.com/24", false},
-		{"", false},
-	}
-
-	for _, test := range tests {
-		result := IsCIDR(test.input)
-		if result != test.expected {
-			t.Errorf("IsCIDR(%q) = %v; want %v", test.input, result, test.expected)
+		kind, canonical := ClassifyResource(test.input)
+		if kind != test.kind || canonical != test.canonical {
+			t.Errorf("ClassifyResource(%q) = (%q, %q); want (%q, %q)",
+				test.input, kind, canonical, test.kind, test.canonical)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -185,9 +185,9 @@ func registerRoutes(mux *http.ServeMux) {
 
 	// RFC 9082-style typed query paths. The ip path uses a rest wildcard so
 	// CIDR prefixes ("/ip/192.0.2.0/24") keep their slash.
-	mux.HandleFunc("/domain/{resource}", typedHandler("domain"))
-	mux.HandleFunc("/ip/{resource...}", typedHandler("ip"))
-	mux.HandleFunc("/autnum/{resource}", typedHandler("asn"))
+	mux.HandleFunc("/domain/{resource}", typedHandler(utils.KindDomain))
+	mux.HandleFunc("/ip/{resource...}", typedHandler(utils.KindIP))
+	mux.HandleFunc("/autnum/{resource}", typedHandler(utils.KindASN))
 
 	// Main query handler (auto-detects the resource type)
 	mux.HandleFunc("/", handler)
@@ -245,9 +245,9 @@ func typedHandler(want string) http.HandlerFunc {
 // typedPathError maps a required resource type to the 400 message returned
 // when the supplied resource is not of that type.
 var typedPathError = map[string]string{
-	"domain": "The /domain/ path requires a valid domain name.",
-	"ip":     "The /ip/ path requires a valid IPv4 or IPv6 address.",
-	"asn":    "The /autnum/ path requires a valid AS number.",
+	utils.KindDomain: "The /domain/ path requires a valid domain name.",
+	utils.KindIP:     "The /ip/ path requires a valid IPv4 or IPv6 address.",
+	utils.KindASN:    "The /autnum/ path requires a valid AS number.",
 }
 
 func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
@@ -268,7 +268,10 @@ func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 
 	ctx, cancel := context.WithTimeout(r.Context(), config.RequestTimeout)
 	defer cancel()
-	resource = strings.ToLower(resource)
+
+	// Classify once, and query the canonical form: equivalent spellings of one
+	// IP or prefix must not each get their own cache entry and upstream query.
+	resourceType, resource := utils.ClassifyResource(strings.ToLower(resource))
 
 	// ?raw requests the unparsed WHOIS text (domains only; RDAP-backed IP
 	// and ASN lookups have no raw-text form). ?raw=0 / ?raw=false opt out.
@@ -294,35 +297,24 @@ func serve(w http.ResponseWriter, r *http.Request, resource, want string) {
 	sw := &statusWriter{ResponseWriter: w, code: http.StatusOK}
 	start := time.Now()
 
-	var resourceType string
-	if utils.IsIP(resource) || utils.IsCIDR(resource) {
-		resourceType = "ip"
-	} else if utils.IsASN(resource) {
-		resourceType = "asn"
-	} else if utils.IsDomain(resource) {
-		resourceType = "domain"
-	} else {
-		resourceType = "unknown"
-	}
-
 	switch {
 	case want != "" && resourceType != want:
 		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, typedPathError[want])
 	case refresh && len(config.AuthClients) == 0:
 		utils.WriteRefreshRequiresAuth(sw)
-	case resourceType == "ip":
+	case resourceType == utils.KindIP:
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
 			handlers.HandleIP(ctx, sw, resource, cacheKeyPrefix, refresh)
 		}
-	case resourceType == "asn":
+	case resourceType == utils.KindASN:
 		if raw {
 			utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Raw output is only supported for domain queries.")
 		} else {
 			handlers.HandleASN(ctx, sw, resource, cacheKeyPrefix, refresh)
 		}
-	case resourceType == "domain":
+	case resourceType == utils.KindDomain:
 		handlers.HandleDomain(ctx, sw, resource, cacheKeyPrefix, raw, refresh)
 	default:
 		utils.HandleHTTPError(sw, utils.ErrorTypeBadRequest, "Invalid input. Please provide a valid domain, IP, or ASN.")

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -128,6 +128,37 @@ func TestBatchMixedResults(t *testing.T) {
 	}
 }
 
+// TestBatchClassifiesIPAndASN verifies batch items are classified and
+// canonicalized like single queries: an expanded IPv6 address, a prefix with
+// host bits set and an "AS"-prefixed number all answer from the cache entry of
+// their canonical form instead of missing it and going upstream.
+func TestBatchClassifiesIPAndASN(t *testing.T) {
+	withTestBatch(t, true, 10)
+
+	seeded := map[string]string{
+		"2001:db8:ffff::1": `{"objectClassName":"ip network","handle":"seeded-ip"}`,
+		"203.0.113.0/24":   `{"objectClassName":"ip network","handle":"seeded-cidr"}`,
+		"64500":            `{"objectClassName":"autnum","handle":"seeded-asn"}`,
+	}
+	for k, v := range seeded {
+		if err := config.CacheManager.Set(context.Background(), handlers.CacheKeyPrefix+k, v, time.Minute); err != nil {
+			t.Fatalf("failed to seed cache: %v", err)
+		}
+	}
+
+	results := handlers.RunBatch(context.Background(), []string{"2001:0DB8:FFFF:0:0:0:0:1", "203.0.113.7/24", "AS64500"})
+	for i, want := range []string{"seeded-ip", "seeded-cidr", "seeded-asn"} {
+		item := results[i]
+		if item.Status != http.StatusOK {
+			t.Errorf("%s: expected 200, got %d (%s)", item.Query, item.Status, item.Error)
+			continue
+		}
+		if !strings.Contains(string(item.Data), want) {
+			t.Errorf("%s: expected the cached %s entry, got: %s", item.Query, want, item.Data)
+		}
+	}
+}
+
 // TestBatchExpiredDeadline verifies queries still queued when the batch
 // deadline expires are reported as per-item errors instead of starting late —
 // the singleflight layer would otherwise give them a fresh detached timeout

--- a/main_batch_test.go
+++ b/main_batch_test.go
@@ -82,7 +82,7 @@ func TestBatchBadRequests(t *testing.T) {
 
 // TestBatchMixedResults verifies per-item successes and failures coexist in
 // one 200 response: a cached domain answers from cache, an invalid input gets
-// a per-item 400 problem, and an unknown TLD reports its per-item 500 — all
+// a per-item 400 problem, and an unknown TLD reports its per-item 404 — all
 // network-free.
 func TestBatchMixedResults(t *testing.T) {
 	withTestBatch(t, true, 10)
@@ -123,7 +123,7 @@ func TestBatchMixedResults(t *testing.T) {
 	}
 
 	noServer := resp.Results[2]
-	if noServer.Status != http.StatusInternalServerError || noServer.Data != nil {
+	if noServer.Status != http.StatusNotFound || noServer.Data != nil {
 		t.Errorf("no-server item: %+v", noServer)
 	}
 }

--- a/main_domain_test.go
+++ b/main_domain_test.go
@@ -15,14 +15,18 @@ import (
 
 // TestHandlerUnknownTLD exercises HandleDomain's server-selection logic for a
 // syntactically valid domain whose TLD has neither an RDAP nor a WHOIS server.
-// This path is network-free.
+// Having no server for the TLD is an answer about the requested resource, not
+// a server-side failure, so it is a 404. This path is network-free.
 func TestHandlerUnknownTLD(t *testing.T) {
 	req := httptest.NewRequest("GET", "/example.zzqqxxnotld", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "#not-found") {
+		t.Errorf("body missing not-found problem type: %s", w.Body.String())
 	}
 	if !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
 		t.Errorf("unexpected body: %s", w.Body.String())

--- a/main_ip_asn_test.go
+++ b/main_ip_asn_test.go
@@ -73,6 +73,70 @@ func TestHandleIPMissAndHit(t *testing.T) {
 	}
 }
 
+// TestIPSpellingsShareOneCacheEntry verifies equivalent spellings of one
+// address resolve to a single canonical cache key and a single upstream
+// query, instead of one entry (and one upstream request) per spelling.
+func TestIPSpellingsShareOneCacheEntry(t *testing.T) {
+	var upstreamHits atomic.Int32
+	var gotPath atomic.Value
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		upstreamHits.Add(1)
+		gotPath.Store(r.URL.Path)
+		_, _ = w.Write([]byte(`{"objectClassName":"ip network","handle":"NET-ZZV6TEST"}`))
+	}, "2001:db8:1234::/48")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/2001:0DB8:1234:0000:0000:0000:0000:0001", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "MISS" {
+		t.Errorf("X-Cache: got %q, want MISS", got)
+	}
+	// The upstream query carries the canonical form, not the caller's spelling.
+	if got, _ := gotPath.Load().(string); got != "/ip/2001:db8:1234::1" {
+		t.Errorf("upstream path: got %q, want the canonical form", got)
+	}
+
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/2001:db8:1234::1", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("compressed form: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("compressed form X-Cache: got %q, want HIT", got)
+	}
+	if n := upstreamHits.Load(); n != 1 {
+		t.Errorf("upstream was queried %d times, want 1", n)
+	}
+}
+
+// TestCIDRHostBitsMasked verifies a prefix carrying host bits is queried as
+// the network it names (RFC 9082), so /24 queries that differ only in the
+// host part share one cache entry.
+func TestCIDRHostBitsMasked(t *testing.T) {
+	var gotPath atomic.Value
+	withFakeRDAP(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath.Store(r.URL.Path)
+		_, _ = w.Write([]byte(`{"objectClassName":"ip network","handle":"NET-ZZCIDRTEST"}`))
+	}, "198.51.100.0/24")
+
+	w := httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/198.51.100.7/24", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if got, _ := gotPath.Load().(string); got != "/ip/198.51.100.0/24" {
+		t.Errorf("upstream path: got %q, want the masked network", got)
+	}
+
+	w = httptest.NewRecorder()
+	newTestMux().ServeHTTP(w, httptest.NewRequest("GET", "/ip/198.51.100.0/24", nil))
+	if got := w.Header().Get("X-Cache"); got != "HIT" {
+		t.Errorf("X-Cache: got %q, want HIT", got)
+	}
+}
+
 // TestHandleIPUpstreamNotFound verifies an upstream 404 is returned as a
 // problem response and negative-cached for the next request.
 func TestHandleIPUpstreamNotFound(t *testing.T) {

--- a/main_refresh_test.go
+++ b/main_refresh_test.go
@@ -60,8 +60,8 @@ func TestRefreshOptOut(t *testing.T) {
 // TestRefreshBypassesCache verifies an authenticated ?refresh skips the cache
 // read. The domain's TLD has no WHOIS/RDAP server, so the cached entry is the
 // only thing that could serve a 200: without refresh the seeded cache answers
-// (HIT); with refresh the handler must go upstream and fails with the
-// "no server known" 500 — proving the cache was bypassed, without network.
+// (HIT); with refresh the handler must take the upstream path and answer
+// "no server known" (404) — proving the cache was bypassed, without network.
 func TestRefreshBypassesCache(t *testing.T) {
 	withTestAuthKeys(t, "refresh-test-key")
 
@@ -81,7 +81,7 @@ func TestRefreshBypassesCache(t *testing.T) {
 	req = httptest.NewRequest("GET", "/"+domain+"?refresh=1", nil)
 	req.Header.Set("X-API-Key", "refresh-test-key")
 	w = authRequest(req)
-	if w.Code != http.StatusInternalServerError || !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
-		t.Errorf("with refresh: expected the upstream path (500 no server known), got %d: %s", w.Code, w.Body.String())
+	if w.Code != http.StatusNotFound || !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
+		t.Errorf("with refresh: expected the upstream path (404 no server known), got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/main_routes_test.go
+++ b/main_routes_test.go
@@ -172,8 +172,8 @@ func TestTypedPathDomainUnknownTLD(t *testing.T) {
 	w := httptest.NewRecorder()
 	newTestMux().ServeHTTP(w, req)
 
-	if w.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
 	}
 	if !strings.Contains(w.Body.String(), "No WHOIS or RDAP server known") {
 		t.Errorf("unexpected body: %s", w.Body.String())


### PR DESCRIPTION
第 8 轮全库审查（v1.1.0 + PR #45–#55 之后）发现的三处低危问题，一并修掉。整体结论是健康的：前 7 轮的加固都还在原位，没有高危发现。

## 修复

**1. 无服务器 TLD 返回 500 → 404**

域名格式合法、但其 TLD 既没有 RDAP 也没有 WHOIS 服务器时，`domain.go` 返回 500 `internal-error`，而同一文件的 `?raw` 分支对同样的情况早就返回 404。这不是服务端故障，而且会污染 5xx 告警和 `whois_http_requests_total{status_code="500"}`——一个 `GET /favicon.ico` 就能触发。现在统一 404，`docs/errors.md` 的 not-found 一节补了这一情形的说明。

**2. IP / CIDR 缓存键未规范化**

缓存键直接用请求里的原始字符串，于是 `2001:db8::1` 和 `2001:0db8:0:0:0:0:0:1` 是同一资源却落在两条缓存、两个 flight 上，重复打上游。CIDR 同理（`192.0.2.5/24` vs `192.0.2.0/24`）。现在在进 handler 之前就规范化，CIDR 顺带把主机位归零——这也是发给上游的正确形式（RFC 9082 查的是网段）。

**3. `?refresh` 与普通请求共用 flight key**

refresh 请求撞上正在跑的普通 MISS flight 时会挂到它上面，拿回的并不是自己强制刷新的结果，却照样回 `X-Cache: REFRESH`。现在 refresh 走独立 flight key，缓存键不变（仍写同一条缓存）。

## 顺带

分类逻辑收敛进 `utils.ClassifyResource(s) (kind, canonical string)`，替换掉 `serve`、`runBatchItem`、MCP `whois_lookup` 三处重复的 if/else 链；`IsIP` / `IsCIDR` 被它取代后删除，测试并入 `TestClassifyResource`。

## 验证

`gofmt` / `go vet` / `golangci-lint run ./...` / `go test -race ./...` 全绿，语句覆盖 91.6% 未降。

起真实服务打真实上游验过：`/foo.invalidtld` 与 `/favicon.ico` 均 404 problem+json；`/2606:4700:4700:0:0:0:0:1111` MISS 之后 `/2606:4700:4700::1111` HIT 且响应体逐字节相同，`/ip/1.1.1.5/24` → `/ip/1.1.1.0/24` 同理；开 auth 后 MISS → HIT → `?refresh=1` 得到 REFRESH、无 key 401；MCP 用展开写法的 IPv6 查询走通；SIGTERM 干净退出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)