### PR TITLE
feat: meter the MCP endpoint, document the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > land in a future major release. The 0.x history below includes the breaking
 > changes made on the way to 1.0.0 (each under a **Breaking** heading).
 
+## [Unreleased]
+
+### Added
+- MCP tool calls are now recorded in `whois_http_requests_total` and
+  `whois_http_request_duration_seconds` under the resource types `mcp` and
+  `mcp_batch`, with the status the query itself produced. Previously the
+  endpoint was invisible in the request metrics — only the per-key counter saw
+  it, and only on instances with authentication enabled.
+- [docs/metrics.md](docs/metrics.md) documents every exported metric, its
+  labels and their values, with suggested alerts (bootstrap staleness, cache
+  backend errors, 5xx rate, concurrency rejections, slow registries) and a few
+  ready-made queries such as the effective cache hit ratio.
+
 ## [1.2.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ docker run -d --name whois -p 8043:8043 \
 | `GET /health` | 存活检查 - 服务运行即返回 200 |
 | `GET /ready` | 就绪检查 - 检查缓存和并发容量状态 |
 | `GET /info` | 运行时信息 - 版本、运行时间、Go 版本等 |
-| `GET /metrics` | Prometheus 指标 - 请求计数、延迟、缓存命中率、上游查询耗时 |
+| `GET /metrics` | Prometheus 指标 - 请求计数、延迟、缓存命中率、上游查询耗时（指标清单与告警建议见 [docs/metrics.md](docs/metrics.md)） |
 | `GET /openapi.json` | OpenAPI 3.1 规范 - 全部端点与响应 schema 的机器可读描述 |
 | `POST /mcp` | MCP Streamable HTTP 端点 - 供 AI 助手集成使用 |
 | `POST /batch` | 批量查询 - 一次提交多个域名/IP/ASN（默认关闭，见 `batch.enabled`） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -170,7 +170,7 @@ The service provides the following health check endpoints:
 | `GET /health` | Liveness probe - returns 200 if service is running |
 | `GET /ready` | Readiness probe - checks cache and capacity status |
 | `GET /info` | Runtime information - version, uptime, Go version, etc. |
-| `GET /metrics` | Prometheus metrics - request count, latency, cache hit rate, upstream query duration |
+| `GET /metrics` | Prometheus metrics - request count, latency, cache hit rate, upstream query duration (see [docs/metrics.md](docs/metrics.md) for the full list and suggested alerts) |
 | `GET /openapi.json` | OpenAPI 3.1 specification - machine-readable description of all endpoints and response schemas |
 | `POST /mcp` | MCP Streamable HTTP endpoint - for AI assistant integration |
 | `POST /batch` | Bulk queries - multiple domains/IPs/ASNs in one request (off by default, see `batch.enabled`) |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,7 +69,10 @@ Histogram of how long the registry took, labelled `protocol` (`rdap` or
 `whois`) and `tld`. IP queries use the pseudo-TLD `_ip` and ASN queries `_asn`.
 
 Only queries that actually left this instance are observed here, so comparing
