### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > land in a future major release. The 0.x history below includes the breaking
 > changes made on the way to 1.0.0 (each under a **Breaking** heading).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-26
 
 ### Added
 - Memory-only mode: leaving `redis.addr` empty now disables Redis outright — no
@@ -381,6 +381,7 @@ See the [release notes](https://github.com/KincaidYang/whois/releases/tag/v0.6.0
 See the [GitHub releases page](https://github.com/KincaidYang/whois/releases)
 for 0.5.x and earlier.
 
+[1.2.0]: https://github.com/KincaidYang/whois/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/KincaidYang/whois/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/KincaidYang/whois/compare/v0.10.0...v1.0.0
 [0.10.0]: https://github.com/KincaidYang/whois/compare/v0.9.0...v0.10.0

--- a/internal/handlers/openapi.json
+++ b/internal/handlers/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "whois",
     "description": "WHOIS/RDAP query service. Returns registration data for domain names, IP networks (including CIDR prefixes) and autonomous system numbers as JSON aligned with the RDAP vocabulary (RFC 9083). Errors follow RFC 9457 Problem Details. API key authentication is disabled by default; when the operator configures `auth.keys`, every endpoint except /health and /ready requires a key sent as `Authorization: Bearer <key>` or `X-API-Key: <key>`.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": {
       "name": "MIT",
       "identifier": "MIT"

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/KincaidYang/whois",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.2.0",
   "websiteUrl": "https://github.com/KincaidYang/whois",
   "remotes": [
     {


### PR DESCRIPTION
发版准备：CHANGELOG 的 `## [Unreleased]` 定版为 `## [1.2.0] - 2026-07-26` 并补 compare 链接，`internal/handlers/openapi.json` 与 `server.json` 的 version 跟到 1.2.0。

（v1.1.0 那次的发版提交是直推 main 的；这次走 PR 只是为了让 CI 跑一遍，内容等价。`server.json` 的 version 在发布时本来就会被 `publish-mcp.yml` 按 tag 覆写，这里同步只是让仓内值不落后。）

合并后打 `v1.2.0` tag，触发 goreleaser（根目录 + `.ide/` 两份配置）与 MCP Registry 发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)