### PR TITLE
fix: allow the MCP standard headers through CORS preflight

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,10 @@ func withCORS(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Expose-Headers", "X-Request-ID, X-Cache, ETag, Retry-After")
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key, If-None-Match, X-Request-ID, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID")
+			// Mcp-Method and Mcp-Name are mandatory on every /mcp request from
+			// protocol revision 2026-07-28 on, so browser-based MCP clients
+			// cannot reach the endpoint at all unless preflight allows them.
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key, If-None-Match, X-Request-ID, Mcp-Session-Id, Mcp-Protocol-Version, Mcp-Method, Mcp-Name, Last-Event-ID")
 			w.Header().Set("Access-Control-Max-Age", "86400")
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/main_routes_test.go
+++ b/main_routes_test.go
@@ -197,6 +197,15 @@ func TestCORSPreflight(t *testing.T) {
 	if got := w.Header().Get("Access-Control-Allow-Methods"); !strings.Contains(got, "GET") {
 		t.Errorf("Access-Control-Allow-Methods: got %q", got)
 	}
+	// The go-sdk rejects a 2026-07-28 request that carries no Mcp-Method (and
+	// no Mcp-Name on tools/call), so a browser client is locked out of /mcp
+	// unless preflight allows those headers.
+	got := w.Header().Get("Access-Control-Allow-Headers")
+	for _, h := range []string{"Mcp-Protocol-Version", "Mcp-Method", "Mcp-Name"} {
+		if !strings.Contains(got, h) {
+			t.Errorf("Access-Control-Allow-Headers missing %s: got %q", h, got)
+		}
+	}
 }
 
 // TestCORSHeaderOnResponse verifies normal responses carry the CORS headers.


### PR DESCRIPTION
## 问题

go-sdk v1.7.0 带来的协议版本 `2026-07-28` 把 HTTP 头标准化列为**强制**：服务端 `validateMcpHeaders` 对每个请求要求 `Mcp-Method`，`tools/call` 还要求 `Mcp-Name`，缺失或与 body 不符即返回 `-32020 HeaderMismatch`。

我们的 `/mcp` handler 是 `Stateless: true`，正好是 SDK 允许协商到 `2026-07-28` 的条件，所以新协议对本服务直接生效。但 `withCORS` 的 `Access-Control-Allow-Headers` 里没有这两个头，**浏览器里的 MCP 客户端在预检阶段就被挡住**，请求根本到不了服务端。非浏览器客户端（Claude Desktop/CLI、各语言 SDK）不受 CORS 约束，不受影响。

## 改动

- `main.go`：预检白名单补上 `Mcp-Method, Mcp-Name`。
- `main_routes_test.go`：`TestCORSPreflight` 断言这三个 MCP 头都在白名单里（去掉修复后该测试会失败，已验证）。

`Mcp-Param-*` 没加：客户端只在 tool 输入 schema 声明了 `x-mcp-header` 时才发送，本服务没有声明，而且 CORS 不支持前缀通配。响应侧 `Access-Control-Expose-Headers` 无需改动：stateless 模式下服务端不回 `Mcp-Session-Id`，也没有其他新的 `Mcp-*` 响应头。

## 验证

`gofmt` / `go vet` / `golangci-lint run ./...` / `go test ./...` 全通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)