-its count with `whois_http_requests_total` gives the effective cache hit ratio.
+its count with `whois_http_requests_total` gives the effective cache hit ratio
+— as long as batch queries are off. A batch request counts once in
+`whois_http_requests_total` but can produce one upstream query per item, so
+with batch traffic the two are no longer per-request comparable.
 
 > The `tld` label has one series per TLD queried — on a busy open instance that
 > is a few hundred series per protocol. That is deliberate (a single misbehaving
@@ -105,8 +108,21 @@ this gauge is the only thing that will tell you the data has stopped moving.
 ```yaml
 # The RDAP server list has stopped updating. Below one day this is normal
 # (the default bootstrap.interval is 86400s); a whole day past that is not.
+# The gauge is 0 both on an instance with bootstrap.interval: 0 and on one
+# that has never had a successful refresh, so it is guarded here and the
+# second alert covers the never-succeeded case.
 - alert: WhoisBootstrapStale
-  expr: time() - whois_bootstrap_last_fetch_timestamp_seconds > 172800
+  expr: |
+    whois_bootstrap_last_fetch_timestamp_seconds > 0
+      and time() - whois_bootstrap_last_fetch_timestamp_seconds > 172800
+  for: 1h
+
+# Refreshes are being attempted and none is succeeding. Silent on an instance
+# with refresh disabled, which attempts nothing.
+- alert: WhoisBootstrapNeverSucceeds
+  expr: |
+    sum(rate(whois_bootstrap_refresh_total[6h])) > 0
+      and sum(rate(whois_bootstrap_refresh_total{result="success"}[6h])) == 0
   for: 1h
 
 # The cache backend is failing, so every request is going upstream.
@@ -145,7 +161,11 @@ this gauge is the only thing that will tell you the data has stopped moving.
 ## Useful queries
 
 ```promql
-# Cache hit ratio (requests that never reached a registry).
+# Cache hit ratio (requests that never reached a registry). Only meaningful
+# while batch queries are off, which is the default: a batch counts as one
+# request but can issue one upstream query per item, so with batch traffic the
+# numerator and the denominator count different things and the ratio can even
+# come out negative.
 1 - (
   sum(rate(whois_upstream_duration_seconds_count[5m]))
     / sum(rate(whois_http_requests_total[5m]))

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,164 @@
+# Metrics
+
+`GET /metrics` serves the Prometheus exposition format, alongside the Go
+runtime and process collectors the client library registers by default. The
+endpoint is not exempt from API key authentication: on an instance with
+`auth.keys` configured, the scraper needs a key like any other client.
+
+## Request metrics
+
+### `whois_http_requests_total{type, status_code}`
+
+Counter. One increment per completed query, labelled with what was queried and
+the status the response carried.
+
+`type` is the resource kind the request resolved to:
+
+| `type` | Source |
+|---|---|
+| `domain`, `ip`, `asn` | A query over HTTP, on either the root path or a typed path (`/domain/…`, `/ip/…`, `/autnum/…`) |
+| `unknown` | The input was not a valid domain, IP or ASN — or the request was rejected by the concurrency limiter before it could be classified |
+| `batch` | `POST /batch` |
+| `mcp` | The `whois_lookup` MCP tool |
+| `mcp_batch` | The `whois_batch_lookup` MCP tool |
+
+`status_code` is the HTTP status of the response. For the MCP tool types it is
+the status the underlying query produced (`200`, `404`, `400` …), which is what
+the tool reports as its error state — the MCP transport itself answers `200`
+either way. For `mcp_batch` it describes the batch call, not the individual
+queries, whose statuses are inside the returned payload.
+
+Requests turned away by the concurrency limiter are counted with
+`status_code="429"` and no latency observation.
+
+### `whois_http_request_duration_seconds{type}`
+
+Histogram (default buckets) of end-to-end handler latency, with the same `type`
+label. Cache hits and upstream queries are both in here, so the distribution is
+bimodal: use it for user-visible latency, and `whois_upstream_duration_seconds`
+for how the registries themselves are behaving.
+
+### `whois_client_requests_total{client, status_code}`
+
+Counter, **only populated when `auth.keys` is configured**. `client` is the
+key's display name, or `unauthenticated` for requests that presented no valid
+key (counted with `status_code="401"`). This is the per-key view of traffic:
+which key is using the instance, and how much of its traffic is being rejected
+by its own `rateLimit`.
+
+## Cache metrics
+
+### `whois_cache_requests_total{backend, result}`
+
+Counter. `backend` is `memory` or `redis`; `result` is `hit`, `miss` or
+`error`. A Redis `error` is a genuine backend failure — a caller's cancelled
+request is not counted as one. With the fallback cache, one lookup can produce
+a `redis` result and a `memory` result.
+
+### `whois_cache_evictions_total{backend}`
+
+Counter of entries evicted from the in-memory LRU because it reached
+`cache.memoryMaxSize`. Expiry is not an eviction. A rising rate means the
+working set no longer fits and the hit ratio is being paid for it.
+
+## Upstream metrics
+
+### `whois_upstream_duration_seconds{protocol, tld}`
+
+Histogram of how long the registry took, labelled `protocol` (`rdap` or
+`whois`) and `tld`. IP queries use the pseudo-TLD `_ip` and ASN queries `_asn`.
+
+Only queries that actually left this instance are observed here, so comparing
+its count with `whois_http_requests_total` gives the effective cache hit ratio.
+
+> The `tld` label has one series per TLD queried — on a busy open instance that
+> is a few hundred series per protocol. That is deliberate (a single misbehaving
+> registry is the thing you want to find), but if cardinality matters in your
+> setup, drop or aggregate the label in the scrape config.
+
+## Bootstrap metrics
+
+### `whois_bootstrap_refresh_total{result}`
+
+Counter of IANA RDAP bootstrap refresh rounds, one per `bootstrap.interval`.
+`result` is:
+
+- `success` — all four bootstrap files fetched
+- `partial` — some categories failed; those keep their last-known-good data
+- `failure` — nothing was fetched; the active index is untouched
+
+### `whois_bootstrap_last_fetch_timestamp_seconds`
+
+Gauge holding the Unix timestamp of the last fully successful refresh, or `0`
+if none has succeeded since startup. Staleness in seconds:
+
+```promql
+time() - whois_bootstrap_last_fetch_timestamp_seconds
+```
+
+Staleness is unbounded by design: a category that keeps failing keeps serving
+its last good data rather than falling back to the compiled-in baseline, so
+this gauge is the only thing that will tell you the data has stopped moving.
+
+## Suggested alerts
+
+```yaml
+# The RDAP server list has stopped updating. Below one day this is normal
+# (the default bootstrap.interval is 86400s); a whole day past that is not.
+- alert: WhoisBootstrapStale
+  expr: time() - whois_bootstrap_last_fetch_timestamp_seconds > 172800
+  for: 1h
+
+# The cache backend is failing, so every request is going upstream.
+- alert: WhoisCacheErrors
+  expr: |
+    sum(rate(whois_cache_requests_total{result="error"}[5m]))
+      / sum(rate(whois_cache_requests_total[5m])) > 0.05
+  for: 10m
+
+# Server-side failures. Queries for resources that do not exist answer 404,
+# so a sustained 5xx rate is this instance or its upstreams, not the input.
+- alert: WhoisServerErrors
+  expr: |
+    sum(rate(whois_http_requests_total{status_code=~"5.."}[5m]))
+      / sum(rate(whois_http_requests_total[5m])) > 0.02
+  for: 10m
+
+# Requests are being turned away by server.rateLimit — either the limit is too
+# low for the traffic, or upstream queries are taking long enough to fill it.
+- alert: WhoisConcurrencyRejections
+  expr: sum(rate(whois_http_requests_total{status_code="429"}[5m])) > 1
+  for: 15m
+
+# One registry has become slow. Excludes the pseudo-TLDs so an RIR's latency
+# does not hide behind the domain traffic.
+- alert: WhoisUpstreamSlow
+  expr: |
+    histogram_quantile(0.95,
+      sum by (le, protocol, tld) (
+        rate(whois_upstream_duration_seconds_bucket{tld!~"_ip|_asn"}[10m])
+      )
+    ) > 5
+  for: 15m
+```
+
+## Useful queries
+
+```promql
+# Cache hit ratio (requests that never reached a registry).
+1 - (
+  sum(rate(whois_upstream_duration_seconds_count[5m]))
+    / sum(rate(whois_http_requests_total[5m]))
+)
+
+# Traffic split by entry point — how much of this instance is MCP.
+sum by (type) (rate(whois_http_requests_total[5m]))
+
+# p95 user-visible latency per resource type.
+histogram_quantile(0.95,
+  sum by (le, type) (rate(whois_http_request_duration_seconds_bucket[5m]))
+)
+
+# Which API key is consuming the instance.
+sum by (client) (rate(whois_client_requests_total[5m]))
+```

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.0 // indirect

--- a/internal/handlers/asn.go
+++ b/internal/handlers/asn.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/rdap"
 	"github.com/KincaidYang/whois/internal/serverlist"
 	"github.com/KincaidYang/whois/internal/utils"
@@ -31,21 +30,8 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 
 	// Check cache first before doing any lookups
 	key := fmt.Sprintf("%s%s", cacheKeyPrefix, asn)
-	if !refresh {
-		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-		if err != nil {
-			utils.HandleInternalError(ctx, w, err)
-			return
-		}
-		if cacheResult.Found {
-			w.Header().Set("X-Cache", "HIT")
-			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
-				return
-			}
-			setCacheControl(w)
-			utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
-			return
-		}
+	if serveFromCache(ctx, w, key, refresh) != cacheMiss {
+		return
 	}
 
 	// Find the RDAP server URL via pre-built sorted ASN range index
@@ -76,8 +62,5 @@ func HandleASN(ctx context.Context, w http.ResponseWriter, resource string, cach
 	}
 
 	// Return the RDAP information
-	w.Header().Set("X-Cache", missLabel(refresh))
-	setCacheControl(w)
-	w.Header().Set("Content-Type", outcome.contentType)
-	_, _ = fmt.Fprint(w, outcome.body)
+	writeUpstreamResult(w, outcome, refresh)
 }

--- a/internal/handlers/domain.go
+++ b/internal/handlers/domain.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/model"
 	"github.com/KincaidYang/whois/internal/rdap"
 	"github.com/KincaidYang/whois/internal/serverlist"
@@ -114,26 +113,8 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 	}
 
 	// Check if the RDAP or WHOIS information for the domain is cached
-	if !refresh {
-		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-		if err != nil {
-			utils.HandleInternalError(ctx, w, err)
-			return
-		}
-
-		if cacheResult.Found {
-			w.Header().Set("X-Cache", "HIT")
-			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
-				return
-			}
-			contentType := "application/json"
-			if len(cacheResult.Data) == 0 || cacheResult.Data[0] != '{' {
-				contentType = "text/plain; charset=utf-8"
-			}
-			setCacheControl(w)
-			utils.HandleCacheResponse(w, cacheResult.Data, contentType)
-			return
-		}
+	if serveFromCache(ctx, w, key, refresh) != cacheMiss {
+		return
 	}
 
 	// Select the query path: RDAP preferred, WHOIS as fallback (raw output
@@ -170,10 +151,7 @@ func HandleDomain(ctx context.Context, w http.ResponseWriter, resource string, c
 		return
 	}
 
-	w.Header().Set("X-Cache", missLabel(refresh))
-	setCacheControl(w)
-	w.Header().Set("Content-Type", outcome.contentType)
-	_, _ = fmt.Fprint(w, outcome.body)
+	writeUpstreamResult(w, outcome, refresh)
 }
 
 // queryRDAPDomain queries RDAP for a domain and parses the response.

--- a/internal/handlers/headers.go
+++ b/internal/handlers/headers.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
 	"github.com/KincaidYang/whois/internal/config"
+	"github.com/KincaidYang/whois/internal/utils"
 )
 
 // setCacheControl tells clients they may cache a successful response for as
@@ -26,4 +28,59 @@ func missLabel(refresh bool) string {
 		return "REFRESH"
 	}
 	return "MISS"
+}
+
+// cacheOutcome is what the cache lookup at the head of a handler settled.
+type cacheOutcome int
+
+const (
+	cacheMiss   cacheOutcome = iota // nothing cached; the caller must query upstream
+	cacheServed                     // the cached entry, or its negative marker, has been written
+	cacheFailed                     // the cache backend failed; an error response has been written
+)
+
+// serveFromCache answers a request from the cached entry for key when there is
+// one. A refresh query skips the lookup entirely: it asked for a forced
+// upstream fetch. Anything other than cacheMiss means the response is already
+// written and the handler is done.
+func serveFromCache(ctx context.Context, w http.ResponseWriter, key string, refresh bool) cacheOutcome {
+	if refresh {
+		return cacheMiss
+	}
+
+	result, err := utils.GetFromCache(ctx, config.CacheManager, key)
+	if err != nil {
+		utils.HandleInternalError(ctx, w, err)
+		return cacheFailed
+	}
+	if !result.Found {
+		return cacheMiss
+	}
+
+	w.Header().Set("X-Cache", "HIT")
+	if utils.IsNegativeCacheHit(w, result.Data) {
+		return cacheServed
+	}
+	setCacheControl(w)
+	utils.HandleCacheResponse(w, result.Data, contentType(result.Data))
+	return cacheServed
+}
+
+// writeUpstreamResult writes a result that came from an upstream query rather
+// than from the cache.
+func writeUpstreamResult(w http.ResponseWriter, outcome queryOutcome, refresh bool) {
+	w.Header().Set("X-Cache", missLabel(refresh))
+	setCacheControl(w)
+	w.Header().Set("Content-Type", outcome.contentType)
+	_, _ = fmt.Fprint(w, outcome.body)
+}
+
+// contentType reports how a cached body should be typed. Only ?raw responses
+// are not JSON, and they are stored under their own key namespace, so the
+// first byte tells the two apart.
+func contentType(data string) string {
+	if len(data) == 0 || data[0] != '{' {
+		return "text/plain; charset=utf-8"
+	}
+	return "application/json"
 }

--- a/internal/handlers/ip.go
+++ b/internal/handlers/ip.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/rdap"
 	"github.com/KincaidYang/whois/internal/serverlist"
 	"github.com/KincaidYang/whois/internal/utils"
@@ -20,21 +19,8 @@ import (
 func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cacheKeyPrefix string, refresh bool) {
 	// Check cache first before doing any lookups
 	key := fmt.Sprintf("%s%s", cacheKeyPrefix, resource)
-	if !refresh {
-		cacheResult, err := utils.GetFromCache(ctx, config.CacheManager, key)
-		if err != nil {
-			utils.HandleInternalError(ctx, w, err)
-			return
-		}
-		if cacheResult.Found {
-			w.Header().Set("X-Cache", "HIT")
-			if utils.IsNegativeCacheHit(w, cacheResult.Data) {
-				return
-			}
-			setCacheControl(w)
-			utils.HandleCacheResponse(w, cacheResult.Data, "application/json")
-			return
-		}
+	if serveFromCache(ctx, w, key, refresh) != cacheMiss {
+		return
 	}
 
 	// Parse the IP (for CIDR input, the prefix base address) and find the
@@ -71,8 +57,5 @@ func HandleIP(ctx context.Context, w http.ResponseWriter, resource string, cache
 	}
 
 	// Return the RDAP information
-	w.Header().Set("X-Cache", missLabel(refresh))
-	setCacheControl(w)
-	w.Header().Set("Content-Type", outcome.contentType)
-	_, _ = fmt.Fprint(w, outcome.body)
+	writeUpstreamResult(w, outcome, refresh)
 }

--- a/internal/mcp/mcp_server.go
+++ b/internal/mcp/mcp_server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/handlers"
+	"github.com/KincaidYang/whois/internal/metrics"
 	"github.com/KincaidYang/whois/internal/utils"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -25,6 +26,30 @@ type BatchInput struct {
 	Queries []string `json:"queries" jsonschema:"Domain names, IP addresses (v4/v6), or ASNs (e.g. AS12345) to look up"`
 }
 
+// Tool calls are reported under the same metrics as the HTTP query endpoints,
+// as their own resource types. Without this, the MCP endpoint — the one this
+// project leads with — is invisible in everything except the per-key client
+// counter, which only exists when authentication is enabled.
+const (
+	toolTypeLookup = "mcp"
+	toolTypeBatch  = "mcp_batch"
+)
+
+// countTool records a tool call rejected before any lookup happened. Like the
+// HTTP handler's own rejections, these get no latency observation: they say
+// nothing about how long a query takes.
+func countTool(tool string, status int) {
+	metrics.HTTPRequestsTotal.WithLabelValues(tool, strconv.Itoa(status)).Inc()
+}
+
+// recordTool records a tool call that ran, with the status the query itself
+// produced (200, 404, 400 …), so MCP traffic is comparable with the same
+// resource's HTTP traffic.
+func recordTool(tool string, status int, start time.Time) {
+	countTool(tool, status)
+	metrics.HTTPRequestDuration.WithLabelValues(tool).Observe(time.Since(start).Seconds())
+}
+
 // errorResult builds a tool result carrying an error message.
 func errorResult(msg string) *mcp.CallToolResult {
 	return &mcp.CallToolResult{
@@ -36,6 +61,8 @@ func errorResult(msg string) *mcp.CallToolResult {
 }
 
 func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput) (*mcp.CallToolResult, any, error) {
+	start := time.Now()
+
 	// MCP requests consume the same upstream resources as plain HTTP queries,
 	// so they share the concurrency limiter, the per-request timeout, and the
 	// graceful-shutdown wait group used by the main handler.
@@ -45,6 +72,7 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	default:
 		config.Wg.Done()
 		slog.WarnContext(ctx, "rate limit reached", "path", "/mcp")
+		countTool(toolTypeLookup, http.StatusTooManyRequests)
 		return errorResult("too many concurrent requests"), nil, nil
 	}
 	defer func() {
@@ -68,9 +96,11 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 	case utils.KindDomain:
 		handlers.HandleDomain(ctx, rc, query, cacheKeyPrefix, false, false)
 	default:
+		recordTool(toolTypeLookup, http.StatusBadRequest, start)
 		return errorResult("Invalid input: please provide a valid domain, IP address, or ASN"), nil, nil
 	}
 
+	recordTool(toolTypeLookup, rc.StatusCode(), start)
 	return &mcp.CallToolResult{
 		IsError: rc.StatusCode() >= 400,
 		Content: []mcp.Content{
@@ -83,13 +113,18 @@ func whoisLookup(ctx context.Context, _ *mcp.CallToolRequest, input *WhoisInput)
 // /batch endpoint, under the same enablement flag, size cap and rate-limit
 // accounting (the HTTP layer charged one token; the rest are charged here).
 func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchInput) (*mcp.CallToolResult, any, error) {
+	start := time.Now()
+
 	if !config.BatchEnabled {
+		countTool(toolTypeBatch, http.StatusForbidden)
 		return errorResult("Batch queries are disabled on this instance (batch.enabled)"), nil, nil
 	}
 	if len(input.Queries) == 0 {
+		countTool(toolTypeBatch, http.StatusBadRequest)
 		return errorResult("The queries list must not be empty"), nil, nil
 	}
 	if len(input.Queries) > config.BatchMaxItems {
+		countTool(toolTypeBatch, http.StatusBadRequest)
 		return errorResult("Too many queries in one batch: the limit on this instance is " + strconv.Itoa(config.BatchMaxItems)), nil, nil
 	}
 
@@ -99,6 +134,7 @@ func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchI
 	default:
 		config.Wg.Done()
 		slog.WarnContext(ctx, "rate limit reached", "path", "/mcp")
+		countTool(toolTypeBatch, http.StatusTooManyRequests)
 		return errorResult("too many concurrent requests"), nil, nil
 	}
 	defer func() {
@@ -109,10 +145,12 @@ func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchI
 	if client := config.AuthClientFromContext(ctx); client != nil && client.Limiter != nil && len(input.Queries) > 1 {
 		reservation := client.Limiter.ReserveN(time.Now(), len(input.Queries)-1)
 		if !reservation.OK() {
+			countTool(toolTypeBatch, http.StatusTooManyRequests)
 			return errorResult("The batch exceeds the API key's per-minute request budget; reduce the batch size"), nil, nil
 		}
 		if delay := reservation.Delay(); delay > 0 {
 			reservation.Cancel()
+			countTool(toolTypeBatch, http.StatusTooManyRequests)
 			return errorResult("The API key's request budget is exhausted; retry in " + delay.Round(time.Second).String()), nil, nil
 		}
 	}
@@ -123,6 +161,7 @@ func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchI
 	results := handlers.RunBatch(ctx, input.Queries)
 	payload, err := json.Marshal(handlers.BatchResponse{Results: results})
 	if err != nil {
+		recordTool(toolTypeBatch, http.StatusInternalServerError, start)
 		return errorResult("failed to encode batch results"), nil, nil
 	}
 
@@ -134,6 +173,8 @@ func whoisBatchLookup(ctx context.Context, _ *mcp.CallToolRequest, input *BatchI
 		}
 	}
 
+	// The batch itself succeeded; per-item statuses are in the payload.
+	recordTool(toolTypeBatch, http.StatusOK, start)
 	return &mcp.CallToolResult{
 		IsError: isError,
 		Content: []mcp.Content{

--- a/internal/mcp/mcp_server_test.go
+++ b/internal/mcp/mcp_server_test.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/KincaidYang/whois/internal/config"
 	"github.com/KincaidYang/whois/internal/handlers"
+	"github.com/KincaidYang/whois/internal/metrics"
 	"github.com/KincaidYang/whois/internal/utils"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // setupBatchTest wires up the minimal config state the batch tool needs
@@ -168,5 +170,55 @@ func TestHandlerStatelessJSON(t *testing.T) {
 	}
 	if !strings.Contains(string(payload), "Invalid input") {
 		t.Errorf("expected the tool's invalid-input error in the response, got: %s", payload)
+	}
+}
+
+// TestToolCallsAreMetered verifies MCP tool calls land in the same request
+// metrics as HTTP queries, under their own resource types. Without this the
+// endpoint the project leads with is invisible in monitoring except through
+// the per-key counter, which only exists when authentication is enabled.
+func TestToolCallsAreMetered(t *testing.T) {
+	setupBatchTest(t, false, 10)
+
+	domain := "mcpmetricstest.cn"
+	if err := config.CacheManager.Set(context.Background(), handlers.CacheKeyPrefix+domain, `{"ldhName":"`+domain+`"}`, time.Minute); err != nil {
+		t.Fatalf("failed to seed cache: %v", err)
+	}
+
+	counter := func(toolType, status string) float64 {
+		return testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(toolType, status))
+	}
+	before := map[string]float64{
+		"lookup ok":      counter(toolTypeLookup, "200"),
+		"lookup bad":     counter(toolTypeLookup, "400"),
+		"batch disabled": counter(toolTypeBatch, "403"),
+	}
+
+	if _, _, err := whoisLookup(context.Background(), nil, &WhoisInput{Query: domain}); err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if _, _, err := whoisLookup(context.Background(), nil, &WhoisInput{Query: "!!invalid!!"}); err != nil {
+		t.Fatalf("invalid lookup: %v", err)
+	}
+	if _, _, err := whoisBatchLookup(context.Background(), nil, &BatchInput{Queries: []string{domain}}); err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+
+	for name, want := range map[string]struct {
+		toolType, status string
+	}{
+		"lookup ok":      {toolTypeLookup, "200"},
+		"lookup bad":     {toolTypeLookup, "400"},
+		"batch disabled": {toolTypeBatch, "403"},
+	} {
+		if got := counter(want.toolType, want.status); got != before[name]+1 {
+			t.Errorf("%s: %s{type=%q,status_code=%q} = %v, want %v",
+				name, "whois_http_requests_total", want.toolType, want.status, got, before[name]+1)
+		}
+	}
+
+	// The successful lookup must also be timed; a rejected call must not be.
+	if n := testutil.CollectAndCount(metrics.HTTPRequestDuration, "whois_http_request_duration_seconds"); n == 0 {
+		t.Error("no latency observations recorded for tool calls")
 	}
 }

--- a/internal/mcp/mcp_server_test.go
+++ b/internal/mcp/mcp_server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KincaidYang/whois/internal/utils"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"golang.org/x/time/rate"
 )
 
 // setupBatchTest wires up the minimal config state the batch tool needs
@@ -220,5 +221,64 @@ func TestToolCallsAreMetered(t *testing.T) {
 	// The successful lookup must also be timed; a rejected call must not be.
 	if n := testutil.CollectAndCount(metrics.HTTPRequestDuration, "whois_http_request_duration_seconds"); n == 0 {
 		t.Error("no latency observations recorded for tool calls")
+	}
+}
+
+// TestRejectedToolCallsAreMetered verifies calls turned away before any lookup
+// are counted too — a saturated concurrency limiter and an exhausted per-key
+// budget. These are exactly the conditions an operator needs to see in the
+// metrics, and they produce no latency observation because no query ran.
+func TestRejectedToolCallsAreMetered(t *testing.T) {
+	setupBatchTest(t, true, 10)
+
+	counter := func(toolType, status string) float64 {
+		return testutil.ToFloat64(metrics.HTTPRequestsTotal.WithLabelValues(toolType, status))
+	}
+	lookupBefore := counter(toolTypeLookup, "429")
+	batchBefore := counter(toolTypeBatch, "429")
+
+	// Saturate the limiter so both tools are rejected on entry.
+	full := make(chan struct{}, 1)
+	full <- struct{}{}
+	config.ConcurrencyLimiter = full
+
+	result, _, err := whoisLookup(context.Background(), nil, &WhoisInput{Query: "example.com"})
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if !result.IsError || !strings.Contains(toolText(t, result), "too many concurrent requests") {
+		t.Errorf("expected a concurrency rejection, got: %s", toolText(t, result))
+	}
+	if _, _, err := whoisBatchLookup(context.Background(), nil, &BatchInput{Queries: []string{"example.com"}}); err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+
+	if got := counter(toolTypeLookup, "429"); got != lookupBefore+1 {
+		t.Errorf("lookup 429 count = %v, want %v", got, lookupBefore+1)
+	}
+	if got := counter(toolTypeBatch, "429"); got != batchBefore+1 {
+		t.Errorf("batch 429 count = %v, want %v", got, batchBefore+1)
+	}
+
+	// A batch larger than the key's whole budget is rejected as well.
+	config.ConcurrencyLimiter = make(chan struct{}, 4)
+	client := &config.AuthClient{
+		Key:       "tiny",
+		Name:      "tiny",
+		RateLimit: 2,
+		Limiter:   rate.NewLimiter(rate.Limit(2)/60, 2),
+	}
+	ctx := config.WithAuthClient(context.Background(), client)
+
+	batchBefore = counter(toolTypeBatch, "429")
+	result, _, err = whoisBatchLookup(ctx, nil, &BatchInput{Queries: []string{"a.cn", "b.cn", "c.cn", "d.cn"}})
+	if err != nil {
+		t.Fatalf("over-budget batch: %v", err)
+	}
+	if !result.IsError || !strings.Contains(toolText(t, result), "reduce the batch size") {
+		t.Errorf("expected an over-budget rejection, got: %s", toolText(t, result))
+	}
+	if got := counter(toolTypeBatch, "429"); got != batchBefore+1 {
+		t.Errorf("over-budget 429 count = %v, want %v", got, batchBefore+1)
 	}
 }

--- a/tools/genserverlist/main_test.go
+++ b/tools/genserverlist/main_test.go
@@ -245,3 +245,53 @@ func fakeWhoisServer(t *testing.T, response string) (addr string, query <-chan s
 	}()
 	return listener.Addr().String(), received
 }
+
+// TestBuildersDoNotWrite verifies the two builders only render: a run that
+// fails partway leaves the existing tables untouched, instead of committing
+// whichever one happened to finish first. main writes the rendered files only
+// after every build has succeeded, so this is the half of that guarantee that
+// can be tested without the network.
+func TestBuildersDoNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	existing := map[string]string{
+		"rdap_servers.go": `package serverlist
+
+var compiledRdapServers = map[string]string{
+	"cn": "https://rdap.example/",
+}
+`,
+		"whois_servers.go": `package serverlist
+
+var TLDToWhoisServer = map[string]string{
+	"cn": "whois.cnnic.cn",
+}
+`,
+	}
+	for name, src := range existing {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A cancelled context fails every fetch and every lookup, which is the
+	// same shape of failure as IANA being unreachable mid-run.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := buildRDAP(ctx, dir); err == nil {
+		t.Error("buildRDAP: expected an error when nothing can be fetched")
+	}
+	if _, err := buildWhois(ctx, dir, 4); err == nil {
+		t.Error("buildWhois: expected an error when nothing can be looked up")
+	}
+
+	for name, want := range existing {
+		got, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Errorf("%s was modified by a failed run:\n%s", name, got)
+		}
+	}
+}


### PR DESCRIPTION
把上一轮审计里剩下的技术债清掉。

## `/mcp` 在指标里是隐形的

项目现在主推 MCP——上了官方 Registry、有独立文档、演示站也挂着——但 `whois_http_requests_total` 和 `whois_http_request_duration_seconds` 只在 HTTP 查询 handler 里记录，工具调用一条都不进。唯一看得见 `/mcp` 的是按 key 的 `whois_client_requests_total`，而它只在开鉴权的实例上存在。运营者答不出「我的流量里 MCP 占多少」「工具调用在报错吗」。

现在工具调用以自己的资源类型 `mcp` / `mcp_batch` 记录，状态码取**底层查询产生的状态**（MCP 传输层无论如何都回 200，用它的状态毫无信息量）。在任何查询发生之前就被拒绝的调用只计数、不记延迟——与 HTTP handler 处理自身拒绝的方式一致。

## 指标零文档

`/metrics` 暴露 8 个指标，此前全仓的说明只有两个 README 里各一行表格。新增 [docs/metrics.md](docs/metrics.md)：逐个指标说明含义、标签及其取值，标注了一些不看源码就不会知道的点——比如 `whois_upstream_duration_seconds` 只统计真正离开本实例的查询（正因如此才能用它算缓存命中率）、`whois_cache_requests_total{result="error"}` 不包含调用方自己取消的请求、bootstrap 陈旧度无上界所以那个 gauge 是唯一能告诉你数据停更的东西。末尾给了五条建议告警和几条常用查询。

## 顺带

- 三个 handler 里缓存读取那段（`GetFromCache` → 负缓存判定 → `Cache-Control` → 写响应）是三份复制，收进 `serveFromCache`——正是上一轮移进 `flight.run` 的缓存写入的对侧；上游结果的写出也收进 `writeUpstreamResult`。domain/ip/asn 三个文件合计少 60 行，行为不变。
- 补测试：生成器某张表构建失败时，已存在的两个文件都不被改动（`main` 全部构建成功才落盘，这是该保证中不依赖网络就能测的那一半）。

## 验证

`gofmt` / `vet` / `golangci-lint`（0 issues）/ `go test -race ./...` 全绿。服务代码语句覆盖 92.0%（与上一轮持平；`-coverpkg=./...` 的总数因纳入 `tools/` 而显示 86.4%，Codecov 侧已由 `codecov.yml` 排除）。

`go.mod` 多了一条 indirect：`kylelemons/godebug`，是 `prometheus/client_golang/prometheus/testutil` 的测试期依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)